### PR TITLE
Utilize MixinExtras 0.2.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
-//version: 1695474595
+//version: 1698936026
 /*
  DO NOT CHANGE THIS FILE!
  Also, you may replace this file at any time if there is an update available.
@@ -646,7 +646,7 @@ repositories {
 
 def mixinProviderGroup = "io.github.legacymoddingmc"
 def mixinProviderModule = "unimixins"
-def mixinProviderVersion = "0.1.7.1"
+def mixinProviderVersion = "0.1.13"
 def mixinProviderSpecNoClassifer = "${mixinProviderGroup}:${mixinProviderModule}:${mixinProviderVersion}"
 def mixinProviderSpec = "${mixinProviderSpecNoClassifer}:dev"
 ext.mixinProviderSpec = mixinProviderSpec
@@ -798,7 +798,7 @@ dependencies {
         java17Dependencies("com.github.GTNewHorizons:lwjgl3ify:${lwjgl3ifyVersion}")
     }
     if (modId != 'hodgepodge') {
-        java17Dependencies('com.github.GTNewHorizons:Hodgepodge:2.3.5')
+        java17Dependencies('com.github.GTNewHorizons:Hodgepodge:2.3.17')
     }
 
     java17PatchDependencies("com.github.GTNewHorizons:lwjgl3ify:${lwjgl3ifyVersion}:forgePatches") {transitive = false}

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -51,21 +51,21 @@ dependencies {
     compileOnly(files("dependencies/SmartRender-1.7.10-2.1-dev.jar"))
 
     // Because who doesn't want NEI
-    compileOnly('com.github.GTNewHorizons:NotEnoughItems:2.3.55-GTNH:dev')
+    compileOnly('com.github.GTNewHorizons:NotEnoughItems:2.4.9-GTNH:dev')
 
     // Notfine Deps
     compileOnly("thaumcraft:Thaumcraft:1.7.10-4.2.3.5:dev")
     runtimeOnly("com.github.GTNewHorizons:Baubles:1.0.1.16:dev")
-    compileOnly("com.github.GTNewHorizons:twilightforest:2.3.8.18:dev") {transitive = false }
+    compileOnly("com.github.GTNewHorizons:twilightforest:2.5.1:dev") {transitive = false }
     devOnlyNonPublishable(rfg.deobf('curse.maven:witchery-69673:2234410'))
 
 
     // ArchaicFix Deps
     implementation("com.github.Speiger:Primitive-Collections:0.9.0")
-    compileOnly("curse.maven:chickenchunks-229316:2233250")
+    compileOnly("codechicken:ChickenChunks:1.7.10-1.3.4.19:dev")
     compileOnly "thaumcraft:Thaumcraft:1.7.10-4.2.3.5:dev"
     compileOnly('curse.maven:cofh-core-69162:2388751')
-    compileOnly('com.github.GTNewHorizons:Botania:1.9.19-GTNH:dev') {transitive = false }
+    compileOnly('com.github.GTNewHorizons:Botania:1.10.2-GTNH:dev') {transitive = false }
     compileOnly("org.projectlombok:lombok:1.18.22") {transitive = false }
     annotationProcessor("org.projectlombok:lombok:1.18.22")
 

--- a/repositories.gradle
+++ b/repositories.gradle
@@ -4,5 +4,9 @@ repositories {
     maven {
         name = 'covers1624 maven'
         url = 'https://nexus.covers1624.net/repository/maven-hosted/'
+        metadataSources {
+            mavenPom()
+            artifact()
+        }
     }
 }

--- a/repositories.gradle
+++ b/repositories.gradle
@@ -1,5 +1,8 @@
 // Add any additional repositories for your dependencies here
 
 repositories {
-
+    maven {
+        name = 'covers1624 maven'
+        url = 'https://nexus.covers1624.net/repository/maven-hosted/'
+    }
 }

--- a/src/main/java/com/gtnewhorizons/angelica/client/Shaders.java
+++ b/src/main/java/com/gtnewhorizons/angelica/client/Shaders.java
@@ -2828,7 +2828,7 @@ public class Shaders {
         }
     }
 
-    public static void beginSpiderEyes() {
+    public static void beginGlowingEyes() {
         if (true) return;
         if (isRenderingWorld) {
             useProgram(ProgramSpiderEyes);

--- a/src/main/java/com/gtnewhorizons/angelica/mixins/early/archaic/client/core/AccessorSplashProgress.java
+++ b/src/main/java/com/gtnewhorizons/angelica/mixins/early/archaic/client/core/AccessorSplashProgress.java
@@ -4,17 +4,19 @@ import cpw.mods.fml.client.SplashProgress;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.gen.Accessor;
 
+@SuppressWarnings("deprecation")
 @Mixin(SplashProgress.class)
 public interface AccessorSplashProgress {
-    @Accessor(value="barBorderColor", remap = false)
+    
+    @Accessor(remap = false)
     static int getBarBorderColor() {
         throw new AssertionError();
     }
-    @Accessor(value="barBackgroundColor", remap = false)
+    @Accessor(remap = false)
     static int getBarBackgroundColor() {
         throw new AssertionError();
     }
-    @Accessor(value="fontColor", remap = false)
+    @Accessor(remap = false)
     static int getFontColor() {
         throw new AssertionError();
     }

--- a/src/main/java/com/gtnewhorizons/angelica/mixins/early/archaic/client/core/MixinBlockFence.java
+++ b/src/main/java/com/gtnewhorizons/angelica/mixins/early/archaic/client/core/MixinBlockFence.java
@@ -10,7 +10,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(BlockFence.class)
 public abstract class MixinBlockFence extends Block {
-    protected MixinBlockFence(Material p_i45394_1_) {
+    private MixinBlockFence(Material p_i45394_1_) {
         super(p_i45394_1_);
     }
 

--- a/src/main/java/com/gtnewhorizons/angelica/mixins/early/archaic/client/core/MixinSplashProgress.java
+++ b/src/main/java/com/gtnewhorizons/angelica/mixins/early/archaic/client/core/MixinSplashProgress.java
@@ -27,6 +27,7 @@ import static org.lwjgl.opengl.GL11.glPushMatrix;
 import static org.lwjgl.opengl.GL11.glScalef;
 import static org.lwjgl.opengl.GL11.glTranslatef;
 
+@SuppressWarnings("deprecation")
 @Mixin(targets = { "cpw/mods/fml/client/SplashProgress$3" })
 public class MixinSplashProgress {
     private static final int memoryGoodColor = 0x78CB34;

--- a/src/main/java/com/gtnewhorizons/angelica/mixins/early/archaic/client/lighting/MixinWorld.java
+++ b/src/main/java/com/gtnewhorizons/angelica/mixins/early/archaic/client/lighting/MixinWorld.java
@@ -1,15 +1,27 @@
 package com.gtnewhorizons.angelica.mixins.early.archaic.client.lighting;
 
-import net.minecraft.world.EnumSkyBlock;
-import net.minecraft.world.World;
-import net.minecraft.world.chunk.Chunk;
+import org.embeddedt.archaicfix.lighting.world.lighting.LightingEngine;
 import org.embeddedt.archaicfix.lighting.world.lighting.LightingHooks;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import net.minecraft.world.EnumSkyBlock;
+import net.minecraft.world.World;
+import net.minecraft.world.chunk.Chunk;
 
 @Mixin(World.class)
 public abstract class MixinWorld {
+
+    @SuppressWarnings("unused")
+    private LightingEngine lightingEngine;
+
+    @Inject(method = "finishSetup", at = @At("RETURN"), remap = false)
+    private void onConstructed(CallbackInfo ci) {
+        this.lightingEngine = new LightingEngine((World) (Object) this);
+    }
 
     @Redirect(method = { "getSkyBlockTypeBrightness", "getSavedLightValue" }, at = @At(value = "INVOKE", target = "Lnet/minecraft/world/chunk/Chunk;getSavedLightValue(Lnet/minecraft/world/EnumSkyBlock;III)I"))
     private int useBlockIntrinsicBrightness(Chunk instance, EnumSkyBlock type, int x, int y, int z) {

--- a/src/main/java/com/gtnewhorizons/angelica/mixins/early/archaic/client/lighting/MixinWorld.java
+++ b/src/main/java/com/gtnewhorizons/angelica/mixins/early/archaic/client/lighting/MixinWorld.java
@@ -1,28 +1,15 @@
 package com.gtnewhorizons.angelica.mixins.early.archaic.client.lighting;
 
-import net.minecraft.block.Block;
 import net.minecraft.world.EnumSkyBlock;
 import net.minecraft.world.World;
 import net.minecraft.world.chunk.Chunk;
-import org.embeddedt.archaicfix.lighting.world.lighting.LightingEngine;
 import org.embeddedt.archaicfix.lighting.world.lighting.LightingHooks;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.Redirect;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(World.class)
 public abstract class MixinWorld {
-    @Shadow public abstract Block getBlock(int p_147439_1_, int p_147439_2_, int p_147439_3_);
-
-    private LightingEngine lightingEngine;
-
-    @Inject(method = "finishSetup", at = @At("RETURN"), remap = false)
-    private void onConstructed(CallbackInfo ci) {
-        this.lightingEngine = new LightingEngine((World) (Object) this);
-    }
 
     @Redirect(method = { "getSkyBlockTypeBrightness", "getSavedLightValue" }, at = @At(value = "INVOKE", target = "Lnet/minecraft/world/chunk/Chunk;getSavedLightValue(Lnet/minecraft/world/EnumSkyBlock;III)I"))
     private int useBlockIntrinsicBrightness(Chunk instance, EnumSkyBlock type, int x, int y, int z) {

--- a/src/main/java/com/gtnewhorizons/angelica/mixins/early/archaic/client/occlusion/MixinRenderGlobal.java
+++ b/src/main/java/com/gtnewhorizons/angelica/mixins/early/archaic/client/occlusion/MixinRenderGlobal.java
@@ -54,12 +54,12 @@ public abstract class MixinRenderGlobal {
     }
 
     @Redirect(method = "loadRenderers", at = @At(value = "INVOKE", target = "Ljava/util/List;clear()V", ordinal = 0))
-    private void clearRendererUpdateQueue(List instance) {
+    private void clearRendererUpdateQueue(List<WorldRenderer> instance) {
         OcclusionHelpers.renderer.clearRendererUpdateQueue(instance);
     }
 
     @Redirect(method = { "loadRenderers", "markRenderersForNewPosition" }, at = @At(value = "INVOKE", target = "Ljava/util/List;add(Ljava/lang/Object;)Z", ordinal = 0))
-    private boolean sortAndAddRendererUpdateQueue(List instance, Object renderer) {
+    private boolean sortAndAddRendererUpdateQueue(List<WorldRenderer> instance, Object renderer) {
         return OcclusionHelpers.renderer.sortAndAddRendererUpdateQueue(instance, renderer);
     }
 
@@ -123,7 +123,6 @@ public abstract class MixinRenderGlobal {
      * @reason occlusion culling
      */
     @Overwrite
-    @SuppressWarnings("unchecked")
     public int renderSortedRenderers(int start, int end, int pass, double tick) {
         return OcclusionHelpers.renderer.sortAndRender(start, end, pass, tick);
     }

--- a/src/main/java/com/gtnewhorizons/angelica/mixins/early/archaic/client/occlusion/MixinWorldRenderer.java
+++ b/src/main/java/com/gtnewhorizons/angelica/mixins/early/archaic/client/occlusion/MixinWorldRenderer.java
@@ -40,7 +40,6 @@ public class MixinWorldRenderer implements IWorldRenderer {
     @Shadow private TesselatorVertexState vertexState;
 
     @Unique private boolean arch$isInUpdateList;
-    @Unique private boolean arch$isFrustumCheckPending;
 
     @Unique private OcclusionWorker.CullInfo arch$cullInfo;
 

--- a/src/main/java/com/gtnewhorizons/angelica/mixins/early/archaic/client/occlusion/MixinWorldRenderer.java
+++ b/src/main/java/com/gtnewhorizons/angelica/mixins/early/archaic/client/occlusion/MixinWorldRenderer.java
@@ -3,6 +3,7 @@ package com.gtnewhorizons.angelica.mixins.early.archaic.client.occlusion;
 import net.minecraft.client.renderer.WorldRenderer;
 import net.minecraft.client.shader.TesselatorVertexState;
 import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.World;
 import net.minecraft.world.chunk.EmptyChunk;
 import org.embeddedt.archaicfix.occlusion.interfaces.IWorldRenderer;
@@ -27,9 +28,9 @@ public class MixinWorldRenderer implements IWorldRenderer {
 
     @Shadow public int posZ;
 
-    @Shadow public List tileEntityRenderers;
+    @Shadow public List<TileEntity> tileEntityRenderers;
 
-    @Shadow private List tileEntities;
+    @Shadow private List<TileEntity> tileEntities;
 
     @Shadow public boolean needsUpdate;
 

--- a/src/main/java/com/gtnewhorizons/angelica/mixins/early/archaic/client/threadedupdates/MixinTessellator_Debug.java
+++ b/src/main/java/com/gtnewhorizons/angelica/mixins/early/archaic/client/threadedupdates/MixinTessellator_Debug.java
@@ -18,7 +18,7 @@ public abstract class MixinTessellator_Debug {
     }
 
     @Inject(method = {"getVertexState", "draw"}, at = @At("HEAD"))
-    private void verifyThreadIsCorrect(CallbackInfoReturnable cir) {
+    private void verifyThreadIsCorrect(CallbackInfoReturnable<?> cir) {
         verifyThreadIsCorrect();
     }
 

--- a/src/main/java/com/gtnewhorizons/angelica/mixins/early/archaic/client/threadedupdates/MixinWorldRenderer.java
+++ b/src/main/java/com/gtnewhorizons/angelica/mixins/early/archaic/client/threadedupdates/MixinWorldRenderer.java
@@ -5,6 +5,7 @@ import net.minecraft.client.renderer.RenderBlocks;
 import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.client.renderer.WorldRenderer;
 import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.ChunkCache;
 import org.embeddedt.archaicfix.threadedupdates.ICapturableTessellator;
 import org.embeddedt.archaicfix.threadedupdates.IRendererUpdateResultHolder;
@@ -28,7 +29,7 @@ public class MixinWorldRenderer implements IRendererUpdateResultHolder {
     }
 
     @Inject(method = "updateRenderer", at = @At(value="INVOKE", target = "Lnet/minecraft/client/renderer/WorldRenderer;postRenderBlocks(ILnet/minecraft/entity/EntityLivingBase;)V"), locals=LocalCapture.CAPTURE_FAILHARD)
-    private void loadTessellationResult(EntityLivingBase cameraEntity, CallbackInfo ci, int i, int j, int k, int l, int i1, int j1, HashSet hashset, Minecraft minecraft, EntityLivingBase entitylivingbase1, int l1, int i2, int j2, byte b0, ChunkCache chunkcache, RenderBlocks renderblocks, int k2) {
+    private void loadTessellationResult(EntityLivingBase cameraEntity, CallbackInfo ci, int i, int j, int k, int l, int i1, int j1, HashSet<TileEntity> hashset, Minecraft minecraft, EntityLivingBase entitylivingbase1, int l1, int i2, int j2, byte b0, ChunkCache chunkcache, RenderBlocks renderblocks, int k2) {
         int pass = k2;
         if(!arch$getRendererUpdateTask().cancelled) {
             ((ICapturableTessellator) Tessellator.instance).arch$addTessellatorVertexState(arch$getRendererUpdateTask().result[pass].renderedQuads);

--- a/src/main/java/com/gtnewhorizons/angelica/mixins/early/archaic/common/chickenchunks/MixinPlayerChunkViewerManager.java
+++ b/src/main/java/com/gtnewhorizons/angelica/mixins/early/archaic/common/chickenchunks/MixinPlayerChunkViewerManager.java
@@ -6,34 +6,28 @@ import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;
 
+import com.llamalad7.mixinextras.sugar.Share;
+import com.llamalad7.mixinextras.sugar.ref.LocalRef;
+
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.LinkedList;
+import java.util.List;
 
 @Mixin(PlayerChunkViewerManager.class)
 public class MixinPlayerChunkViewerManager {
     @Shadow(remap = false) public LinkedList<PlayerChunkViewerManager.TicketChange> ticketChanges;
 
-    private ArrayList<PlayerChunkViewerManager.TicketChange> oldTicketChanges;
-
-    @Redirect(method = "update", at = @At(value = "INVOKE", target = "Ljava/util/LinkedList;iterator()Ljava/util/Iterator;"), remap = false)
-    private Iterator<?> getSafeIterator(LinkedList<?> list) {
-        if(list == this.ticketChanges) {
-            oldTicketChanges = new ArrayList<>((LinkedList<PlayerChunkViewerManager.TicketChange>)list);
-            return oldTicketChanges.iterator();
-        } else {
-            return list.iterator();
-        }
+    @Redirect(method = "update", at = @At(ordinal = 7, value = "INVOKE", target = "Ljava/util/LinkedList;iterator()Ljava/util/Iterator;"), remap = false)
+    private Iterator<?> getSafeIterator(LinkedList<PlayerChunkViewerManager.TicketChange> list, @Share("oldTicketChanges") LocalRef<List<PlayerChunkViewerManager.TicketChange>> oldTicketChanges) {
+        oldTicketChanges.set(new ArrayList<>(list));
+        return oldTicketChanges.get().iterator();
     }
 
-    @Redirect(method = "update", at = @At(value = "INVOKE", target = "Ljava/util/LinkedList;clear()V"), remap = false)
-    private void clearListSafely(LinkedList<?> list) {
-        if(list == this.ticketChanges) {
-            this.ticketChanges.removeAll(oldTicketChanges);
-            oldTicketChanges = null;
-        } else {
-            list.clear();
-        }
+    @Redirect(method = "update", at = @At(ordinal = 4, value = "INVOKE", target = "Ljava/util/LinkedList;clear()V"), remap = false)
+    private void clearListSafely(LinkedList<PlayerChunkViewerManager.TicketChange> list, @Share("oldTicketChanges") LocalRef<List<PlayerChunkViewerManager.TicketChange>> oldTicketChanges) {
+        this.ticketChanges.removeAll(oldTicketChanges.get());
+        oldTicketChanges.set(null);
     }
 
 }

--- a/src/main/java/com/gtnewhorizons/angelica/mixins/early/archaic/common/core/MixinAxisAlignedBB.java
+++ b/src/main/java/com/gtnewhorizons/angelica/mixins/early/archaic/common/core/MixinAxisAlignedBB.java
@@ -8,7 +8,6 @@ import org.spongepowered.asm.mixin.injection.ModifyVariable;
 @Mixin(AxisAlignedBB.class)
 public class MixinAxisAlignedBB {
     private final double XZ_MARGIN = 1E-6;
-    private final double Y_MARGIN = 0.000000001;
 
     @ModifyVariable(method = "calculateXOffset", at = @At(value = "STORE", ordinal = 0), index = 2, argsOnly = true)
     private double subXMargin(double old) {

--- a/src/main/java/com/gtnewhorizons/angelica/mixins/early/archaic/common/core/MixinBlock.java
+++ b/src/main/java/com/gtnewhorizons/angelica/mixins/early/archaic/common/core/MixinBlock.java
@@ -1,56 +1,19 @@
 package com.gtnewhorizons.angelica.mixins.early.archaic.common.core;
 
-import cpw.mods.fml.common.FMLCommonHandler;
-import cpw.mods.fml.relauncher.Side;
 import net.minecraft.block.Block;
-import net.minecraft.server.MinecraftServer;
-import org.embeddedt.archaicfix.block.ThreadedBlockData;
 import org.objectweb.asm.Opcodes;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;
 
-import java.lang.ref.WeakReference;
-
 @Mixin(Block.class)
 public class MixinBlock {
-    @Shadow public Block.SoundType stepSound;
-    private WeakReference<MinecraftServer> lastServer = new WeakReference<>(null);
-    private ThreadedBlockData arch$serverThreadedData = null;
-    private ThreadedBlockData arch$clientThreadedData = new ThreadedBlockData();
 
-    private final ThreadLocal<ThreadedBlockData> arch$threadBlockData = new ThreadLocal<>();
+    @Shadow public Block.SoundType stepSound;
 
     @Redirect(method = "<init>", at = @At(opcode = Opcodes.PUTFIELD, value = "FIELD", target = "Lnet/minecraft/block/Block;stepSound:Lnet/minecraft/block/Block$SoundType;", ordinal = 0))
     private void onConstruct(Block block, Block.SoundType sound) {
         stepSound = sound;
-    }
-
-    private ThreadedBlockData arch$calculateThreadedData() {
-        FMLCommonHandler inst = FMLCommonHandler.instance();
-        Side trueSide;
-        if(inst.getSidedDelegate() == null) {
-            trueSide = inst.getEffectiveSide();
-        } else {
-            trueSide = inst.getSide();
-        }
-        if(trueSide == Side.SERVER || inst.getEffectiveSide() == Side.SERVER) {
-            if(lastServer.get() != inst.getMinecraftServerInstance()) {
-                lastServer = new WeakReference<>(inst.getMinecraftServerInstance());
-                arch$serverThreadedData = new ThreadedBlockData(arch$clientThreadedData);
-            }
-            return arch$serverThreadedData;
-        }
-        return arch$clientThreadedData;
-    }
-
-    public ThreadedBlockData arch$getThreadedData() {
-        ThreadedBlockData calculated = arch$threadBlockData.get();
-        if(calculated == null) {
-            calculated = arch$calculateThreadedData();
-            arch$threadBlockData.set(calculated);
-        }
-        return calculated;
     }
 }

--- a/src/main/java/com/gtnewhorizons/angelica/mixins/early/archaic/common/core/MixinChunk.java
+++ b/src/main/java/com/gtnewhorizons/angelica/mixins/early/archaic/common/core/MixinChunk.java
@@ -23,7 +23,6 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Map;
 
 @Mixin(value = Chunk.class, priority = 1100)
 public class MixinChunk {
@@ -34,8 +33,6 @@ public class MixinChunk {
     @Shadow @Final public int xPosition;
 
     @Shadow @Final public int zPosition;
-
-    @Shadow public Map chunkTileEntityMap;
 
     @Inject(method = "onChunkUnload", at = @At("HEAD"))
     public void handlePlayerChunkUnload(CallbackInfo ci) {

--- a/src/main/java/com/gtnewhorizons/angelica/mixins/early/archaic/common/core/MixinEmbeddedChannel.java
+++ b/src/main/java/com/gtnewhorizons/angelica/mixins/early/archaic/common/core/MixinEmbeddedChannel.java
@@ -21,7 +21,7 @@ import java.util.Queue;
 
 @Mixin(EmbeddedChannel.class)
 public abstract class MixinEmbeddedChannel extends AbstractChannel {
-    protected MixinEmbeddedChannel(Channel parent) {
+    private MixinEmbeddedChannel(Channel parent) {
         super(parent);
     }
 

--- a/src/main/java/com/gtnewhorizons/angelica/mixins/early/archaic/common/core/MixinEntityLiving.java
+++ b/src/main/java/com/gtnewhorizons/angelica/mixins/early/archaic/common/core/MixinEntityLiving.java
@@ -11,7 +11,7 @@ import org.spongepowered.asm.mixin.injection.ModifyConstant;
 
 @Mixin(EntityLiving.class)
 public abstract class MixinEntityLiving extends EntityLivingBase {
-    public MixinEntityLiving(World p_i1594_1_) {
+    private MixinEntityLiving(World p_i1594_1_) {
         super(p_i1594_1_);
     }
 

--- a/src/main/java/com/gtnewhorizons/angelica/mixins/early/archaic/common/core/MixinEntityPlayerMP.java
+++ b/src/main/java/com/gtnewhorizons/angelica/mixins/early/archaic/common/core/MixinEntityPlayerMP.java
@@ -15,7 +15,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 @Mixin(EntityPlayerMP.class)
 public abstract class MixinEntityPlayerMP extends EntityPlayer {
 
-    public MixinEntityPlayerMP(World worldIn, GameProfile gameProfileIn) {super(worldIn, gameProfileIn);}
+    private MixinEntityPlayerMP(World worldIn, GameProfile gameProfileIn) {super(worldIn, gameProfileIn);}
 
     /**
      * @reason This is incorrectly set to 1, but not noticable in vanilla since the move logic

--- a/src/main/java/com/gtnewhorizons/angelica/mixins/early/archaic/common/core/MixinEntityTrackerEntry.java
+++ b/src/main/java/com/gtnewhorizons/angelica/mixins/early/archaic/common/core/MixinEntityTrackerEntry.java
@@ -4,6 +4,7 @@ import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLeashKnot;
 import net.minecraft.entity.EntityTrackerEntry;
 import net.minecraft.entity.item.EntityItemFrame;
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.projectile.EntityArrow;
 import net.minecraft.network.Packet;
 import net.minecraft.network.play.server.S0CPacketSpawnPlayer;
@@ -34,7 +35,7 @@ public class MixinEntityTrackerEntry {
     @Shadow public int ticks;
 
     @Inject(method = "sendLocationToAllClients", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/EntityTrackerEntry;sendMetadataToAllAssociatedPlayers()V", ordinal = 1, shift = At.Shift.AFTER), locals = LocalCapture.CAPTURE_FAILHARD)
-    private void saveIfTeleported(List clientList, CallbackInfo ci, int i, int j, int k, int l, int i1, int j1, int k1, int l1, Object object) {
+    private void saveIfTeleported(List<EntityPlayer> clientList, CallbackInfo ci, int i, int j, int k, int l, int i1, int j1, int k1, int l1, Object object) {
         if(object instanceof S18PacketEntityTeleport) {
             this.lastScaledXPosition = i;
             this.lastScaledYPosition = j;

--- a/src/main/java/com/gtnewhorizons/angelica/mixins/early/archaic/common/core/MixinMapGenStructure.java
+++ b/src/main/java/com/gtnewhorizons/angelica/mixins/early/archaic/common/core/MixinMapGenStructure.java
@@ -2,6 +2,8 @@ package com.gtnewhorizons.angelica.mixins.early.archaic.common.core;
 
 import com.google.common.collect.ImmutableList;
 import net.minecraft.world.gen.structure.MapGenStructure;
+import net.minecraft.world.gen.structure.StructureStart;
+
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;
@@ -13,7 +15,7 @@ import java.util.Map;
 public abstract class MixinMapGenStructure {
 
     @Redirect(method = { "func_143028_c", "func_142038_b", "func_151545_a", "generateStructuresInChunk" }, at = @At(value = "INVOKE", target = "Ljava/util/Map;values()Ljava/util/Collection;"))
-    private Collection getStructureMapValues(Map structureMap) {
+    private Collection<StructureStart> getStructureMapValues(Map<Long, StructureStart> structureMap) {
         return ImmutableList.copyOf(structureMap.values());
     }
 }

--- a/src/main/java/com/gtnewhorizons/angelica/mixins/early/archaic/common/core/MixinMaterialLiquid.java
+++ b/src/main/java/com/gtnewhorizons/angelica/mixins/early/archaic/common/core/MixinMaterialLiquid.java
@@ -7,7 +7,7 @@ import org.spongepowered.asm.mixin.Mixin;
 
 @Mixin(MaterialLiquid.class)
 public abstract class MixinMaterialLiquid extends Material {
-    public MixinMaterialLiquid(MapColor p_i2116_1_) {
+    private MixinMaterialLiquid(MapColor p_i2116_1_) {
         super(p_i2116_1_);
     }
 

--- a/src/main/java/com/gtnewhorizons/angelica/mixins/early/archaic/common/core/MixinObjectIntIdentityMap.java
+++ b/src/main/java/com/gtnewhorizons/angelica/mixins/early/archaic/common/core/MixinObjectIntIdentityMap.java
@@ -11,15 +11,14 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import java.util.List;
 
-@SuppressWarnings("rawtypes")
 @Mixin(ObjectIntIdentityMap.class)
 public class MixinObjectIntIdentityMap {
 
-    @Shadow protected List field_148748_b;
+    @Shadow protected List<Object> field_148748_b;
 
     @Inject(method = "<init>", at = @At("RETURN"))
     private void initIdArray(CallbackInfo ci) {
-        this.field_148748_b = new UnexpectionalObjectArrayList();
+        this.field_148748_b = new UnexpectionalObjectArrayList<>();
     }
 
     /**
@@ -30,6 +29,6 @@ public class MixinObjectIntIdentityMap {
      */
     @Overwrite
     public Object func_148745_a(int id) {
-        return ((UnexpectionalObjectArrayList)field_148748_b).getOrNull(id);
+        return ((UnexpectionalObjectArrayList<Object>)field_148748_b).getOrNull(id);
     }
 }

--- a/src/main/java/com/gtnewhorizons/angelica/mixins/early/archaic/common/core/MixinSpawnerAnimals.java
+++ b/src/main/java/com/gtnewhorizons/angelica/mixins/early/archaic/common/core/MixinSpawnerAnimals.java
@@ -1,6 +1,7 @@
 package com.gtnewhorizons.angelica.mixins.early.archaic.common.core;
 
 import net.minecraft.entity.Entity;
+import net.minecraft.world.ChunkCoordIntPair;
 import net.minecraft.world.SpawnerAnimals;
 import net.minecraft.world.World;
 import org.embeddedt.archaicfix.config.ArchaicConfig;
@@ -15,7 +16,7 @@ import java.util.HashMap;
 
 @Mixin(SpawnerAnimals.class)
 public class MixinSpawnerAnimals {
-    @Shadow private HashMap eligibleChunksForSpawning;
+    @Shadow private HashMap<ChunkCoordIntPair, Boolean> eligibleChunksForSpawning;
 
     @ModifyConstant(method = "findChunksForSpawning", constant = @Constant(doubleValue = 24.0D))
     private double lowerSpawnRange(double old) {

--- a/src/main/java/com/gtnewhorizons/angelica/mixins/early/archaic/common/core/MixinWorld.java
+++ b/src/main/java/com/gtnewhorizons/angelica/mixins/early/archaic/common/core/MixinWorld.java
@@ -30,7 +30,7 @@ import java.util.Set;
 public abstract class MixinWorld {
     @Shadow public boolean isRemote;
 
-    @Shadow public List playerEntities;
+    @Shadow public List<EntityPlayer> playerEntities;
 
     @Shadow protected IChunkProvider chunkProvider;
 

--- a/src/main/java/com/gtnewhorizons/angelica/mixins/early/archaic/common/core/MixinWorldServer.java
+++ b/src/main/java/com/gtnewhorizons/angelica/mixins/early/archaic/common/core/MixinWorldServer.java
@@ -20,7 +20,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 public abstract class MixinWorldServer extends World {
     @Shadow public ChunkProviderServer theChunkProviderServer;
 
-    public MixinWorldServer(ISaveHandler p_i45368_1_, String p_i45368_2_, WorldProvider p_i45368_3_, WorldSettings p_i45368_4_, Profiler p_i45368_5_) {
+    private MixinWorldServer(ISaveHandler p_i45368_1_, String p_i45368_2_, WorldProvider p_i45368_3_, WorldSettings p_i45368_4_, Profiler p_i45368_5_) {
         super(p_i45368_1_, p_i45368_2_, p_i45368_3_, p_i45368_4_, p_i45368_5_);
     }
 

--- a/src/main/java/com/gtnewhorizons/angelica/mixins/early/archaic/common/extrautils/MixinEventHandlerSiege.java
+++ b/src/main/java/com/gtnewhorizons/angelica/mixins/early/archaic/common/extrautils/MixinEventHandlerSiege.java
@@ -1,7 +1,6 @@
 package com.gtnewhorizons.angelica.mixins.early.archaic.common.extrautils;
 
 import com.rwtema.extrautils.EventHandlerSiege;
-import net.minecraft.tileentity.TileEntityBeacon;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;
@@ -10,6 +9,6 @@ import org.spongepowered.asm.mixin.injection.Redirect;
 public class MixinEventHandlerSiege {
     @Redirect(method = "golemDeath", at = @At(value = "INVOKE", target = "Ljava/lang/Object;equals(Ljava/lang/Object;)Z"))
     private boolean checkSubclassofBeacon(Object subject, Object teBeaconClass) {
-        return ((Class<TileEntityBeacon>)teBeaconClass).isAssignableFrom((Class<?>)subject);
+        return ((Class<?>)teBeaconClass).isAssignableFrom((Class<?>)subject);
     }
 }

--- a/src/main/java/com/gtnewhorizons/angelica/mixins/early/archaic/common/lighting/MixinChunk.java
+++ b/src/main/java/com/gtnewhorizons/angelica/mixins/early/archaic/common/lighting/MixinChunk.java
@@ -23,10 +23,8 @@ import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-@SuppressWarnings("UnnecessaryQualifiedMemberReference")
 @Mixin(value = Chunk.class)
 public abstract class MixinChunk implements IChunkLighting, IChunkLightingData, ILightingEngineProvider {
-    private static final EnumFacing[] HORIZONTAL = LightingHooks.HORIZONTAL_FACINGS;
 
     /**
      * Callback injected to the head of getLightSubtracted(BlockPos, int) to force deferred light updates to be processed.
@@ -76,7 +74,7 @@ public abstract class MixinChunk implements IChunkLighting, IChunkLightingData, 
      * @author Angeline
      */
     @Overwrite
-    public void relightBlock(int x, int y, int z) {
+    private void relightBlock(int x, int y, int z) {
         int i = this.heightMap[z << 4 | x] & 255;
 
         int j = Math.max(y, i);
@@ -131,7 +129,7 @@ public abstract class MixinChunk implements IChunkLighting, IChunkLightingData, 
      * @author Angeline
      */
     @Overwrite
-    public void recheckGaps(boolean onlyOne) {
+    private void recheckGaps(boolean onlyOne) {
         this.worldObj.theProfiler.startSection("recheckGaps");
 
         WorldChunkSlice slice = new WorldChunkSlice(this.worldObj, this.xPosition, this.zPosition);
@@ -179,7 +177,7 @@ public abstract class MixinChunk implements IChunkLighting, IChunkLightingData, 
     private int recheckGapsGetLowestHeight(WorldChunkSlice slice, int x, int z) {
         int max = Integer.MAX_VALUE;
 
-        for (EnumFacing facing : HORIZONTAL) {
+        for (EnumFacing facing : LightingHooks.HORIZONTAL_FACINGS) {
             int j = x + facing.getFrontOffsetX();
             int k = z + facing.getFrontOffsetZ();
 
@@ -192,7 +190,7 @@ public abstract class MixinChunk implements IChunkLighting, IChunkLightingData, 
     private void recheckGapsSkylightNeighborHeight(WorldChunkSlice slice, int x, int z, int height, int max) {
         this.checkSkylightNeighborHeight(slice, x, z, max);
 
-        for (EnumFacing facing : HORIZONTAL) {
+        for (EnumFacing facing : LightingHooks.HORIZONTAL_FACINGS) {
             int j = x + facing.getFrontOffsetX();
             int k = z + facing.getFrontOffsetZ();
 

--- a/src/main/java/com/gtnewhorizons/angelica/mixins/early/archaic/common/lighting/MixinChunkProviderServer.java
+++ b/src/main/java/com/gtnewhorizons/angelica/mixins/early/archaic/common/lighting/MixinChunkProviderServer.java
@@ -14,7 +14,7 @@ import java.util.Set;
 
 @Mixin(ChunkProviderServer.class)
 public abstract class MixinChunkProviderServer {
-    @Shadow private Set chunksToUnload;
+    @Shadow private Set<Long> chunksToUnload;
 
     @Shadow public WorldServer worldObj;
 

--- a/src/main/java/com/gtnewhorizons/angelica/mixins/early/archaic/common/lighting/MixinWorld_Lighting.java
+++ b/src/main/java/com/gtnewhorizons/angelica/mixins/early/archaic/common/lighting/MixinWorld_Lighting.java
@@ -1,5 +1,6 @@
 package com.gtnewhorizons.angelica.mixins.early.archaic.common.lighting;
 
+import net.minecraft.world.ChunkCoordIntPair;
 import net.minecraft.world.EnumSkyBlock;
 import net.minecraft.world.World;
 import net.minecraft.world.chunk.IChunkProvider;
@@ -17,7 +18,7 @@ import java.util.Set;
 
 @Mixin(value = World.class, priority = 999)
 public abstract class MixinWorld_Lighting implements ILightingEngineProvider {
-    @Shadow protected Set activeChunkSet;
+    @Shadow protected Set<ChunkCoordIntPair> activeChunkSet;
 
     @Shadow public abstract IChunkProvider getChunkProvider();
 

--- a/src/main/java/com/gtnewhorizons/angelica/mixins/early/notfine/leaves/MixinBlockLeaves.java
+++ b/src/main/java/com/gtnewhorizons/angelica/mixins/early/notfine/leaves/MixinBlockLeaves.java
@@ -53,7 +53,7 @@ public abstract class MixinBlockLeaves extends BlockLeavesBase {
 
     @Shadow protected IIcon[][] field_150129_M;
 
-    protected MixinBlockLeaves(Material material, boolean overridden) {
+    private MixinBlockLeaves(Material material, boolean overridden) {
         super(material, overridden);
     }
 

--- a/src/main/java/com/gtnewhorizons/angelica/mixins/early/notfine/leaves/MixinBlockLeavesBase.java
+++ b/src/main/java/com/gtnewhorizons/angelica/mixins/early/notfine/leaves/MixinBlockLeavesBase.java
@@ -16,7 +16,7 @@ public abstract class MixinBlockLeavesBase extends Block implements ILeafBlock {
         return LeafRenderUtil.shouldSideBeRendered(world, x, y, z, side);
     }
 
-    protected MixinBlockLeavesBase(Material material) {
+    private MixinBlockLeavesBase(Material material) {
         super(material);
     }
 

--- a/src/main/java/com/gtnewhorizons/angelica/mixins/early/notfine/particles/MixinBlockEnchantmentTable.java
+++ b/src/main/java/com/gtnewhorizons/angelica/mixins/early/notfine/particles/MixinBlockEnchantmentTable.java
@@ -15,7 +15,7 @@ import net.minecraft.world.World;
 @Mixin(value = BlockEnchantmentTable.class)
 public abstract class MixinBlockEnchantmentTable extends BlockContainer {
 
-	protected MixinBlockEnchantmentTable(Material material) {
+	private MixinBlockEnchantmentTable(Material material) {
 		super(material);
 	}
 

--- a/src/main/java/com/gtnewhorizons/angelica/mixins/early/notfine/particles/MixinEffectRenderer.java
+++ b/src/main/java/com/gtnewhorizons/angelica/mixins/early/notfine/particles/MixinEffectRenderer.java
@@ -88,7 +88,7 @@ public abstract class MixinEffectRenderer {
 
     @Shadow @Final
     private static ResourceLocation particleTextures;
-    @Shadow private List[] fxLayers;
+    @Shadow private List<EntityFX>[] fxLayers;
     @Shadow private TextureManager renderer;
 
 }

--- a/src/main/java/com/gtnewhorizons/angelica/mixins/early/notfine/settings/MixinGameSettings.java
+++ b/src/main/java/com/gtnewhorizons/angelica/mixins/early/notfine/settings/MixinGameSettings.java
@@ -96,6 +96,8 @@ public abstract class MixinGameSettings {
             case STREAM_FPS:
                 field_152404_N = value;
                 break;
+            default:
+                break;
         }
     }
 
@@ -193,6 +195,8 @@ public abstract class MixinGameSettings {
             case ENABLE_VSYNC:
                 enableVsync = !enableVsync;
                 Display.setVSyncEnabled(enableVsync);
+                break;
+            default:
                 break;
         }
         saveOptions();

--- a/src/main/java/com/gtnewhorizons/angelica/mixins/early/shaders/MixinEntityRenderer.java
+++ b/src/main/java/com/gtnewhorizons/angelica/mixins/early/shaders/MixinEntityRenderer.java
@@ -59,12 +59,6 @@ public class MixinEntityRenderer {
         }
     }
 
-    private void toggleFog(boolean enable) {
-        if (fogToggleListener != null) {
-            fogToggleListener.run();
-        }
-    }
-
 
     @Inject(at = @At(shift = At.Shift.AFTER, target = "Lnet/minecraft/client/renderer/EntityRenderer;setupCameraTransform(FI)V", value = "INVOKE"), method = "renderWorld(FJ)V")
     private void iris$setCamera(float tickDelta, long startTime, CallbackInfo ci) {

--- a/src/main/java/com/gtnewhorizons/angelica/mixins/early/shadersmod/renderer/MixinRenderDragon.java
+++ b/src/main/java/com/gtnewhorizons/angelica/mixins/early/shadersmod/renderer/MixinRenderDragon.java
@@ -20,7 +20,7 @@ public class MixinRenderDragon {
                     value = "INVOKE"),
             method = "shouldRenderPass(Lnet/minecraft/entity/boss/EntityDragon;IF)I")
     private void angelica$beginSpiderEyes(CallbackInfoReturnable<Integer> cir) {
-        Shaders.beginSpiderEyes();
+        Shaders.beginGlowingEyes();
     }
 
 }

--- a/src/main/java/com/gtnewhorizons/angelica/mixins/early/shadersmod/renderer/MixinRenderEnderman.java
+++ b/src/main/java/com/gtnewhorizons/angelica/mixins/early/shadersmod/renderer/MixinRenderEnderman.java
@@ -20,7 +20,7 @@ public class MixinRenderEnderman {
                     value = "INVOKE"),
             method = "shouldRenderPass(Lnet/minecraft/entity/monster/EntityEnderman;IF)I")
     private void angelica$beginSpiderEyes(CallbackInfoReturnable<Integer> cir) {
-        Shaders.beginSpiderEyes();
+        Shaders.beginGlowingEyes();
     }
 
 }

--- a/src/main/java/com/gtnewhorizons/angelica/mixins/early/shadersmod/renderer/MixinRenderSpider.java
+++ b/src/main/java/com/gtnewhorizons/angelica/mixins/early/shadersmod/renderer/MixinRenderSpider.java
@@ -20,7 +20,7 @@ public class MixinRenderSpider {
                     value = "INVOKE"),
             method = "shouldRenderPass(Lnet/minecraft/entity/monster/EntitySpider;IF)I")
     private void angelica$beginSpiderEyes(CallbackInfoReturnable<Integer> cir) {
-        Shaders.beginSpiderEyes();
+        Shaders.beginGlowingEyes();
     }
 
 }

--- a/src/main/java/com/gtnewhorizons/angelica/mixins/early/shadersmod/renderer/MixinSimpleTexture.java
+++ b/src/main/java/com/gtnewhorizons/angelica/mixins/early/shadersmod/renderer/MixinSimpleTexture.java
@@ -1,6 +1,8 @@
 package com.gtnewhorizons.angelica.mixins.early.shadersmod.renderer;
 
 import com.gtnewhorizons.angelica.client.ShadersTex;
+import com.llamalad7.mixinextras.sugar.Local;
+
 import net.minecraft.client.renderer.texture.AbstractTexture;
 import net.minecraft.client.renderer.texture.SimpleTexture;
 import net.minecraft.client.resources.IResourceManager;
@@ -8,9 +10,7 @@ import net.minecraft.util.ResourceLocation;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.Redirect;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import java.awt.image.BufferedImage;
 
@@ -18,24 +18,16 @@ import java.awt.image.BufferedImage;
 public abstract class MixinSimpleTexture extends AbstractTexture {
     // TODO: PBR
 
-    private IResourceManager passedResourceManager;
-
     @Shadow
     protected ResourceLocation textureLocation;
-
-    // TODO: Use @Local as soon as it exists in a stable version of MixinExtras
-    @Inject(method = "loadTexture(Lnet/minecraft/client/resources/IResourceManager;)V", at = @At("HEAD"))
-    private void angelica$getResourceManager(IResourceManager p_110551_1_, CallbackInfo cbi) {
-        passedResourceManager = p_110551_1_;
-    }
 
     @Redirect(
             method = "loadTexture(Lnet/minecraft/client/resources/IResourceManager;)V",
             at = @At(
                     value = "INVOKE",
                     target = "Lnet/minecraft/client/renderer/texture/TextureUtil;uploadTextureImageAllocate(ILjava/awt/image/BufferedImage;ZZ)I"))
-    private int angelica$loadSimpleTexture(int textureID, BufferedImage bufferedImage, boolean flag, boolean flag1) {
-        ShadersTex.loadSimpleTexture(textureID, bufferedImage, flag, flag1, passedResourceManager, this.textureLocation, ShadersTex.getMultiTexID(this));
+    private int angelica$loadSimpleTexture(int textureID, BufferedImage bufferedImage, boolean flag, boolean flag1, @Local IResourceManager p_110551_1_) {
+        ShadersTex.loadSimpleTexture(textureID, bufferedImage, flag, flag1, p_110551_1_, this.textureLocation, ShadersTex.getMultiTexID(this));
         return 0;
     }
 

--- a/src/main/java/com/gtnewhorizons/angelica/mixins/early/shadersmod/renderer/MixinTextureMap.java
+++ b/src/main/java/com/gtnewhorizons/angelica/mixins/early/shadersmod/renderer/MixinTextureMap.java
@@ -1,6 +1,8 @@
 package com.gtnewhorizons.angelica.mixins.early.shadersmod.renderer;
 
 import com.gtnewhorizons.angelica.client.ShadersTex;
+import com.llamalad7.mixinextras.sugar.Local;
+
 import net.minecraft.client.renderer.texture.Stitcher;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.client.renderer.texture.TextureMap;
@@ -8,13 +10,11 @@ import net.minecraft.client.resources.IResource;
 import net.minecraft.client.resources.IResourceManager;
 import net.minecraft.util.ResourceLocation;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.Slice;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 
 import java.io.IOException;
 
@@ -24,9 +24,6 @@ public class MixinTextureMap extends MixinAbstractTexture {
 
     public int angelica$atlasWidth;
     public int angelica$atlasHeight;
-
-    @Unique
-    private Stitcher stitcher;
 
     // loadTextureAtlas
 
@@ -39,23 +36,14 @@ public class MixinTextureMap extends MixinAbstractTexture {
         return ShadersTex.loadResource(p_110571_1_, resourcelocation1);
     }
 
-    // TODO: Use @Local as soon as it is in a stable version of MixinExtras
-    @Inject(
-            at = @At(ordinal = 0, remap = false, target = "Ljava/util/Map;clear()V", value = "INVOKE"),
-            locals = LocalCapture.CAPTURE_FAILEXCEPTION,
-            method = "loadTextureAtlas(Lnet/minecraft/client/resources/IResourceManager;)V")
-    private void angelica$captureStitcher(IResourceManager p_110571_1_, CallbackInfo ci, int i, Stitcher stitcher) {
-        this.stitcher = stitcher;
-    }
-
     @Redirect(
             at = @At(
                     target = "Lnet/minecraft/client/renderer/texture/TextureUtil;allocateTextureImpl(IIIIF)V",
                     value = "INVOKE"),
             method = "loadTextureAtlas(Lnet/minecraft/client/resources/IResourceManager;)V")
     private void angelica$allocateTextureMap(int p_147946_0_, int p_147946_1_, int p_147946_2_, int p_147946_3_,
-            float p_147946_4_) {
-        ShadersTex.allocateTextureMap(p_147946_0_, p_147946_1_, p_147946_2_, p_147946_3_, p_147946_4_, this.stitcher, (TextureMap) (Object) this);
+            float p_147946_4_, @Local Stitcher stitcher) {
+        ShadersTex.allocateTextureMap(p_147946_0_, p_147946_1_, p_147946_2_, p_147946_3_, p_147946_4_, stitcher, (TextureMap) (Object) this);
     }
 
     @Redirect(

--- a/src/main/java/com/gtnewhorizons/angelica/mixins/late/archaic/common/mrtjp/MixinBlockUpdateHandler.java
+++ b/src/main/java/com/gtnewhorizons/angelica/mixins/late/archaic/common/mrtjp/MixinBlockUpdateHandler.java
@@ -12,10 +12,10 @@ import java.util.HashSet;
 @Mixin(BlockUpdateHandler$.class)
 public class MixinBlockUpdateHandler {
     @Redirect(method = "getActiveChunkSet", at = @At(value = "INVOKE", target = "Ljava/util/HashSet;add(Ljava/lang/Object;)Z"), remap = false)
-    private boolean addChunkIfLoaded(HashSet chunkSet, Object o, World world) {
+    private boolean addChunkIfLoaded(HashSet<ChunkCoordIntPair> chunkSet, Object o, World world) {
         ChunkCoordIntPair pair = (ChunkCoordIntPair)o;
         if(world.getChunkProvider().chunkExists(pair.chunkXPos, pair.chunkZPos))
-            return chunkSet.add(o);
+            return chunkSet.add(pair);
         return false;
     }
 }

--- a/src/main/java/com/gtnewhorizons/angelica/mixins/late/client/journeymap/MixinTileDrawStep.java
+++ b/src/main/java/com/gtnewhorizons/angelica/mixins/late/client/journeymap/MixinTileDrawStep.java
@@ -8,7 +8,7 @@ import org.spongepowered.asm.mixin.injection.Redirect;
 
 @Mixin(TileDrawStep.class)
 public class MixinTileDrawStep {
-    @Redirect(method = "*", at = @At(value = "FIELD", opcode = Opcodes.GETFIELD, target = "Ljourneymap/client/render/map/TileDrawStep;debug:Z"))
+    @Redirect(method = "*", at = @At(value = "FIELD", opcode = Opcodes.GETFIELD, target = "Ljourneymap/client/render/map/TileDrawStep;debug:Z", remap = false))
     private boolean getDebug(TileDrawStep instance) {
         return false;
     }

--- a/src/main/java/com/gtnewhorizons/angelica/mixins/late/notfine/leaves/thaumcraft/MixinBlockMagicalLeaves.java
+++ b/src/main/java/com/gtnewhorizons/angelica/mixins/late/notfine/leaves/thaumcraft/MixinBlockMagicalLeaves.java
@@ -49,7 +49,7 @@ public abstract class MixinBlockMagicalLeaves extends Block implements ILeafBloc
         return LeafRenderUtil.shouldSideBeRendered(world, x, y, z, side);
     }
 
-    protected MixinBlockMagicalLeaves(Material material) {
+    private MixinBlockMagicalLeaves(Material material) {
         super(material);
     }
 

--- a/src/main/java/com/gtnewhorizons/angelica/mixins/late/notfine/leaves/witchery/MixinBlockWitchLeaves.java
+++ b/src/main/java/com/gtnewhorizons/angelica/mixins/late/notfine/leaves/witchery/MixinBlockWitchLeaves.java
@@ -44,7 +44,7 @@ public abstract class MixinBlockWitchLeaves extends BlockLeavesBase {
     @Shadow(remap = false)
     private IIcon[][] iconsForModes;
 
-    protected MixinBlockWitchLeaves(Material material, boolean unused) {
+    private MixinBlockWitchLeaves(Material material, boolean unused) {
         super(material, unused);
     }
 


### PR DESCRIPTION
... and other various fixes/cleanups:
- Update buildscript
- Update dependencies
- Change ChickenChunks dep to use covers1624 maven
- Make required constructors in mixins private
- Remove dead code
- Add generics
- Use `@Local` and `@Share` -> ***This needs to be tested!***
- Rename `Shaders.beginSpiderEyes()` to `Shaders.beginGlowingEyes()`, as it is also used for Endermen and Ender Dragons
- Remove `value` argument from `@Accessor` annotations in `AccessorSplashProgress` -> ***This needs to be tested!***
- Specify ordinal of `@Redirect`s in `MixinPlayerChunkViewerManager`
- Set `remap = false` in `MixinTileDrawStep`
- Add default cases in `MixinGameSettings`

I couldn't do any testing because I'm missing the `lwjgl3ify-1.5.3-pre` dep