### PR TITLE
Use Sodium's smooth lighting for entities

### DIFF
--- a/src/main/java/com/gtnewhorizons/angelica/mixins/Mixins.java
+++ b/src/main/java/com/gtnewhorizons/angelica/mixins/Mixins.java
@@ -42,6 +42,7 @@ public enum Mixins {
             ,"sodium.MixinWorldClient"
             ,"sodium.MixinWorldRenderer"
             ,"sodium.MixinEntity"
+            ,"sodium.MixinRenderManager"
         )
     ),
 

--- a/src/main/java/com/gtnewhorizons/angelica/mixins/early/sodium/MixinRenderManager.java
+++ b/src/main/java/com/gtnewhorizons/angelica/mixins/early/sodium/MixinRenderManager.java
@@ -1,0 +1,28 @@
+package com.gtnewhorizons.angelica.mixins.early.sodium;
+
+import me.jellysquid.mods.sodium.client.SodiumClientMod;
+import me.jellysquid.mods.sodium.client.gui.SodiumGameOptions;
+import me.jellysquid.mods.sodium.client.model.light.EntityLighter;
+import net.minecraft.client.renderer.entity.RenderManager;
+import net.minecraft.entity.Entity;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(RenderManager.class)
+public class MixinRenderManager {
+
+    /**
+     * Sodium: Use Sodium smooth entity light if enabled.
+     */
+    @Redirect(method = "renderEntityStatic", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/Entity;getBrightnessForRender(F)I"))
+    private int sodium$getBrightnessForRender(Entity self, float partialTicks) {
+
+        if (SodiumClientMod.options().quality.smoothLighting == SodiumGameOptions.LightingQuality.HIGH) {
+
+            return EntityLighter.getBlendedLight(self, partialTicks);
+        }
+
+        return self.getBrightnessForRender(partialTicks);
+    }
+}

--- a/src/main/java/me/jellysquid/mods/sodium/client/model/light/EntityLighter.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/model/light/EntityLighter.java
@@ -1,12 +1,9 @@
 package me.jellysquid.mods.sodium.client.model.light;
 
 import com.gtnewhorizons.angelica.compat.mojang.BlockPos;
-import com.gtnewhorizons.angelica.compat.mojang.BlockRenderView;
-import com.gtnewhorizons.angelica.compat.mojang.BlockState;
-import me.jellysquid.mods.sodium.client.render.entity.EntityLightSampler;
-import net.minecraft.block.Block;
 import net.minecraft.util.MathHelper;
 import net.minecraft.entity.Entity;
+import net.minecraft.world.EnumSkyBlock;
 
 import static org.joml.Math.lerp;
 
@@ -63,11 +60,9 @@ public class EntityLighter {
                 for (int bZ = bMinZ; bZ < bMaxZ; bZ++) {
                     pos.set(bX, bY, bZ);
 
-                    // TODO - Sodium - Blocks
-                    Block block = entity.worldObj.getBlock(pos.x, pos.y, pos.z);
-
                     // Do not consider light-blocking volumes
-                    if (block.isOpaqueCube() && entity.worldObj.getBlockLightValue(pos.x, pos.y, pos.z) <= 0) {
+                    if (entity.worldObj.getBlock(pos.x, pos.y, pos.z).isOpaqueCube()
+                        && entity.worldObj.getBlockLightValue(pos.x, pos.y, pos.z) <= 0) {
                         continue;
                     }
 
@@ -81,18 +76,15 @@ public class EntityLighter {
                     // Keep count of how much light could've been contributed
                     max += weight;
 
-                    // lighter.bridge$getSkyLight(entity, pos) and lighter.bridge$getBlockLight(entity, pos) replaced
-                    // get the sky light at that block pos
-                    // x, y, z, block light to add
-                    double skylight = entity.worldObj.getLightBrightnessForSkyBlocks(pos.x, pos.y, pos.z, 0);
-                    // Ditto for block light, BUT it's always 15 if the entity is on fire
-                    double blklight = (entity.isBurning()) ? 15 : entity.worldObj.getBlockLightValue(pos.x, pos.y, pos.z);
+                    // note: lighter.bridge$getSkyLight(entity, pos) and lighter.bridge$getBlockLight(entity, pos)
+                    // were replaced, mixin+this method de-generified. as far as I can tell they only existed because
+                    // Sodium had a weird setup just for paintings, don't think we need it.
 
                     // Sum the light actually contributed by this volume
-                    sl += weight * (skylight / MAX_LIGHT_VAL);
+                    sl += weight * (entity.worldObj.getSkyBlockTypeBrightness(EnumSkyBlock.Sky, pos.x, pos.y, pos.z) / MAX_LIGHT_VAL);
 
                     if (calcBlockLight) {
-                        bl += weight * (blklight / MAX_LIGHT_VAL);
+                        bl += weight * (entity.worldObj.getBlockLightValue(pos.x, pos.y, pos.z) / MAX_LIGHT_VAL);
                     } else {
                         bl += weight;
                     }


### PR DESCRIPTION
Sodium had a weird special case for paintings; from my testing it looks fine without that, but I'm not an expert.