### PR TITLE
move biome data byte array to BiomeGenBase array to fix modded biome detection

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/world/WorldSlice.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/world/WorldSlice.java
@@ -72,7 +72,7 @@ public class WorldSlice implements IBlockAccess {
     private ClonedChunkSection[] sections;
 
     // Biome data for each chunk section
-    private byte[][] biomeData;
+    private BiomeGenBase[][] biomeData;
 
     // The starting point from which this slice captures blocks
     private int baseX, baseY, baseZ;
@@ -130,7 +130,7 @@ public class WorldSlice implements IBlockAccess {
         this.sections = new ClonedChunkSection[SECTION_TABLE_ARRAY_SIZE];
         this.blockArrays = new Block[SECTION_TABLE_ARRAY_SIZE][];
         this.metadataArrays = new int[SECTION_TABLE_ARRAY_SIZE][];
-        this.biomeData = new byte[SECTION_TABLE_ARRAY_SIZE][];
+        this.biomeData = new BiomeGenBase[SECTION_TABLE_ARRAY_SIZE][];
 
         for (int x = 0; x < SECTION_LENGTH; x++) {
             for (int y = 0; y < SECTION_LENGTH; y++) {
@@ -214,9 +214,8 @@ public class WorldSlice implements IBlockAccess {
         int relY = 0;
         int relZ = z - this.baseZ;
 
-        final int k = this.biomeData[getLocalSectionIndex(relX >> 4, relY >> 4, relZ >> 4)]
-                [(x & 15) | (z & 15) << 4] & 255;
-        BiomeGenBase biome = BiomeGenBase.getBiome(k);
+        BiomeGenBase biome = this.biomeData[getLocalSectionIndex(relX >> 4, relY >> 4, relZ >> 4)]
+            [(x & 15) | (z & 15) << 4];
         // can be null if biome wasn't generated yet
         return biome == null ? BiomeGenBase.plains : biome;
     }

--- a/src/main/java/me/jellysquid/mods/sodium/client/world/cloned/ClonedChunkSection.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/world/cloned/ClonedChunkSection.java
@@ -16,7 +16,6 @@ import net.minecraft.world.chunk.Chunk;
 import net.minecraft.world.chunk.storage.ExtendedBlockStorage;
 import net.minecraft.world.gen.structure.StructureBoundingBox;
 
-import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class ClonedChunkSection {
@@ -34,7 +33,7 @@ public class ClonedChunkSection {
     private ChunkSectionPos pos;
 
     @Getter
-    private byte[] biomeData;
+    private BiomeGenBase[] biomeData;
 
     private long lastUsedTimestamp = Long.MAX_VALUE;
 
@@ -60,13 +59,13 @@ public class ClonedChunkSection {
         this.pos = pos;
         this.data = new ExtendedBlockStorageExt(section);
 
-        this.biomeData = Arrays.copyOf(chunk.getBiomeArray(), chunk.getBiomeArray().length);
+        this.biomeData = new BiomeGenBase[chunk.getBiomeArray().length];
 
         StructureBoundingBox box = new StructureBoundingBox(pos.getMinX(), pos.getMinY(), pos.getMinZ(), pos.getMaxX(), pos.getMaxY(), pos.getMaxZ());
 
         this.tileEntities.clear();
 
-        // Check for tile entities
+        // Check for tile entities & fill biome data
         for(int y = pos.getMinY(); y <= pos.getMaxY(); y++) {
             for(int z = pos.getMinZ(); z <= pos.getMaxZ(); z++) {
                 for(int x = pos.getMinX(); x <= pos.getMaxX(); x++) {
@@ -83,6 +82,7 @@ public class ClonedChunkSection {
                             this.tileEntities.put(ChunkSectionPos.packLocal(new BlockPos(tileentity.xCoord & 15, tileentity.yCoord & 15, tileentity.zCoord & 15)), tileentity);
                         }
                     }
+                    this.biomeData[(lZ << 4) | lX] = world.getBiomeGenForCoords(x, z);
                 }
             }
         }
@@ -106,8 +106,7 @@ public class ClonedChunkSection {
     }
 
     public BiomeGenBase getBiomeForNoiseGen(int x, int y, int z) {
-        int k = this.biomeData[x | z << 4] & 255;
-        return BiomeGenBase.getBiome(k);
+        return this.biomeData[x | z << 4];
 
     }
 


### PR DESCRIPTION
Unlike world.getBiomeGenForCoords() which always returns the exact biome present, BiomeGenBase.getBiome() only returns biomes present in the BiomeGenBase array which will lead to errors with modded biomes
with patch:
![2023-12-04_13 59 24](https://github.com/GTNewHorizons/Angelica/assets/70655895/1d10ffc7-cb81-4722-bf8d-c85056aa0a9b)
without:

![2023-12-04_14 00 48](https://github.com/GTNewHorizons/Angelica/assets/70655895/40825d56-7b9a-4575-a1ae-19466c363a78)
