### PR TITLE
Make glPushAttrib match native behavior if bypassing state manager cache

### DIFF
--- a/src/main/java/com/gtnewhorizons/angelica/glsm/GLStateManager.java
+++ b/src/main/java/com/gtnewhorizons/angelica/glsm/GLStateManager.java
@@ -672,7 +672,7 @@ public class GLStateManager {
     public static void glPushAttrib(int mask) {
         // TODO: Proper state tracking; but at least for now the current cases of this didn't do anything related to textures and
         // just overly broadly set ALL_BITS :facepalm:
-        GL11.glPushAttrib(mask & ~(GL11.GL_TEXTURE_BIT));
+        GL11.glPushAttrib(GLStateManager.BYPASS_CACHE ? mask : (mask & ~(GL11.GL_TEXTURE_BIT)));
     }
 
     public static void glPopAttrib() {


### PR DESCRIPTION
If the cache is being bypassed, it won't matter if we aren't completely up-to-date on the active texture, so we should allow the full mask through. This allows playing with mods that push all attributes (e.g. EFR elytra renderer) when the cache is disabled.