### PR TITLE
Delete vanilla's global block bounds fields

### DIFF
--- a/src/main/java/com/gtnewhorizons/angelica/loading/MixinCompatHackTweaker.java
+++ b/src/main/java/com/gtnewhorizons/angelica/loading/MixinCompatHackTweaker.java
@@ -1,5 +1,6 @@
 package com.gtnewhorizons.angelica.loading;
 
+import com.gtnewhorizons.angelica.transform.BlockTransformer;
 import com.gtnewhorizons.angelica.transform.RedirectorTransformer;
 import cpw.mods.fml.common.Loader;
 import cpw.mods.fml.relauncher.FMLLaunchHandler;
@@ -74,6 +75,7 @@ public class MixinCompatHackTweaker implements ITweaker {
         if (FMLLaunchHandler.side().isClient()) {
             // Run after Mixins, but before LWJGl3ify
             Launch.classLoader.registerTransformer(RedirectorTransformer.class.getName());
+            Launch.classLoader.registerTransformer(BlockTransformer.class.getName());
         }
 
         return new String[0];

--- a/src/main/java/com/gtnewhorizons/angelica/transform/BlockTransformer.java
+++ b/src/main/java/com/gtnewhorizons/angelica/transform/BlockTransformer.java
@@ -1,0 +1,44 @@
+package com.gtnewhorizons.angelica.transform;
+
+import com.google.common.collect.ImmutableList;
+import net.minecraft.launchwrapper.IClassTransformer;
+import org.apache.commons.lang3.tuple.Pair;
+import org.spongepowered.asm.lib.ClassReader;
+import org.spongepowered.asm.lib.ClassWriter;
+import org.spongepowered.asm.lib.tree.ClassNode;
+
+import java.util.List;
+
+public class BlockTransformer implements IClassTransformer {
+    public static final String BlockClass = "net/minecraft/block/Block";
+    private static final String BlockClassFriendly = BlockClass.replace('/', '.');
+    public static final List<Pair<String, String>> BlockBoundsFields = ImmutableList.of(
+        Pair.of("minX", "field_149759_B"),
+        Pair.of("minY", "field_149760_C"),
+        Pair.of("minZ", "field_149754_D"),
+        Pair.of("maxX", "field_149755_E"),
+        Pair.of("maxY", "field_149756_F"),
+        Pair.of("maxZ", "field_149757_G")
+    );
+
+    /**
+     * Delete the global vanilla bounding box fields off the Block object. {@link RedirectorTransformer}
+     * replaces these with a thread-safe alternative.
+     */
+    @Override
+    public byte[] transform(String name, String transformedName, byte[] basicClass) {
+        if(basicClass != null && transformedName.equals(BlockClassFriendly)) {
+            final ClassReader cr = new ClassReader(basicClass);
+            final ClassNode cn = new ClassNode();
+            cr.accept(cn, 0);
+
+            cn.fields.removeIf(node -> BlockBoundsFields.stream().anyMatch(pair -> node.name.equals(pair.getLeft()) || node.name.equals(pair.getRight())));
+
+            ClassWriter cw = new ClassWriter(ClassWriter.COMPUTE_MAXS);
+            cn.accept(cw);
+            basicClass = cw.toByteArray();
+        }
+
+        return basicClass;
+    }
+}

--- a/src/main/java/com/gtnewhorizons/angelica/transform/RedirectorTransformer.java
+++ b/src/main/java/com/gtnewhorizons/angelica/transform/RedirectorTransformer.java
@@ -31,6 +31,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static com.gtnewhorizons.angelica.transform.BlockTransformer.*;
+
 /**
  * This transformer redirects all Tessellator.instance field accesses to go through our TessellatorManager.
  * As well as redirect some GL calls to our custom GLStateManager
@@ -50,22 +52,12 @@ public class RedirectorTransformer implements IClassTransformer {
     private static final String EXTBlendFunc = "org/lwjgl/opengl/EXTBlendFuncSeparate";
     private static final String ARBMultiTexture = "org/lwjgl/opengl/ARBMultitexture";
     private static final String TessellatorClass = "net/minecraft/client/renderer/Tessellator";
-    private static final String BlockClass = "net/minecraft/block/Block";
     private static final String MinecraftClient = "net.minecraft.client";
     private static final String SplashProgress = "cpw.mods.fml.client.SplashProgress";
     private static final String ThreadedBlockData = "com/gtnewhorizons/angelica/glsm/ThreadedBlockData";
     private static final Set<String> ExcludedMinecraftMainThreadChecks = ImmutableSet.of(
         "startGame", "func_71384_a",
         "initializeTextures", "func_77474_a"
-    );
-
-    private static final List<Pair<String, String>> BlockBoundsFields = ImmutableList.of(
-        Pair.of("minX", "field_149759_B"),
-        Pair.of("minY", "field_149760_C"),
-        Pair.of("minZ", "field_149754_D"),
-        Pair.of("maxX", "field_149755_E"),
-        Pair.of("maxY", "field_149756_F"),
-        Pair.of("maxZ", "field_149757_G")
     );
 
     private static final ClassConstantPoolParser cstPoolParser = new ClassConstantPoolParser(GL11, GL13, GL14, OpenGlHelper, EXTBlendFunc, ARBMultiTexture, TessellatorClass, BlockClass,


### PR DESCRIPTION
We have a global `RedirectorTransformer` that redirects all usage of these fields to a thread-safe data structure. To help catch usages of the fields that weren't redirected, let's remove them from the vanilla class entirely. 