### PR TITLE
Fix Block bounds fields redirects not applying to subclasses

### DIFF
--- a/src/main/java/com/gtnewhorizons/angelica/transform/RedirectorTransformer.java
+++ b/src/main/java/com/gtnewhorizons/angelica/transform/RedirectorTransformer.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.file.Files;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;


### PR DESCRIPTION
Apparently, `javac` will emit field accesses with the strictest known subclass as the owner, rather than the class the field was declared on. To fix this, we track all subclasses of `Block` and redirect a field access with any relevant owner.