### PR TITLE
Do not include transformed mods in runtime classpath by default

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -39,11 +39,13 @@ configurations {
     transformedModCompileOnly
     transformedModCompileOnly.canBeConsumed = false
 
-    // Add the transformed mod dependencies to the compilation and runtime classpaths, but don't publish them in the Maven metadata
+    // Add the transformed mod dependencies to the compilation classpaths, but don't publish them in the Maven metadata
     compileClasspath.extendsFrom(transformedMod, transformedModCompileOnly)
-    runtimeClasspath.extendsFrom(transformedMod)
     testCompileClasspath.extendsFrom(transformedMod, transformedModCompileOnly)
-    testRuntimeClasspath.extendsFrom(transformedMod)
+
+    // Can be enabled for testing if desired
+    // runtimeClasspath.extendsFrom(transformedMod)
+    // testRuntimeClasspath.extendsFrom(transformedMod)
 }
 
 dependencies {


### PR DESCRIPTION
Having content mods loaded at runtime slows down launches in dev quite a bit; in my opinion, we should keep the default dev environment minimal.