### PR TITLE
Preliminary ChunkAPI/EndlessIDs compatibility

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -76,6 +76,7 @@ dependencies {
     compileOnly(rfg.deobf('curse.maven:witchery-69673:2234410'))
 
     compileOnly("com.falsepattern:chunkapi-mc1.7.10:0.5.0:api")
+    compileOnly("com.falsepattern:endlessids-mc1.7.10:1.5-beta0002:dev")
 
     compileOnly(rfg.deobf("curse.maven:extrautils-225561:2264383"))
     compileOnly(rfg.deobf("curse.maven:dynamiclights-227874:2337326"))

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -75,6 +75,7 @@ dependencies {
     compileOnly("com.github.GTNewHorizons:twilightforest:2.5.1:dev") {transitive = false }
     compileOnly(rfg.deobf('curse.maven:witchery-69673:2234410'))
 
+    compileOnly("com.falsepattern:chunkapi-mc1.7.10:0.5.0:api")
 
     compileOnly(rfg.deobf("curse.maven:extrautils-225561:2264383"))
     compileOnly(rfg.deobf("curse.maven:dynamiclights-227874:2337326"))

--- a/repositories.gradle
+++ b/repositories.gradle
@@ -9,5 +9,9 @@ repositories {
             artifact()
         }
     }
+    maven {
+        name = 'mavenpattern'
+        url = 'https://mvn.falsepattern.com/releases'
+    }
     mavenLocal()
 }

--- a/src/main/java/com/gtnewhorizons/angelica/AngelicaMod.java
+++ b/src/main/java/com/gtnewhorizons/angelica/AngelicaMod.java
@@ -26,6 +26,8 @@ public class AngelicaMod {
     public static boolean isOldNEIDLoaded;
 
     public static boolean isChunkAPILoaded;
+
+    public static boolean isEIDBiomeLoaded;
     public static final boolean lwjglDebug = Boolean.parseBoolean(System.getProperty("org.lwjgl.util.Debug", "false"));
 
     public static final ManagedEnum<AnimationMode> animationsMode = new ManagedEnum<>(AnimationMode.VISIBLE_ONLY);
@@ -35,6 +37,7 @@ public class AngelicaMod {
         isNEIDLoaded = Loader.isModLoaded("neid");
         isOldNEIDLoaded = Loader.isModLoaded("notenoughIDs");
         isChunkAPILoaded = Loader.isModLoaded("chunkapi");
+        isEIDBiomeLoaded = Loader.isModLoaded("endlessids_biome");
         proxy.preInit(event);
     }
 

--- a/src/main/java/com/gtnewhorizons/angelica/AngelicaMod.java
+++ b/src/main/java/com/gtnewhorizons/angelica/AngelicaMod.java
@@ -24,6 +24,8 @@ public class AngelicaMod {
     public static boolean isNEIDLoaded;
     /** ASM Version */
     public static boolean isOldNEIDLoaded;
+
+    public static boolean isChunkAPILoaded;
     public static final boolean lwjglDebug = Boolean.parseBoolean(System.getProperty("org.lwjgl.util.Debug", "false"));
 
     public static final ManagedEnum<AnimationMode> animationsMode = new ManagedEnum<>(AnimationMode.VISIBLE_ONLY);
@@ -32,6 +34,7 @@ public class AngelicaMod {
     public void preInit(FMLPreInitializationEvent event) {
         isNEIDLoaded = Loader.isModLoaded("neid");
         isOldNEIDLoaded = Loader.isModLoaded("notenoughIDs");
+        isChunkAPILoaded = Loader.isModLoaded("chunkapi");
         proxy.preInit(event);
     }
 

--- a/src/main/java/com/gtnewhorizons/angelica/compat/ExtendedBlockStorageExt.java
+++ b/src/main/java/com/gtnewhorizons/angelica/compat/ExtendedBlockStorageExt.java
@@ -23,7 +23,9 @@ public class ExtendedBlockStorageExt extends ExtendedBlockStorage {
         super(((MixinExtendedBlockStorage) storage).getYBase(), storage.getSkylightArray() != null);
 
         if (AngelicaMod.isChunkAPILoaded) {
-            hasSky = !chunk.worldObj.provider.hasNoSky;
+            if (storage.getSkylightArray() != null) {
+                hasSky = true;
+            }
             DataRegistry.cloneSubChunk(chunk, storage, this);
         } else {
             int arrayLen;

--- a/src/main/java/com/gtnewhorizons/angelica/compat/ExtendedBlockStorageExt.java
+++ b/src/main/java/com/gtnewhorizons/angelica/compat/ExtendedBlockStorageExt.java
@@ -1,9 +1,12 @@
 package com.gtnewhorizons.angelica.compat;
 
+import com.falsepattern.chunk.api.DataRegistry;
 import com.gtnewhorizons.angelica.AngelicaMod;
 import com.gtnewhorizons.angelica.mixins.early.sodium.MixinExtendedBlockStorage;
 import com.gtnewhorizons.angelica.mixins.interfaces.ExtendedNibbleArray;
 import com.gtnewhorizons.neid.mixins.interfaces.IExtendedBlockStorageMixin;
+
+import net.minecraft.world.chunk.Chunk;
 import net.minecraft.world.chunk.NibbleArray;
 import net.minecraft.world.chunk.storage.ExtendedBlockStorage;
 import ru.fewizz.idextender.Hooks;
@@ -16,44 +19,49 @@ public class ExtendedBlockStorageExt extends ExtendedBlockStorage {
         this.hasSky = hasSky;
     }
 
-    public ExtendedBlockStorageExt(ExtendedBlockStorage storage) {
+    public ExtendedBlockStorageExt(Chunk chunk, ExtendedBlockStorage storage) {
         super(((MixinExtendedBlockStorage) storage).getYBase(), storage.getSkylightArray() != null);
 
-        int arrayLen;
-        if (AngelicaMod.isNEIDLoaded){
-            final short[] block16BArray = ((IExtendedBlockStorageMixin)(Object)this).getBlock16BArray();
-            System.arraycopy(((IExtendedBlockStorageMixin)(Object)storage).getBlock16BArray(), 0, block16BArray, 0, block16BArray.length);
-            if(storage.getBlockMSBArray() != null) {
-                this.setBlockMSBArray(new NibbleArray(block16BArray.length, 4));
-                copyNibbleArray((ExtendedNibbleArray) storage.getBlockMSBArray(), (ExtendedNibbleArray) this.getBlockMSBArray());
+        if (AngelicaMod.isChunkAPILoaded) {
+            hasSky = !chunk.worldObj.provider.hasNoSky;
+            DataRegistry.cloneSubChunk(chunk, storage, this);
+        } else {
+            int arrayLen;
+            if (AngelicaMod.isNEIDLoaded){
+                final short[] block16BArray = ((IExtendedBlockStorageMixin)(Object)this).getBlock16BArray();
+                System.arraycopy(((IExtendedBlockStorageMixin)(Object)storage).getBlock16BArray(), 0, block16BArray, 0, block16BArray.length);
+                if(storage.getBlockMSBArray() != null) {
+                    this.setBlockMSBArray(new NibbleArray(block16BArray.length, 4));
+                    copyNibbleArray((ExtendedNibbleArray) storage.getBlockMSBArray(), (ExtendedNibbleArray) this.getBlockMSBArray());
+                }
+                arrayLen = block16BArray.length;
             }
-            arrayLen = block16BArray.length;
-        }
-        else if (AngelicaMod.isOldNEIDLoaded){
-            final short[] blockLSBArray = Hooks.get(this);
-            System.arraycopy(Hooks.get(storage), 0, blockLSBArray, 0, blockLSBArray.length);
-            // getBlockMSBArray is nuked in asm version
-            arrayLen = blockLSBArray.length;
-        }
-        else {
-            final byte[] blockLSBArray = this.getBlockLSBArray();
-            System.arraycopy(storage.getBlockLSBArray(), 0, blockLSBArray, 0, blockLSBArray.length);
-            if(storage.getBlockMSBArray() != null) {
-                this.setBlockMSBArray(new NibbleArray(blockLSBArray.length, 4));
-                copyNibbleArray((ExtendedNibbleArray) storage.getBlockMSBArray(), (ExtendedNibbleArray) this.getBlockMSBArray());
+            else if (AngelicaMod.isOldNEIDLoaded){
+                final short[] blockLSBArray = Hooks.get(this);
+                System.arraycopy(Hooks.get(storage), 0, blockLSBArray, 0, blockLSBArray.length);
+                // getBlockMSBArray is nuked in asm version
+                arrayLen = blockLSBArray.length;
             }
-            arrayLen = blockLSBArray.length;
-        }
+            else {
+                final byte[] blockLSBArray = this.getBlockLSBArray();
+                System.arraycopy(storage.getBlockLSBArray(), 0, blockLSBArray, 0, blockLSBArray.length);
+                if(storage.getBlockMSBArray() != null) {
+                    this.setBlockMSBArray(new NibbleArray(blockLSBArray.length, 4));
+                    copyNibbleArray((ExtendedNibbleArray) storage.getBlockMSBArray(), (ExtendedNibbleArray) this.getBlockMSBArray());
+                }
+                arrayLen = blockLSBArray.length;
+            }
 
 
-        copyNibbleArray((ExtendedNibbleArray) storage.getMetadataArray(), (ExtendedNibbleArray)this.getMetadataArray());
-        copyNibbleArray((ExtendedNibbleArray) storage.getBlocklightArray(), (ExtendedNibbleArray)this.getBlocklightArray());
-        if(storage.getSkylightArray() != null) {
-            hasSky = true;
-            if(this.getSkylightArray() == null) {
-                this.setSkylightArray(new NibbleArray(arrayLen, 4));
+            copyNibbleArray((ExtendedNibbleArray) storage.getMetadataArray(), (ExtendedNibbleArray)this.getMetadataArray());
+            copyNibbleArray((ExtendedNibbleArray) storage.getBlocklightArray(), (ExtendedNibbleArray)this.getBlocklightArray());
+            if(storage.getSkylightArray() != null) {
+                hasSky = true;
+                if(this.getSkylightArray() == null) {
+                    this.setSkylightArray(new NibbleArray(arrayLen, 4));
+                }
+                copyNibbleArray((ExtendedNibbleArray) storage.getSkylightArray(), (ExtendedNibbleArray) this.getSkylightArray());
             }
-            copyNibbleArray((ExtendedNibbleArray) storage.getSkylightArray(), (ExtendedNibbleArray) this.getSkylightArray());
         }
         ((MixinExtendedBlockStorage) this).setBlockRefCount(((MixinExtendedBlockStorage) storage).getBlockRefCount());
     }

--- a/src/main/java/me/jellysquid/mods/sodium/client/world/cloned/ClonedChunkSection.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/world/cloned/ClonedChunkSection.java
@@ -56,7 +56,7 @@ public class ClonedChunkSection {
         }
 
         this.pos = pos;
-        this.data = new ExtendedBlockStorageExt(section);
+        this.data = new ExtendedBlockStorageExt(chunk, section);
 
         this.biomeData = new BiomeGenBase[chunk.getBiomeArray().length];
 

--- a/src/main/java/me/jellysquid/mods/sodium/client/world/cloned/ClonedChunkSection.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/world/cloned/ClonedChunkSection.java
@@ -1,5 +1,7 @@
 package me.jellysquid.mods.sodium.client.world.cloned;
 
+import com.falsepattern.endlessids.mixin.helpers.ChunkBiomeHook;
+import com.gtnewhorizons.angelica.AngelicaMod;
 import com.gtnewhorizons.angelica.compat.ExtendedBlockStorageExt;
 import com.gtnewhorizons.angelica.compat.mojang.BlockPos;
 import com.gtnewhorizons.angelica.compat.mojang.ChunkSectionPos;
@@ -58,7 +60,13 @@ public class ClonedChunkSection {
         this.pos = pos;
         this.data = new ExtendedBlockStorageExt(chunk, section);
 
-        this.biomeData = new BiomeGenBase[chunk.getBiomeArray().length];
+        int bArrLength;
+        if (AngelicaMod.isEIDBiomeLoaded) {
+            bArrLength = ((ChunkBiomeHook)chunk).getBiomeShortArray().length;
+        } else {
+            bArrLength = chunk.getBiomeArray().length;
+        }
+        this.biomeData = new BiomeGenBase[bArrLength];
 
         StructureBoundingBox box = new StructureBoundingBox(pos.getMinX(), pos.getMinY(), pos.getMinZ(), pos.getMaxX(), pos.getMaxY(), pos.getMaxZ());
 


### PR DESCRIPTION
This is a minimal viable compatibility patch for ChunkAPI (and thus EndlessIDs).

Note: This might also require other changes to work properly, it needs to be tested in a larger instance to make sure things don't break horribly when the extended IDs start being used. I don't know much about Angelica's codebase so this is the only required change i could spot.

Related issue: #29