### PR TITLE
Re-enable lighting after rendering Thaumcraft aspects

### DIFF
--- a/src/main/java/com/gtnewhorizons/angelica/mixins/Mixins.java
+++ b/src/main/java/com/gtnewhorizons/angelica/mixins/Mixins.java
@@ -42,6 +42,13 @@ public enum Mixins {
             "angelica.debug.MixinSplashProgress"
         )
     ),
+
+    ANGELICA_THAUMCRAFT_COMPAT(new Builder("Angelica Thaumcraft Compat").addTargetedMod(TargetedMod.THAUMCRAFT).setSide(Side.CLIENT)
+        .setPhase(Phase.EARLY).addMixinClasses(
+            "angelica.thaumcraft.MixinClientTickEventsFML"
+        )
+    ),
+
     // Not compatible with the lwjgl debug callbacks, so disable if that's enabled
     ARCHAIC_SPLASH(new Builder("ArchaicFix Splash").addTargetedMod(TargetedMod.VANILLA).setSide(Side.CLIENT)
         .setPhase(Phase.EARLY).setApplyIf(() -> AngelicaConfig.showSplashMemoryBar && !AngelicaMod.lwjglDebug).addMixinClasses(

--- a/src/main/java/com/gtnewhorizons/angelica/mixins/early/angelica/thaumcraft/MixinClientTickEventsFML.java
+++ b/src/main/java/com/gtnewhorizons/angelica/mixins/early/angelica/thaumcraft/MixinClientTickEventsFML.java
@@ -1,0 +1,22 @@
+package com.gtnewhorizons.angelica.mixins.early.angelica.thaumcraft;
+
+import org.lwjgl.opengl.GL11;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import thaumcraft.client.lib.ClientTickEventsFML;
+
+@Mixin(ClientTickEventsFML.class)
+public class MixinClientTickEventsFML {
+
+    /**
+     * Thaumcraft disables lighting and only re-enables it if actually drawing an aspect(hovering over an item that
+     * you can see the aspect for and draws it). This shoves in a lighting re-enable at the end so that it is always
+     * re-enabled regardless.
+     */
+    @Inject(method = "renderAspectsInGui", at = @At(value = "INVOKE", target = "Lorg/lwjgl/opengl/GL11;glPopAttrib()V"), remap = false)
+    private void angelica$lightingFix(CallbackInfo ci) {
+        GL11.glEnable(GL11.GL_LIGHTING);
+    }
+}


### PR DESCRIPTION
This is for #95 

Thaumcraft disables `GL_LIGHTING` when drawing aspects in a container. However, it only re-enables it if it actually draws an aspect, so unless you are hovering over an item and it draws an aspect, you get the darkened screen as demonstrated in the issue.

This injects a `Gl11.glEnable(GL11.GL_LIGHTING)` call into the end of the Aspect drawing so that it ensures it gets re-enabled regardless.

I'm not sure if this is where the mixin should go/how it should be loaded, if there are critiques on how that's being done let me know and I can re-organize it.