### PR TITLE
fix sodium fluid renderer not using biome colors

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/render/pipeline/FluidRenderer.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/pipeline/FluidRenderer.java
@@ -355,7 +355,6 @@ public class FluidRenderer {
         int[] biomeColors = null;
 
         if (colorized) {
-            // TODO: Sodium - Colorizer
             biomeColors = new int[4];
             int color = slice.getBlock(pos.x,pos.y,pos.z).colorMultiplier(slice,pos.x,pos.y,pos.z);
             Arrays.fill(biomeColors,ColorARGB.toABGR(color));

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/pipeline/FluidRenderer.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/pipeline/FluidRenderer.java
@@ -15,6 +15,7 @@ import me.jellysquid.mods.sodium.client.render.chunk.compile.buffers.ChunkModelB
 import me.jellysquid.mods.sodium.client.render.chunk.format.ModelVertexSink;
 import me.jellysquid.mods.sodium.client.util.Norm3b;
 import me.jellysquid.mods.sodium.client.util.color.ColorABGR;
+import me.jellysquid.mods.sodium.client.util.color.ColorARGB;
 import me.jellysquid.mods.sodium.client.world.WorldSlice;
 import me.jellysquid.mods.sodium.common.util.DirectionUtil;
 import me.jellysquid.mods.sodium.common.util.WorldUtil;
@@ -28,6 +29,8 @@ import net.minecraftforge.common.util.ForgeDirection;
 import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.IFluidBlock;
 import org.joml.Vector3d;
+
+import java.util.Arrays;
 
 import static org.joml.Math.lerp;
 
@@ -193,7 +196,7 @@ public class FluidRenderer {
             this.setVertex(quad, 2, 1.0F, h3, 1.0F, u3, v3);
             this.setVertex(quad, 3, 1.0F, h4, 0.0f, u4, v4);
 
-            this.calculateQuadColors(quad, pos, lighter, ForgeDirection.UP, 1.0F, hc);
+            this.calculateQuadColors(quad, pos, lighter, ForgeDirection.UP, 1.0F, hc, slice);
             this.flushQuad(buffers, quad, facing, false);
 
             if (WorldUtil.method_15756(slice, this.scratchPos.set(posX, posY + 1, posZ), fluid)) {
@@ -222,7 +225,7 @@ public class FluidRenderer {
             this.setVertex(quad, 2, 1.0F, yOffset, 0.0f, maxU, minV);
             this.setVertex(quad, 3, 1.0F, yOffset, 1.0F, maxU, maxV);
 
-            this.calculateQuadColors(quad, pos, lighter, ForgeDirection.DOWN, 1.0F, hc);
+            this.calculateQuadColors(quad, pos, lighter, ForgeDirection.DOWN, 1.0F, hc, slice);
             this.flushQuad(buffers, quad, ModelQuadFacing.DOWN, false);
 
             rendered = true;
@@ -326,7 +329,7 @@ public class FluidRenderer {
 
                 ModelQuadFacing facing = ModelQuadFacing.fromDirection(dir);
 
-                this.calculateQuadColors(quad, pos, lighter, dir, br, hc);
+                this.calculateQuadColors(quad, pos, lighter, dir, br, hc, slice);
                 this.flushQuad(buffers, quad, facing, false);
 
                 if (sprite != oSprite) {
@@ -345,7 +348,7 @@ public class FluidRenderer {
         return rendered;
     }
 
-    private void calculateQuadColors(ModelQuadView quad, BlockPos pos, LightPipeline lighter, ForgeDirection dir, float brightness, boolean colorized) {
+    private void calculateQuadColors(ModelQuadView quad, BlockPos pos, LightPipeline lighter, ForgeDirection dir, float brightness, boolean colorized, WorldSlice slice) {
         QuadLightData light = this.quadLightData;
         lighter.calculate(quad, pos, light, null, dir, false);
 
@@ -353,6 +356,9 @@ public class FluidRenderer {
 
         if (colorized) {
             // TODO: Sodium - Colorizer
+            biomeColors = new int[4];
+            int color = slice.getBlock(pos.x,pos.y,pos.z).colorMultiplier(slice,pos.x,pos.y,pos.z);
+            Arrays.fill(biomeColors,ColorARGB.toABGR(color));
         }
 
         for (int i = 0; i < 4; i++) {


### PR DESCRIPTION
Fixes the fluid renderer not using the biome colors.
This will require revisiting when mcpf is hooked up but this fixes the main issue it has atm.
Before:
![2024-01-03_11 26 14](https://github.com/GTNewHorizons/Angelica/assets/70655895/677c4214-1315-4dd7-8f9d-386e27a4f31e)
After:
![2024-01-03_11 27 35](https://github.com/GTNewHorizons/Angelica/assets/70655895/0366581a-9624-4c54-acdf-1d1b05a9e9dd)
Fluid renderer off:
![2024-01-03_11 28 04](https://github.com/GTNewHorizons/Angelica/assets/70655895/cc4957bc-9e70-4391-9fa0-841197dbe1ec)

This also fixes the water turning grey when lotr is present as lotr forces other mods to use the water color multiplier