### PR TITLE
Quad cleanup

### DIFF
--- a/src/main/java/com/gtnewhorizons/angelica/compat/nd/Quad.java
+++ b/src/main/java/com/gtnewhorizons/angelica/compat/nd/Quad.java
@@ -127,9 +127,9 @@ public class Quad implements ModelQuadView {
             ns[vi] = flags.hasNormals ? rawBuffer[i + 6] : 0;
             bs[vi] = flags.hasBrightness ? rawBuffer[i + 7] : DEFAULT_BRIGHTNESS;
 
-            this.hasColor |= flags.hasColor;
-            this.hasShade |= flags.hasBrightness;
-            this.hasNormals |= flags.hasNormals;
+            this.hasColor = flags.hasColor;
+            this.hasShade = flags.hasBrightness;
+            this.hasNormals = flags.hasNormals;
 
 
             i += 8;

--- a/src/main/java/com/gtnewhorizons/angelica/compat/nd/Quad.java
+++ b/src/main/java/com/gtnewhorizons/angelica/compat/nd/Quad.java
@@ -21,9 +21,9 @@ public class Quad implements ModelQuadView {
     public float[] zs = new float[4];
     public float[] us = new float[4];
     public float[] vs = new float[4];
-    public int[] bs = new int[4];
     public int[] cs = new int[4];
     public int[] ns = new int[4];
+    public int[] bs = new int[4];
 
     public boolean deleted;
 

--- a/src/main/java/com/gtnewhorizons/angelica/compat/nd/Quad.java
+++ b/src/main/java/com/gtnewhorizons/angelica/compat/nd/Quad.java
@@ -8,7 +8,6 @@ import net.minecraftforge.common.util.ForgeDirection;
 import org.joml.Vector3f;
 import org.lwjgl.opengl.GL11;
 
-import java.util.Arrays;
 import java.util.Locale;
 
 public class Quad implements ModelQuadView {
@@ -152,7 +151,7 @@ public class Quad implements ModelQuadView {
     }
 
     public void setState(int[] rawBuffer, int offset, BlockRenderer.Flags flags, int drawMode, float offsetX, float offsetY, float offsetZ) {
-        resetState();
+        deleted = false;
 
         read(rawBuffer, offset, offsetX, offsetY, offsetZ, drawMode, flags);
 
@@ -167,19 +166,6 @@ public class Quad implements ModelQuadView {
         vectorA.cross(vectorB, vectorC);
 
         normal = ModelQuadFacing.fromVector(vectorC);
-    }
-
-    private void resetState() {
-        Arrays.fill(xs, 0);
-        Arrays.fill(ys, 0);
-        Arrays.fill(zs, 0);
-        Arrays.fill(us, 0);
-        Arrays.fill(vs, 0);
-        Arrays.fill(bs, 0);
-        Arrays.fill(cs, 0);
-
-        deleted = false;
-        normal = null;
     }
 
     public static boolean isValid(Quad q) {


### PR DESCRIPTION
- Integrate upstream changes (https://github.com/makamys/Neodymium/pull/35)
  - Remove leftover quad merging code
  - Reorder fields to follow tessellator layout
  - Avoid unnecesssary clearing
- Remove `getStride` since Angelica has its own way of managing the vertex layout
- Fix flags getting or'ed when they should be getting set instead