### PR TITLE
Fix chunk update stutter by unparking main thread when a chunk render job completes

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/compile/ChunkBuilder.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/compile/ChunkBuilder.java
@@ -1,5 +1,6 @@
 package me.jellysquid.mods.sodium.client.render.chunk.compile;
 
+import com.gtnewhorizons.angelica.glsm.GLStateManager;
 import com.gtnewhorizons.angelica.rendering.AngelicaRenderQueue;
 import me.jellysquid.mods.sodium.client.SodiumClientMod;
 import me.jellysquid.mods.sodium.client.gl.device.RenderDevice;
@@ -30,6 +31,7 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.LockSupport;
 
 public class ChunkBuilder<T extends ChunkGraphicsState> {
     /**
@@ -365,6 +367,8 @@ public class ChunkBuilder<T extends ChunkGraphicsState> {
                 if (result != null) {
                     // Notify the future that the result is now available
                     job.future.complete(result);
+                    // Unpark the main thread so it wakes up if it was blocking on the future having completed
+                    LockSupport.unpark(GLStateManager.getMainThread());
                 } else if (!job.isCancelled()) {
                     // If the job wasn't cancelled and no result was produced, we've hit a bug
                     job.future.completeExceptionally(new RuntimeException("No result was produced by the task"));


### PR DESCRIPTION
Since `AngelicaRenderQueue` blocks while waiting for the future to complete by using `LockSupport.park`, it can cause a delay of up to 50ms when a render job finishes before it is processed. This introduces massive amounts of stuttering when placing blocks.

Luckily, it is trivial to solve this: simply unpark the main thread whenever a render job finishes. This might result in the thread being unblocked sometimes when the task it was waiting for wasn't ready yet, but it will immediately park again in that case.

I actually intended to add this when originally writing `AngelicaRenderQueue`, but missed it somehow, oops....