### PR TITLE
Fix `drawString` returning wrong value

### DIFF
--- a/src/main/java/com/gtnewhorizons/angelica/client/font/BatchingFontRenderer.java
+++ b/src/main/java/com/gtnewhorizons/angelica/client/font/BatchingFontRenderer.java
@@ -319,7 +319,7 @@ public class BatchingFontRenderer {
         final boolean unicodeFlag, final CharSequence string, int stringOffset, int stringLength) {
         // noinspection SizeReplaceableByIsEmpty
         if (string == null || string.length() == 0) {
-            return 0.0f;
+            return anchorX + (enableShadow ? 1.0f : 0.0f);
         }
         final int shadowColor = (color & 0xfcfcfc) >> 2 | color & 0xff000000;
 
@@ -571,7 +571,7 @@ public class BatchingFontRenderer {
         } finally {
             this.endBatch();
         }
-        return curX;
+        return curX + (enableShadow ? 1.0f : 0.0f);
     }
 
 }


### PR DESCRIPTION
The original `drawString` method would return the x position of the text if the passed string was of length 0. This is important as when the cursor is at position 0 it first tries to draw a string of length 0 and then the remaining string after the cursor based on the return value.

`1.0f` should also be added to the return values as the width of the drawn shadow needs to be included to prevent the text shifting around when moving the cursor.

Fixes #117, fixes #42