### PR TITLE
VBO Manager

### DIFF
--- a/src/main/java/com/gtnewhorizons/angelica/glsm/VBOManager.java
+++ b/src/main/java/com/gtnewhorizons/angelica/glsm/VBOManager.java
@@ -1,0 +1,43 @@
+package com.gtnewhorizons.angelica.glsm;
+
+import com.gtnewhorizons.angelica.compat.mojang.VertexBuffer;
+
+import java.util.ArrayList;
+
+public class VBOManager {
+    // Not thread safe, only expected to be called from the main thread
+
+    private static int nextDisplayList = 0;
+
+    private static int getNextDisplayList() {
+        return nextDisplayList++;
+    }
+
+    private static ArrayList<VertexBuffer> vertexBuffers = new ArrayList<>();
+
+    /*
+     * Allocate a (range) of "display list IDs" that will refer to a VBO in the arraylist of vertex buffers.
+     */
+    public static int generateDisplayLists(int range) {
+        if(range < 1) throw new IllegalArgumentException("Range must be at least 1!");
+
+        final int id = getNextDisplayList();
+        for (int i = 1; i < range; i++) {
+            // Reserve, but don't use, the rest in the range
+            getNextDisplayList();
+        }
+        // Return the first in the range
+        return id;
+    }
+
+    public static void registerVBO(int displayList, VertexBuffer vertexBuffer) {
+        if(displayList > vertexBuffers.size()) {
+            vertexBuffers.ensureCapacity(displayList * 2);
+        }
+        vertexBuffers.add(displayList, vertexBuffer);
+    }
+
+    public static VertexBuffer get(int list) {
+        return vertexBuffers.get(list);
+    }
+}

--- a/src/main/java/com/gtnewhorizons/angelica/mixins/early/angelica/vbo/MixinModelRenderer.java
+++ b/src/main/java/com/gtnewhorizons/angelica/mixins/early/angelica/vbo/MixinModelRenderer.java
@@ -1,8 +1,8 @@
 package com.gtnewhorizons.angelica.mixins.early.angelica.vbo;
 
 import com.gtnewhorizons.angelica.compat.mojang.DefaultVertexFormat;
-import com.gtnewhorizons.angelica.compat.mojang.VertexBuffer;
 import com.gtnewhorizons.angelica.glsm.TessellatorManager;
+import com.gtnewhorizons.angelica.glsm.VBOManager;
 import net.minecraft.client.model.ModelRenderer;
 import org.lwjgl.opengl.GL11;
 import org.spongepowered.asm.mixin.Mixin;
@@ -10,38 +10,32 @@ import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;
 
-import java.util.ArrayList;
-
 @Mixin(ModelRenderer.class)
 public class MixinModelRenderer {
     @Shadow
     public int displayList;
-    private static int nextDisplayList = 0;
-    private static int getNextDisplayList() {
-        return nextDisplayList++;
-    }
-    private static ArrayList<VertexBuffer> vertexBuffers = new ArrayList<>();
 
     @Redirect(method = "compileDisplayList", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/GLAllocation;generateDisplayLists(I)I"))
     public int generateDisplayLists(int range) {
-        return getNextDisplayList();
+        return VBOManager.generateDisplayLists(range);
     }
 
     @Redirect(method = "compileDisplayList", at = @At(value = "INVOKE", target = "Lorg/lwjgl/opengl/GL11;glNewList(II)V", remap = false))
     public void startCapturingVBO(int list, int mode) {
         TessellatorManager.startCapturing();
     }
+
     @Redirect(method = "compileDisplayList", at = @At(value = "INVOKE", target = "Lorg/lwjgl/opengl/GL11;glEndList()V", remap = false))
     public void stopCapturingVBO() {
-        vertexBuffers.add(this.displayList, TessellatorManager.stopCapturingToVBO(DefaultVertexFormat.POSITION_TEXTURE_NORMAL));
+        VBOManager.registerVBO(this.displayList, TessellatorManager.stopCapturingToVBO(DefaultVertexFormat.POSITION_TEXTURE_NORMAL));
     }
 
     @Redirect(method = "render", at = @At(value = "INVOKE", target = "Lorg/lwjgl/opengl/GL11;glCallList(I)V", remap = false))
     public void renderVBO(int list) {
-        vertexBuffers.get(list).render(GL11.GL_QUADS);
+        VBOManager.get(list).render(GL11.GL_QUADS);
     }
     @Redirect(method = "renderWithRotation", at = @At(value = "INVOKE", target = "Lorg/lwjgl/opengl/GL11;glCallList(I)V", remap = false))
     public void renderWithRotationVBO(int list) {
-        vertexBuffers.get(list).render(GL11.GL_QUADS);
+        VBOManager.get(list).render(GL11.GL_QUADS);
     }
 }


### PR DESCRIPTION
* Add a VBO manager
* Stop allocating display lists for the vanilla chunk renderer when sodium is enabled
* Move RenderGlobal * ModelRenderer to VBO Manager
* Stop preventing display list allocation for displayListEntities