### PR TITLE
Fix VBO crash

### DIFF
--- a/src/main/java/com/gtnewhorizons/angelica/glsm/VBOManager.java
+++ b/src/main/java/com/gtnewhorizons/angelica/glsm/VBOManager.java
@@ -7,7 +7,7 @@ import it.unimi.dsi.fastutil.objects.ObjectList;
 public class VBOManager {
     // Not thread safe, only expected to be called from the main thread
 
-    private static int nextDisplayList = 0;
+    private static int nextDisplayList = Integer.MIN_VALUE;
 
     private static int getNextDisplayList() {
         return nextDisplayList++;

--- a/src/main/java/com/gtnewhorizons/angelica/glsm/VBOManager.java
+++ b/src/main/java/com/gtnewhorizons/angelica/glsm/VBOManager.java
@@ -31,6 +31,7 @@ public class VBOManager {
     }
 
     public static VertexBuffer registerVBO(int displayList, VertexBuffer vertexBuffer) {
+        displayList -= Integer.MIN_VALUE;
         final int requestedSize = displayList + 1;
         if(requestedSize + 1 > vertexBuffers.size()) {
             vertexBuffers.size(requestedSize);
@@ -40,6 +41,7 @@ public class VBOManager {
     }
 
     public static VertexBuffer get(int list) {
+        list -= Integer.MIN_VALUE;
         return vertexBuffers.get(list);
     }
 }

--- a/src/main/java/com/gtnewhorizons/angelica/mixins/Mixins.java
+++ b/src/main/java/com/gtnewhorizons/angelica/mixins/Mixins.java
@@ -32,9 +32,10 @@ public enum Mixins {
     ANGELICA_VBO(
         new Builder("Angelica VBO").addTargetedMod(TargetedMod.VANILLA).setApplyIf(() -> AngelicaConfig.enableVBO).setSide(Side.CLIENT)
             .setPhase(Phase.EARLY).addMixinClasses(
-                 "angelica.vbo.MixinWavefrontObject"
-                ,"angelica.vbo.MixinRenderGlobal"
+                 "angelica.vbo.MixinGLAllocation"
                 ,"angelica.vbo.MixinModelRenderer"
+                ,"angelica.vbo.MixinRenderGlobal"
+                ,"angelica.vbo.MixinWavefrontObject"
         )
     ),
     ANGELICA_FONT_RENDERER(new Builder("Angelica Font Renderer").addTargetedMod(TargetedMod.VANILLA).setSide(Side.CLIENT)

--- a/src/main/java/com/gtnewhorizons/angelica/mixins/early/angelica/vbo/MixinGLAllocation.java
+++ b/src/main/java/com/gtnewhorizons/angelica/mixins/early/angelica/vbo/MixinGLAllocation.java
@@ -1,0 +1,15 @@
+package com.gtnewhorizons.angelica.mixins.early.angelica.vbo;
+
+import net.minecraft.client.renderer.GLAllocation;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(GLAllocation.class)
+public class MixinGLAllocation {
+    @Inject(method = "deleteDisplayLists", at = @At("HEAD"), cancellable = true)
+    private static void deleteDisplayLists(int list, CallbackInfo ci) {
+        if(list < 0) ci.cancel();
+    }
+}

--- a/src/main/java/com/gtnewhorizons/angelica/proxy/ClientProxy.java
+++ b/src/main/java/com/gtnewhorizons/angelica/proxy/ClientProxy.java
@@ -38,6 +38,7 @@ import java.util.Locale;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class ClientProxy extends CommonProxy {
+    final Minecraft mc = Minecraft.getMinecraft();
 
     @Override
     public void preInit(FMLPreInitializationEvent event) {
@@ -191,7 +192,7 @@ public class ClientProxy extends CommonProxy {
 
     @SubscribeEvent
     public void onTick(TickEvent.ClientTickEvent event) {
-        if (event.phase == TickEvent.Phase.END) {
+        if (event.phase == TickEvent.Phase.END && mc.theWorld != null) {
             CloudRenderer.getCloudRenderer().checkSettings();
         }
     }


### PR DESCRIPTION
* Use integer.min_value for VBOized display list IDs, and prevent a NPE when trying to delete a VBOized display list


Should fix https://github.com/GTNewHorizons/Angelica/issues/142. 