### PR TITLE
Handle state changes for display lists correctly in GLSM

### DIFF
--- a/src/main/java/com/gtnewhorizons/angelica/glsm/GLStateManager.java
+++ b/src/main/java/com/gtnewhorizons/angelica/glsm/GLStateManager.java
@@ -55,6 +55,7 @@ import java.nio.ByteBuffer;
 import java.nio.DoubleBuffer;
 import java.nio.FloatBuffer;
 import java.nio.IntBuffer;
+import java.util.AbstractMap;
 import java.util.Map;
 import java.util.Set;
 
@@ -747,7 +748,7 @@ public class GLStateManager {
         final Set<Map.Entry<IStateStack<?>, ISettableState<?>>> changedStates = new ObjectArraySet<>();
         for(Map.Entry<IStateStack<?>, ISettableState<?>> entry : glListStates.entrySet()) {
             if(!((ISettableState<?>)entry.getKey()).sameAs(entry.getValue())) {
-                changedStates.add(entry);
+                changedStates.add(new AbstractMap.SimpleEntry<>(entry.getKey(), (ISettableState<?>) ((ISettableState<?>) entry.getKey()).copy()));
             }
         }
         if(changedStates.size() != 0) {

--- a/src/main/java/com/gtnewhorizons/angelica/glsm/GLStateManager.java
+++ b/src/main/java/com/gtnewhorizons/angelica/glsm/GLStateManager.java
@@ -733,6 +733,7 @@ public class GLStateManager {
         glListMode = mode;
         GL11.glNewList(list, mode);
         for(IStateStack<?> stack : Feature.maskToFeatures(GL11.GL_ALL_ATTRIB_BITS)) {
+            // Feature Stack, copy of current feature state
             glListStates.put(stack, (ISettableState<?>) ((ISettableState<?>)stack).copy());
         }
         if(glListMode == GL11.GL_COMPILE) {
@@ -747,7 +748,9 @@ public class GLStateManager {
 
         final Set<Map.Entry<IStateStack<?>, ISettableState<?>>> changedStates = new ObjectArraySet<>();
         for(Map.Entry<IStateStack<?>, ISettableState<?>> entry : glListStates.entrySet()) {
+            // If the current stack state is different than the copy of the state at the start
             if(!((ISettableState<?>)entry.getKey()).sameAs(entry.getValue())) {
+                // Then we want to put into the change set the stack and the copy of the state now
                 changedStates.add(new AbstractMap.SimpleEntry<>(entry.getKey(), (ISettableState<?>) ((ISettableState<?>) entry.getKey()).copy()));
             }
         }
@@ -770,6 +773,7 @@ public class GLStateManager {
         GL11.glCallList(list);
         if(glListChanges.containsKey(list)) {
             for(Map.Entry<IStateStack<?>, ISettableState<?>> entry : glListChanges.get(list)) {
+                // Set the stack to the cached state at the end of the call list compilation
                 ((ISettableState<?>)entry.getKey()).set(entry.getValue());
             }
         }


### PR DESCRIPTION
In the GLStateManager, when handling the state for display lists, we were previously setting the GLStateManager values back to what they were BEFORE the display list was executed by OpenGL. This meant that any state which changed, would be set back to the original state beforehand, but only on the client side.

This issue mostly manifested with #116 because AE2 storage monitors use Display Lists. The problem in this issue was that the display list sets the color `(0, 0, 0, 0)`, and because of this bug, the GLStateManager client side, after the display list runs gets it's color set back to `(1, 1, 1, 1)`, while the actual OpenGL server on the GPU is still at the color set by the display list.

This means that subsequent calls to `glColor4f` for example that try to set the color to `(1, 1, 1, 1)` won't actually make it to the server because GLStateManager thinks it is already at that value.

I'm not sure if this is actually the best way to fix this problem or not, if anyone has thoughts on the specifics of the fix let me know.