### PR TITLE
Clear event phase before reusing object

### DIFF
--- a/src/main/java/com/gtnewhorizons/angelica/mixins/early/sodium/MixinBiomeGenBase.java
+++ b/src/main/java/com/gtnewhorizons/angelica/mixins/early/sodium/MixinBiomeGenBase.java
@@ -1,5 +1,6 @@
 package com.gtnewhorizons.angelica.mixins.early.sodium;
 
+import com.gtnewhorizons.angelica.utils.EventUtils;
 import net.minecraft.world.biome.BiomeGenBase;
 import net.minecraftforge.event.terraingen.BiomeEvent;
 import org.spongepowered.asm.mixin.Mixin;
@@ -19,6 +20,7 @@ public class MixinBiomeGenBase {
     @Unique
     private void prepareEvent(BiomeEvent.BiomeColor event, int defaultColor) {
         event.newColor = defaultColor;
+        EventUtils.clearPhase(event);
         ((AccessorBiomeColorEvent)event).setOriginalColor(defaultColor);
     }
 

--- a/src/main/java/com/gtnewhorizons/angelica/utils/EventUtils.java
+++ b/src/main/java/com/gtnewhorizons/angelica/utils/EventUtils.java
@@ -1,0 +1,28 @@
+package com.gtnewhorizons.angelica.utils;
+
+import cpw.mods.fml.common.eventhandler.Event;
+import cpw.mods.fml.common.eventhandler.EventPriority;
+import cpw.mods.fml.relauncher.ReflectionHelper;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+
+public class EventUtils {
+    private static final MethodHandle EVENT_PHASE;
+
+    static {
+        try {
+            EVENT_PHASE = MethodHandles.publicLookup().unreflectSetter(ReflectionHelper.findField(Event.class, "phase"));
+        } catch (IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static void clearPhase(Event e) {
+        try {
+            EVENT_PHASE.invokeExact(e, (EventPriority)null);
+        } catch(Throwable ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #163 in theory

Since we reuse event objects, we have to deal with bugs in the event bus when reusing these objects. One such issue is that the `phase` field must be cleared before refiring the event.