### PR TITLE
Only use BatchedFontRenderer when not in a display list compilation

### DIFF
--- a/src/main/java/com/gtnewhorizons/angelica/glsm/GLStateManager.java
+++ b/src/main/java/com/gtnewhorizons/angelica/glsm/GLStateManager.java
@@ -927,4 +927,8 @@ public class GLStateManager {
     public static int getActiveTextureUnit() {
         return activeTextureUnit.topInt();
     }
+
+    public static int getListMode() {
+        return glListMode;
+    }
 }

--- a/src/main/java/com/gtnewhorizons/angelica/mixins/interfaces/FontRendererAccessor.java
+++ b/src/main/java/com/gtnewhorizons/angelica/mixins/interfaces/FontRendererAccessor.java
@@ -4,6 +4,9 @@ import com.gtnewhorizons.angelica.client.font.BatchingFontRenderer;
 import net.minecraft.util.ResourceLocation;
 
 public interface FontRendererAccessor {
+
+    int angelica$drawStringBatched(String text, int x, int y, int argb, boolean dropShadow);
+
     BatchingFontRenderer angelica$getBatcher();
 
     void angelica$bindTexture(ResourceLocation location);


### PR DESCRIPTION
The BatchedFontRenderer uses vertex buffers in order to batch things, vertex buffers are mostly conceptually incompatible with display lists. #116, which was fixed by #168 has an explanation of the FontRenderer causing the problem. #168 fixed that but only for the Vanilla font renderer, since the vertex buffers in BatchedFontRenderer manipulate client state, they are fundamentally incompatible with display lists so the state manager gets very tripped up when it is used in that context.

This adjusts the `MixinFontRenderer` to remove the `@Overwrite` for `drawString` and `renderString` and replaces them with an Inject that will only call into the batched renderer if we are not currently in a display list compilation. This means that any FontRenderer usage within the context of a display list, will fallback to the original vanilla code.