### PR TITLE
disable sodium weather quality redirect if dynamic surroundings is pr…

### DIFF
--- a/src/main/java/com/gtnewhorizons/angelica/mixins/Mixins.java
+++ b/src/main/java/com/gtnewhorizons/angelica/mixins/Mixins.java
@@ -117,6 +117,13 @@ public enum Mixins {
         )
     ),
 
+    SODIUM_DYN_SURROUND(new Builder("Sodium without Dynamic Surroundings").addTargetedMod(TargetedMod.VANILLA)
+        .addExcludedMod(TargetedMod.DYNAMIC_SURROUNDINGS_MIST).addExcludedMod(TargetedMod.DYNAMIC_SURROUNDINGS_ORIGINAL).setSide(Side.CLIENT)
+        .setPhase(Phase.EARLY).setApplyIf(() -> AngelicaConfig.enableSodium).addMixinClasses(
+            "sodium.MixinEntityRenderer$WeatherQuality"
+        )
+    ),
+
     // Required for Sodium's FluidRenderer, so it treats vanilla liquids as IFluidBlocks
     SODIUM_WISHLIST(new Builder("Sodiumer").addTargetedMod(TargetedMod.VANILLA).setSide(Side.BOTH)
         .setPhase(Phase.EARLY).setApplyIf(() -> AngelicaConfig.enableSodiumFluidRendering).addMixinClasses(

--- a/src/main/java/com/gtnewhorizons/angelica/mixins/TargetedMod.java
+++ b/src/main/java/com/gtnewhorizons/angelica/mixins/TargetedMod.java
@@ -10,6 +10,8 @@ public enum TargetedMod {
     , BOTANIA("Botania", null, "Botania")
     , CHICKENCHUNKS("ChickenChunks", null, "ChickenChunks")
     , COFHCORE("CoFHCore", "cofh.asm.LoadingPlugin", "CoFHCore")
+    , DYNAMIC_SURROUNDINGS_MIST("Dynamic Surroundings", "org.blockartistry.mod.DynSurround.mixinplugin.DynamicSurroundingsEarlyMixins", "dsurround")
+    , DYNAMIC_SURROUNDINGS_ORIGINAL("Dynamic Surroundings", "org.blockartistry.mod.DynSurround.asm.TransformLoader", "dsurround")
     , EXTRAUTILS("ExtraUtilities", null, "ExtraUtilities")
     , GTNHLIB("GTNHLib", "com.gtnewhorizon.gtnhlib.core.GTNHLibCore", "gtnhlib")
     , IC2("IC2", "ic2.core.coremod.IC2core", "IC2")

--- a/src/main/java/com/gtnewhorizons/angelica/mixins/early/sodium/MixinEntityRenderer$WeatherQuality.java
+++ b/src/main/java/com/gtnewhorizons/angelica/mixins/early/sodium/MixinEntityRenderer$WeatherQuality.java
@@ -1,0 +1,21 @@
+package com.gtnewhorizons.angelica.mixins.early.sodium;
+
+import me.jellysquid.mods.sodium.client.SodiumClientMod;
+import net.minecraft.client.renderer.EntityRenderer;
+import net.minecraft.client.settings.GameSettings;
+import org.spongepowered.asm.lib.Opcodes;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+/**
+ * Dynamic surroundings overwrites the method resulting in a clash
+ */
+@Mixin(EntityRenderer.class)
+public abstract class MixinEntityRenderer$WeatherQuality {
+
+    @Redirect(method = "renderRainSnow(F)V", at = @At(value = "FIELD", target = "Lnet/minecraft/client/settings/GameSettings;fancyGraphics:Z", opcode = Opcodes.GETFIELD))
+    protected boolean redirectGetFancyWeather(GameSettings settings) {
+        return SodiumClientMod.options().quality.weatherQuality.isFancy();
+    }
+}

--- a/src/main/java/com/gtnewhorizons/angelica/mixins/early/sodium/MixinEntityRenderer.java
+++ b/src/main/java/com/gtnewhorizons/angelica/mixins/early/sodium/MixinEntityRenderer.java
@@ -1,15 +1,11 @@
 package com.gtnewhorizons.angelica.mixins.early.sodium;
 
-import me.jellysquid.mods.sodium.client.SodiumClientMod;
 import me.jellysquid.mods.sodium.client.gl.compat.FogHelper;
 import net.minecraft.client.renderer.EntityRenderer;
-import net.minecraft.client.settings.GameSettings;
-import org.spongepowered.asm.lib.Opcodes;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(EntityRenderer.class)
@@ -23,8 +19,4 @@ public class MixinEntityRenderer {
         FogHelper.blue = fogColorBlue;
     }
 
-    @Redirect(method = "renderRainSnow(F)V", at = @At(value = "FIELD", target = "Lnet/minecraft/client/settings/GameSettings;fancyGraphics:Z", opcode = Opcodes.GETFIELD))
-    protected boolean redirectGetFancyWeather(GameSettings settings) {
-        return SodiumClientMod.options().quality.weatherQuality.isFancy();
-    }
 }


### PR DESCRIPTION
…esent as it overwrites the entire method

When I created my fork of Dynamic Surroundings I moved the transformer location, hence the two entries in TargetedMod