### PR TITLE
Fix hud caching vignette and crosshair color issues

### DIFF
--- a/src/main/java/com/gtnewhorizons/angelica/mixins/Mixins.java
+++ b/src/main/java/com/gtnewhorizons/angelica/mixins/Mixins.java
@@ -167,7 +167,8 @@ public enum Mixins {
     HUD_CACHING(new Builder("Renders the HUD elements 20 times per second maximum to improve performance")
         .addTargetedMod(TargetedMod.VANILLA).setSide(Side.CLIENT).setPhase(Phase.EARLY)
         .setApplyIf(() -> AngelicaConfig.enableHudCaching).addMixinClasses(
-            "angelica.hudcaching.GuiIngameForgeAccessor",
+        	"angelica.hudcaching.GuiIngameAccessor",
+        	"angelica.hudcaching.GuiIngameForgeAccessor",
             "angelica.hudcaching.MixinEntityRenderer_HUDCaching",
             "angelica.hudcaching.MixinFramebuffer_HUDCaching",
             "angelica.hudcaching.MixinGuiIngame_HUDCaching",

--- a/src/main/java/com/gtnewhorizons/angelica/mixins/early/angelica/hudcaching/GuiIngameAccessor.java
+++ b/src/main/java/com/gtnewhorizons/angelica/mixins/early/angelica/hudcaching/GuiIngameAccessor.java
@@ -1,0 +1,19 @@
+package com.gtnewhorizons.angelica.mixins.early.angelica.hudcaching;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Invoker;
+
+import net.minecraft.client.gui.GuiIngame;
+
+@Mixin(GuiIngame.class)
+public interface GuiIngameAccessor {
+	@Invoker
+	void callRenderVignette(float brightness, int width, int height);
+	
+	@Invoker
+	void callRenderPumpkinBlur(int width, int height);
+	
+	// render portal
+	@Invoker
+	void callFunc_130015_b(float partialTicks, int width, int height);
+}

--- a/src/main/java/com/gtnewhorizons/angelica/mixins/early/angelica/hudcaching/GuiIngameForgeAccessor.java
+++ b/src/main/java/com/gtnewhorizons/angelica/mixins/early/angelica/hudcaching/GuiIngameForgeAccessor.java
@@ -1,5 +1,6 @@
 package com.gtnewhorizons.angelica.mixins.early.angelica.hudcaching;
 
+import net.minecraft.client.gui.ScaledResolution;
 import net.minecraftforge.client.GuiIngameForge;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.gen.Invoker;
@@ -9,4 +10,10 @@ public interface GuiIngameForgeAccessor {
 
     @Invoker(remap = false)
     void callRenderCrosshairs(int width, int height);
+    
+    @Invoker(remap = false)
+    void callRenderHelmet(ScaledResolution res, float partialTicks, boolean hasScreen, int mouseX, int mouseY);
+    
+    @Invoker(remap = false)
+    void callRenderPortal(int width, int height, float partialTicks);
 }

--- a/src/main/java/com/gtnewhorizons/angelica/mixins/early/angelica/hudcaching/MixinGuiIngameForge_HUDCaching.java
+++ b/src/main/java/com/gtnewhorizons/angelica/mixins/early/angelica/hudcaching/MixinGuiIngameForge_HUDCaching.java
@@ -9,11 +9,37 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(GuiIngameForge.class)
 public class MixinGuiIngameForge_HUDCaching {
-
-    @Inject(method = "renderCrosshairs", at = @At("HEAD"), cancellable = true, remap = false)
-    private void angelica$cancelCrosshair(CallbackInfo ci) {
+	@Inject(method = "renderGameOverlay", at = @At("HEAD"))
+    private void angelica$resetCaptures(CallbackInfo ci) {
         if (HUDCaching.renderingCacheOverride) {
-            ci.cancel();
+        	HUDCaching.renderVignetteCaptured = false;
+        	HUDCaching.renderHelmetCaptured = false;
+        	HUDCaching.renderPortalCapturedTicks = -1;
+        	HUDCaching.renderCrosshairsCaptured = false;
+        }
+    }
+	
+    @Inject(method = "renderCrosshairs", at = @At("HEAD"), cancellable = true, remap = false)
+    private void angelica$captureRenderCrosshair(CallbackInfo ci) {
+        if (HUDCaching.renderingCacheOverride) {
+        	HUDCaching.renderCrosshairsCaptured = true;
+        	ci.cancel();
+        }
+    }
+    
+    @Inject(method = "renderHelmet", at = @At("HEAD"), cancellable = true, remap = false)
+    private void angelica$captureRenderHelmet(CallbackInfo ci) {
+    	if (HUDCaching.renderingCacheOverride) {
+    		HUDCaching.renderHelmetCaptured = true;
+        	ci.cancel();
+        }
+    }
+    
+    @Inject(method = "renderPortal", at = @At("HEAD"), cancellable = true, remap = false)
+    private void angelica$captureRenderPortal(int width, int height, float partialTicks, CallbackInfo ci) {
+    	if (HUDCaching.renderingCacheOverride) {
+    		HUDCaching.renderPortalCapturedTicks = partialTicks;
+        	ci.cancel();
         }
     }
 }

--- a/src/main/java/com/gtnewhorizons/angelica/mixins/early/angelica/hudcaching/MixinGuiIngame_HUDCaching.java
+++ b/src/main/java/com/gtnewhorizons/angelica/mixins/early/angelica/hudcaching/MixinGuiIngame_HUDCaching.java
@@ -1,19 +1,47 @@
 package com.gtnewhorizons.angelica.mixins.early.angelica.hudcaching;
 
-import com.gtnewhorizons.angelica.hudcaching.HUDCaching;
-import net.minecraft.client.gui.GuiIngame;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
+import com.gtnewhorizons.angelica.hudcaching.HUDCaching;
+
+import net.minecraft.client.gui.GuiIngame;
+
 @Mixin(GuiIngame.class)
 public class MixinGuiIngame_HUDCaching {
-
-    @Inject(method = "renderVignette", at = @At("HEAD"), cancellable = true)
-    private void angelica$cancelVignette(CallbackInfo ci) {
+	@Inject(method = "renderGameOverlay", at = @At("HEAD"))
+    private void angelica$resetCaptures(CallbackInfo ci) {
         if (HUDCaching.renderingCacheOverride) {
-            ci.cancel();
+        	HUDCaching.renderVignetteCaptured = false;
+        	HUDCaching.renderHelmetCaptured = false;
+        	HUDCaching.renderPortalCapturedTicks = -1;
+        	// GuiIngame doesn't allow a clean way to capture crosshair
+        }
+    }
+	
+    @Inject(method = "renderVignette", at = @At("HEAD"), cancellable = true)
+    private void angelica$captureRenderVignette(CallbackInfo ci) {
+        if (HUDCaching.renderingCacheOverride) {
+        	HUDCaching.renderVignetteCaptured = true;
+        	ci.cancel();
+        }
+    }
+    
+    @Inject(method = "renderPumpkinBlur", at = @At("HEAD"), cancellable = true)
+    private void angelica$captureRenderPumpkimBlur(CallbackInfo ci) {
+    	if (HUDCaching.renderingCacheOverride) {
+    		HUDCaching.renderHelmetCaptured = true;
+        	ci.cancel();
+        }
+    }
+    
+    @Inject(method = "func_130015_b", at = @At("HEAD"), cancellable = true)
+    private void angelica$captureRenderPortal(float partialTicks, int width, int height, CallbackInfo ci) {
+    	if (HUDCaching.renderingCacheOverride) {
+    		HUDCaching.renderPortalCapturedTicks = partialTicks;
+        	ci.cancel();
         }
     }
 }


### PR DESCRIPTION
Closes #86 
Closes #157 

### Problem Description
Vanilla vignette is rendered with a texture that has no alpha. In HUD caching, when it is rendered into the cache frame buffer, it overwrites the alpha values for all pixels, causing the screen to turn black. Currently HUDCaching simply skips rendering vignette. However, other mods like Thaumcraft are using the same mechanism to render vignette in other render events such as Portal (because there's no event for vignette)

### Fix Description
Treat vignette, helmet and portal the same way as crosshair, where rendering is skipped when rendering into the cache, and manually called later to render directly onto the frame.

### Validation
Tested with just angelica and with Thaumcraft. Deadly gaze works as expected. However, it seems like sun scorned has no effect when given through command, so I wasn't able to test it

### Other
HUD caching basically breaks when rendering something into the cache frame buffer that is meant to be blended with the scene directly. This fix only allows exceptions in the helmet and portal render events. 