### PR TITLE
Redirect negative display list calls to VBOs globally (fixes Smart Moving)

### DIFF
--- a/src/main/java/com/gtnewhorizons/angelica/compat/mojang/VertexBuffer.java
+++ b/src/main/java/com/gtnewhorizons/angelica/compat/mojang/VertexBuffer.java
@@ -11,14 +11,16 @@ public class VertexBuffer implements AutoCloseable {
     private int id;
     private int vertexCount;
     private VertexFormat format;
+    private int drawMode;
 
     public VertexBuffer() {
         this.id = GL15.glGenBuffers();
     }
 
-    public VertexBuffer(VertexFormat format) {
+    public VertexBuffer(VertexFormat format, int drawMode) {
         this();
         this.format = format;
+        this.drawMode = drawMode;
     }
 
     public void bind() {
@@ -50,16 +52,16 @@ public class VertexBuffer implements AutoCloseable {
         }
     }
 
-    public void draw(FloatBuffer floatBuffer, int mode) {
+    public void draw(FloatBuffer floatBuffer) {
         GL11.glPushMatrix();
         GL11.glLoadIdentity();
         GL11.glMultMatrix(floatBuffer);
-        draw(mode);
+        draw();
         GL11.glPopMatrix();
     }
 
-    public void draw(int mode) {
-        GL11.glDrawArrays(mode, 0, this.vertexCount);
+    public void draw() {
+        GL11.glDrawArrays(drawMode, 0, this.vertexCount);
     }
 
     public void setupState() {
@@ -72,11 +74,11 @@ public class VertexBuffer implements AutoCloseable {
         format.clearBufferState();
         unbind();
     }
-    public void render(int mode) {
+    public void render() {
         if(format == null) throw new IllegalStateException("No format specified for VBO render");
         bind();
         format.setupBufferState(0L);
-        draw(mode);
+        draw();
         format.clearBufferState();
         unbind();
     }

--- a/src/main/java/com/gtnewhorizons/angelica/glsm/GLStateManager.java
+++ b/src/main/java/com/gtnewhorizons/angelica/glsm/GLStateManager.java
@@ -771,8 +771,7 @@ public class GLStateManager {
 
     public static void glCallList(int list) {
         if(list < 0) {
-            // TODO support other draw modes (note: CapturingTessellator can only emit quads currently)
-            VBOManager.get(list).render(GL11.GL_QUADS);
+            VBOManager.get(list).render();
         } else {
             GL11.glCallList(list);
             if(glListChanges.containsKey(list)) {

--- a/src/main/java/com/gtnewhorizons/angelica/glsm/GLStateManager.java
+++ b/src/main/java/com/gtnewhorizons/angelica/glsm/GLStateManager.java
@@ -770,11 +770,16 @@ public class GLStateManager {
     }
 
     public static void glCallList(int list) {
-        GL11.glCallList(list);
-        if(glListChanges.containsKey(list)) {
-            for(Map.Entry<IStateStack<?>, ISettableState<?>> entry : glListChanges.get(list)) {
-                // Set the stack to the cached state at the end of the call list compilation
-                ((ISettableState<?>)entry.getKey()).set(entry.getValue());
+        if(list < 0) {
+            // TODO support other draw modes (note: CapturingTessellator can only emit quads currently)
+            VBOManager.get(list).render(GL11.GL_QUADS);
+        } else {
+            GL11.glCallList(list);
+            if(glListChanges.containsKey(list)) {
+                for(Map.Entry<IStateStack<?>, ISettableState<?>> entry : glListChanges.get(list)) {
+                    // Set the stack to the cached state at the end of the call list compilation
+                    ((ISettableState<?>)entry.getKey()).set(entry.getValue());
+                }
             }
         }
     }

--- a/src/main/java/com/gtnewhorizons/angelica/glsm/TessellatorManager.java
+++ b/src/main/java/com/gtnewhorizons/angelica/glsm/TessellatorManager.java
@@ -9,6 +9,8 @@ import net.minecraft.client.renderer.Tessellator;
 import java.nio.ByteBuffer;
 import java.util.List;
 
+import org.lwjgl.opengl.GL11;
+
 @SuppressWarnings("unused")
 public class TessellatorManager {
     private static final ThreadLocal<CapturingTessellator> capturingTessellator = ThreadLocal.withInitial(CapturingTessellator::new);
@@ -76,7 +78,7 @@ public class TessellatorManager {
      * uploads the buffer to a new VertexBuffer, and clears the quads.
      */
     public static VertexBuffer stopCapturingToVBO(VertexFormat format) {
-        return new VertexBuffer(format).upload(stopCapturingToBuffer(format));
+        return new VertexBuffer(format, GL11.GL_QUADS).upload(stopCapturingToBuffer(format));
     }
 
     static {

--- a/src/main/java/com/gtnewhorizons/angelica/mixins/early/angelica/vbo/MixinModelRenderer.java
+++ b/src/main/java/com/gtnewhorizons/angelica/mixins/early/angelica/vbo/MixinModelRenderer.java
@@ -4,7 +4,6 @@ import com.gtnewhorizons.angelica.compat.mojang.DefaultVertexFormat;
 import com.gtnewhorizons.angelica.glsm.TessellatorManager;
 import com.gtnewhorizons.angelica.glsm.VBOManager;
 import net.minecraft.client.model.ModelRenderer;
-import org.lwjgl.opengl.GL11;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
@@ -28,14 +27,5 @@ public class MixinModelRenderer {
     @Redirect(method = "compileDisplayList", at = @At(value = "INVOKE", target = "Lorg/lwjgl/opengl/GL11;glEndList()V", remap = false))
     public void stopCapturingVBO() {
         VBOManager.registerVBO(this.displayList, TessellatorManager.stopCapturingToVBO(DefaultVertexFormat.POSITION_TEXTURE_NORMAL));
-    }
-
-    @Redirect(method = "render", at = @At(value = "INVOKE", target = "Lorg/lwjgl/opengl/GL11;glCallList(I)V", remap = false))
-    public void renderVBO(int list) {
-        VBOManager.get(list).render(GL11.GL_QUADS);
-    }
-    @Redirect(method = "renderWithRotation", at = @At(value = "INVOKE", target = "Lorg/lwjgl/opengl/GL11;glCallList(I)V", remap = false))
-    public void renderWithRotationVBO(int list) {
-        VBOManager.get(list).render(GL11.GL_QUADS);
     }
 }

--- a/src/main/java/com/gtnewhorizons/angelica/mixins/early/angelica/vbo/MixinRenderGlobal.java
+++ b/src/main/java/com/gtnewhorizons/angelica/mixins/early/angelica/vbo/MixinRenderGlobal.java
@@ -11,7 +11,6 @@ import net.minecraft.client.renderer.GLAllocation;
 import net.minecraft.client.renderer.RenderGlobal;
 import net.minecraft.client.renderer.Tessellator;
 import net.minecraftforge.client.IRenderHandler;
-import org.lwjgl.opengl.GL11;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Overwrite;
 import org.spongepowered.asm.mixin.Shadow;
@@ -70,11 +69,6 @@ public class MixinRenderGlobal {
     @Redirect(method="<init>", at = @At(value="INVOKE", target="Lorg/lwjgl/opengl/GL11;glEndList()V", ordinal = 2), remap = false)
     public void finishSky2VBO() {
         VBOManager.registerVBO(glSkyList2, TessellatorManager.stopCapturingToVBO(DefaultVertexFormat.POSITION));
-    }
-
-    @Redirect(method="renderSky(F)V", at = @At(value="INVOKE", target="Lorg/lwjgl/opengl/GL11;glCallList(I)V"), remap = false)
-    public void renderSky(int list) {
-        VBOManager.get(list).render(GL11.GL_QUADS);
     }
 
     /**

--- a/src/main/java/com/gtnewhorizons/angelica/mixins/early/angelica/vbo/MixinWavefrontObject.java
+++ b/src/main/java/com/gtnewhorizons/angelica/mixins/early/angelica/vbo/MixinWavefrontObject.java
@@ -48,7 +48,7 @@ public abstract class MixinWavefrontObject implements IModelCustomExt {
         if(vertexBuffer == null) {
             rebuildVBO();
         }
-        vertexBuffer.render(GL11.GL_QUADS);
+        vertexBuffer.render();
     }
 
     /**

--- a/src/main/java/com/gtnewhorizons/angelica/render/CloudRenderer.java
+++ b/src/main/java/com/gtnewhorizons/angelica/render/CloudRenderer.java
@@ -333,7 +333,7 @@ public class CloudRenderer implements IResourceManagerReloadListener {
         // Depth pass to prevent insides rendering from the outside.
         GLStateManager.glColorMask(false, false, false, false);
 
-        vbo.draw(GL11.GL_QUADS);
+        vbo.draw();
 
         // Full render.
         if (!mc.gameSettings.anaglyph) {
@@ -356,14 +356,14 @@ public class CloudRenderer implements IResourceManagerReloadListener {
             GLStateManager.disableTexture();
             GLStateManager.glDepthMask(false);
             GLStateManager.disableFog();
-            vbo.draw(GL11.GL_QUADS);
+            vbo.draw();
             GL11.glPolygonMode(GL11.GL_FRONT_AND_BACK, GL11.GL_FILL);
             GLStateManager.glDepthMask(true);
             GLStateManager.enableTexture();
             GLStateManager.enableFog();
         }
 
-        vbo.draw(GL11.GL_QUADS);
+        vbo.draw();
         vbo.cleanupState(); // Unbind buffer and disable pointers.
 
         // Disable our coloring.

--- a/src/main/java/net/coderbot/iris/pipeline/HorizonRenderer.java
+++ b/src/main/java/net/coderbot/iris/pipeline/HorizonRenderer.java
@@ -157,7 +157,7 @@ public class HorizonRenderer {
 		vertexBuffer.bind();
         GL11.glVertexPointer(3, GL11.GL_FLOAT, 12, 0L);
         GL11.glEnableClientState(GL11.GL_VERTEX_ARRAY);
-		vertexBuffer.draw(floatBuffer, GL11.GL_QUADS);
+		vertexBuffer.draw(floatBuffer);
 		GL11.glDisableClientState(GL11.GL_VERTEX_ARRAY);
 		vertexBuffer.unbind();
 	}


### PR DESCRIPTION
Fixes Smart Moving not rendering the player model, which happened because its [`glCallLists` call](https://github.com/makamys/SmartRender/blob/16592c9925965fb6a4a5a5e262154bbe74674439/src/main/java/net/smart/render/ModelRotationRenderer.java#L70) was not getting redirected even though the VBO was set up.

Additionally, `VertexBuffer` now keeps track of its own draw mode so `GLStateManager` can know what draw mode it's supposed to use.