### PR TITLE
Fix campfire backport animations

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -85,6 +85,7 @@ dependencies {
     compileOnly("com.github.GTNewHorizons:NotEnoughIds-Legacy:1.4.7:dev") // ASM Version
 
     compileOnly("com.github.GTNewHorizons:Jabba:1.3.1:dev")
+    compileOnly(rfg.deobf("curse.maven:campfirebackport-387444:4611675"))
     // HMMMMM
     compileOnly(rfg.deobf("curse.maven:journeymap-32274:2367915"))
 

--- a/src/main/java/com/gtnewhorizons/angelica/mixins/Mixins.java
+++ b/src/main/java/com/gtnewhorizons/angelica/mixins/Mixins.java
@@ -194,6 +194,11 @@ public enum Mixins {
             "angelica.animation.MixinRenderBlockFluid",
             "angelica.animation.MixinWorldRenderer",
             "angelica.animation.MixinRenderItem")),
+    
+    SPEEDUP_CAMPFIRE_BACKPORT_ANIMATIONS(new Builder("Add animation speedup support to Campfire Backport").setPhase(Phase.LATE)
+            .addTargetedMod(TargetedMod.CAMPFIRE_BACKPORT).setSide(Side.CLIENT)
+            .setApplyIf(() -> AngelicaConfig.speedupAnimations)
+            .addMixinClasses("client.campfirebackport.MixinRenderBlockCampfire")),
 
     IC2_FLUID_RENDER_FIX(new Builder("IC2 Fluid Render Fix").setPhase(Phase.EARLY).setSide(Side.CLIENT)
         .addTargetedMod(TargetedMod.IC2).setApplyIf(() -> AngelicaConfig.speedupAnimations)

--- a/src/main/java/com/gtnewhorizons/angelica/mixins/TargetedMod.java
+++ b/src/main/java/com/gtnewhorizons/angelica/mixins/TargetedMod.java
@@ -8,6 +8,7 @@ public enum TargetedMod {
     , FASTCRAFT("FastCraft", "fastcraft.Tweaker")
     , OPTIFINE("Optifine", "optifine.OptiFineForgeTweaker", "Optifine")
     , BOTANIA("Botania", null, "Botania")
+    , CAMPFIRE_BACKPORT("CampfireBackport", null, "campfirebackport")
     , CHICKENCHUNKS("ChickenChunks", null, "ChickenChunks")
     , COFHCORE("CoFHCore", "cofh.asm.LoadingPlugin", "CoFHCore")
     , DYNAMIC_SURROUNDINGS_MIST("Dynamic Surroundings", "org.blockartistry.mod.DynSurround.mixinplugin.DynamicSurroundingsEarlyMixins", "dsurround")

--- a/src/main/java/com/gtnewhorizons/angelica/mixins/early/angelica/animation/MixinRenderBlocks.java
+++ b/src/main/java/com/gtnewhorizons/angelica/mixins/early/angelica/animation/MixinRenderBlocks.java
@@ -66,6 +66,14 @@ public class MixinRenderBlocks implements ITexturesCache {
 
         return icon;
     }
+    
+    @Inject(method = "drawCrossedSquares", at = @At("HEAD"))
+    public void angelica$markCrossedSquaresAnimationForUpdate(IIcon icon, double p_147765_2_, double p_147765_4_, double p_147765_6_, float p_147765_8_,
+            CallbackInfo ci) {
+        AnimationsRenderUtils.markBlockTextureForUpdate(icon, blockAccess);
+
+        this.renderedSprites.add(icon);
+    }
 
     @Override
     public Set<IIcon> getRenderedTextures() {

--- a/src/main/java/com/gtnewhorizons/angelica/mixins/late/client/campfirebackport/MixinRenderBlockCampfire.java
+++ b/src/main/java/com/gtnewhorizons/angelica/mixins/late/client/campfirebackport/MixinRenderBlockCampfire.java
@@ -14,7 +14,7 @@ import net.minecraft.block.Block;
 import net.minecraft.client.renderer.RenderBlocks;
 import net.minecraft.util.IIcon;
 
-@Mixin(targets = "connor135246.campfirebackport.client.rendering.RenderBlockCampfire")
+@Mixin(targets = "connor135246.campfirebackport.client.rendering.RenderBlockCampfire", remap = false)
 public class MixinRenderBlockCampfire {
     @Inject(method = "renderFace", at = @At("HEAD"))
     private static void angelica$beforeRenderFace(double x, double y, double z, Block block, RenderBlocks renderer, IIcon icon, int side, CallbackInfo ci) {

--- a/src/main/java/com/gtnewhorizons/angelica/mixins/late/client/campfirebackport/MixinRenderBlockCampfire.java
+++ b/src/main/java/com/gtnewhorizons/angelica/mixins/late/client/campfirebackport/MixinRenderBlockCampfire.java
@@ -1,0 +1,35 @@
+package com.gtnewhorizons.angelica.mixins.late.client.campfirebackport;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.ModifyArgs;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.invoke.arg.Args;
+
+import com.gtnewhorizons.angelica.mixins.interfaces.ITexturesCache;
+import com.gtnewhorizons.angelica.utils.AnimationsRenderUtils;
+
+import net.minecraft.block.Block;
+import net.minecraft.client.renderer.RenderBlocks;
+import net.minecraft.util.IIcon;
+
+@Mixin(targets = "connor135246.campfirebackport.client.rendering.RenderBlockCampfire")
+public class MixinRenderBlockCampfire {
+    @Inject(method = "renderFace", at = @At("HEAD"))
+    private static void angelica$beforeRenderFace(double x, double y, double z, Block block, RenderBlocks renderer, IIcon icon, int side, CallbackInfo ci) {
+        AnimationsRenderUtils.markBlockTextureForUpdate(icon, renderer.blockAccess);
+        ((ITexturesCache)renderer).getRenderedTextures().add(icon);
+    }
+    
+    @ModifyArgs(method = "renderFire", at = @At(value = "INVOKE", target = "Lconnor135246/campfirebackport/client/rendering/RenderBlockCampfire;drawCrossedSquaresTwoIcons(Lnet/minecraft/util/IIcon;Lnet/minecraft/util/IIcon;DDDF)V"))
+    private static void angelica$onDrawCrossedSquaresTwoIcons(Args args, double x, double y, double z, Block block, RenderBlocks renderer, boolean mix) {
+        IIcon icon1 = (IIcon)args.get(0);
+        AnimationsRenderUtils.markBlockTextureForUpdate(icon1, renderer.blockAccess);
+        ((ITexturesCache)renderer).getRenderedTextures().add(icon1);
+        
+        IIcon icon2 = (IIcon)args.get(1);
+        AnimationsRenderUtils.markBlockTextureForUpdate(icon2, renderer.blockAccess);
+        ((ITexturesCache)renderer).getRenderedTextures().add(icon2);
+    }
+}


### PR DESCRIPTION
This PR fixes Campfire Backport's animations not playing when `speedupAnimations` is enabled. It does this by doing two things:
- It adds a hook to `RenderBlocks#drawCrossedSquares` to mark animated icons.
  - Fixes campfire flames, as well as [this test pack](https://github.com/GTNewHorizons/Hodgepodge/files/12908735/animated_crossed_squares_pack.zip)'s poppies not animating.
- It adds hooks to [`RenderBlockCampfire`](https://github.com/connor135246/Campfire-Backport/blob/951901efc6b9f5585dc2d354d3582ab2e84fe7b8/src/main/java/connor135246/campfirebackport/client/rendering/RenderBlockCampfire.java)'s face rendering methods to mark animated icons. It would be a good idea to add an API for this later, but since there is currently none, patching them from Angelica's side is necessary.
  - Fixes campfire embers and the mixed campfires in the NEI handlers not animating.
