### PR TITLE
Fix hud caching alpha handling and boss health

### DIFF
--- a/src/main/java/com/gtnewhorizons/angelica/glsm/GLStateManager.java
+++ b/src/main/java/com/gtnewhorizons/angelica/glsm/GLStateManager.java
@@ -124,8 +124,6 @@ public class GLStateManager {
     private static final Map<IStateStack<?>, ISettableState<?>> glListStates = new Object2ObjectArrayMap<>();
     private static final Int2ObjectMap<Set<Map.Entry<IStateStack<?>, ISettableState<?>>>> glListChanges = new Int2ObjectOpenHashMap<>();
 
-    private static boolean hudCaching$blendEnabled;
-
     public static void init() {
         if (AngelicaConfig.enableIris) {
             StateUpdateNotifiers.blendFuncNotifier = listener -> blendFuncListener = listener;
@@ -204,7 +202,6 @@ public class GLStateManager {
                 return;
             }
         }
-        hudCaching$blendEnabled = true;
         blendMode.enable();
     }
 
@@ -215,7 +212,6 @@ public class GLStateManager {
                 return;
             }
         }
-        hudCaching$blendEnabled = false;
         blendMode.disable();
     }
 
@@ -299,36 +295,24 @@ public class GLStateManager {
     }
 
     public static void glColor4f(float red, float green, float blue, float alpha) {
-        if (!hudCaching$blendEnabled && HUDCaching.renderingCacheOverride && alpha < 1f) {
-            alpha = 1f;
-        }
         if (changeColor(red, green, blue, alpha)) {
             GL11.glColor4f(red, green, blue, alpha);
         }
     }
 
     public static void glColor4d(double red, double green, double blue, double alpha) {
-        if (!hudCaching$blendEnabled && HUDCaching.renderingCacheOverride && alpha < 1d) {
-            alpha = 1d;
-        }
         if (changeColor((float) red, (float) green, (float) blue, (float) alpha)) {
             GL11.glColor4d(red, green, blue, alpha);
         }
     }
 
     public static void glColor4b(byte red, byte green, byte blue, byte alpha) {
-        if (!hudCaching$blendEnabled && HUDCaching.renderingCacheOverride && alpha < Byte.MAX_VALUE) {
-            alpha = Byte.MAX_VALUE;
-        }
         if (changeColor(b2f(red), b2f(green), b2f(blue), b2f(alpha))) {
             GL11.glColor4b(red, green, blue, alpha);
         }
     }
 
     public static void glColor4ub(byte red, byte green, byte blue, byte alpha) {
-        if (!hudCaching$blendEnabled && HUDCaching.renderingCacheOverride && alpha < Byte.MAX_VALUE) {
-            alpha = Byte.MAX_VALUE;
-        }
         if (changeColor(ub2f(red), ub2f(green), ub2f(blue), ub2f(alpha))) {
             GL11.glColor4ub(red, green, blue, alpha);
         }

--- a/src/main/java/com/gtnewhorizons/angelica/mixins/early/angelica/hudcaching/GuiIngameForgeAccessor.java
+++ b/src/main/java/com/gtnewhorizons/angelica/mixins/early/angelica/hudcaching/GuiIngameForgeAccessor.java
@@ -1,9 +1,11 @@
 package com.gtnewhorizons.angelica.mixins.early.angelica.hudcaching;
 
-import net.minecraft.client.gui.ScaledResolution;
-import net.minecraftforge.client.GuiIngameForge;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.gen.Invoker;
+
+import net.minecraft.client.gui.ScaledResolution;
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.client.GuiIngameForge;
 
 @Mixin(GuiIngameForge.class)
 public interface GuiIngameForgeAccessor {
@@ -16,4 +18,7 @@ public interface GuiIngameForgeAccessor {
     
     @Invoker(remap = false)
     void callRenderPortal(int width, int height, float partialTicks);
+    
+    @Invoker(remap = false)
+    void callBind(ResourceLocation res);
 }

--- a/src/main/java/com/gtnewhorizons/angelica/mixins/early/angelica/hudcaching/MixinGuiIngameForge_HUDCaching.java
+++ b/src/main/java/com/gtnewhorizons/angelica/mixins/early/angelica/hudcaching/MixinGuiIngameForge_HUDCaching.java
@@ -1,6 +1,8 @@
 package com.gtnewhorizons.angelica.mixins.early.angelica.hudcaching;
 
 import com.gtnewhorizons.angelica.hudcaching.HUDCaching;
+
+import net.minecraft.client.gui.Gui;
 import net.minecraftforge.client.GuiIngameForge;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -41,5 +43,14 @@ public class MixinGuiIngameForge_HUDCaching {
     		HUDCaching.renderPortalCapturedTicks = partialTicks;
         	ci.cancel();
         }
+    }
+    
+    @Inject(method = "renderBossHealth", at = @At("HEAD"))
+    private void angelica$bindBossHealthTexture(CallbackInfo ci) {
+    	// boss health texture is bind in renderCrosshairs
+    	// but HUD caching skips rendering crosshairs when rendering into cache
+    	if (HUDCaching.renderingCacheOverride) {
+    		((GuiIngameForgeAccessor) this).callBind(Gui.icons);
+    	}
     }
 }

--- a/src/main/java/com/gtnewhorizons/angelica/mixins/early/angelica/hudcaching/MixinGuiIngame_HUDCaching.java
+++ b/src/main/java/com/gtnewhorizons/angelica/mixins/early/angelica/hudcaching/MixinGuiIngame_HUDCaching.java
@@ -6,7 +6,10 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import com.gtnewhorizons.angelica.hudcaching.HUDCaching;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 
+import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.gui.GuiIngame;
 
 @Mixin(GuiIngame.class)
@@ -44,4 +47,15 @@ public class MixinGuiIngame_HUDCaching {
         	ci.cancel();
         }
     }
+    
+    @WrapOperation(method = "func_96136_a", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/FontRenderer;drawString(Ljava/lang/String;III)I"))
+    private int angelica$fixScoreboardTextAlpha(FontRenderer fontRenderer, String text, int x, int y, int color, Operation<Integer> op) {
+    	// Vanilla uses 0x20 for the alpha but it looks like 0xFF for some reason
+    	// here we just make it 0xFF so it doesn't cause issues
+    	if (HUDCaching.renderingCacheOverride) {
+    		color |= 0xFF000000;
+    	}
+    	return op.call(fontRenderer, text, x, y, color);
+    }
+    
 }


### PR DESCRIPTION
Closes #204 
Also mitigates #231 but probably doesn't fix the root issue (which seems to be related to `enableFontRenderer`)

### Problem
- Original HUD caching had a hack for setting any alpha to 1 to fix scoreboard, this also removes alpha from elements that do need it
- Boss health texture is binded in `renderCrosshairs` but HUD caching skips crosshairs when rendering the cache, causing boss health to have the wrong texture

### Fix
- Removed the original HUD caching alpha hack and target the hack specifically to the scoreboard render function
- Bind boss health texture in `renderBossHealth`

### Other
In testing I noticed sometimes the crosshairs flickers, but I can't repro it consistently. I can help look into it if anyone found a consistent setup to repro

### Validation
(not really obvious in the screenshot but the hunger bar animates properly when holding food)
![2024-01-24_03 53 37](https://github.com/GTNewHorizons/Angelica/assets/44533763/1f075024-b28e-44ec-b5c2-dd05035b421b)

