### PR TITLE
Handle depth buffer properly in HUD Caching

### DIFF
--- a/src/main/java/com/gtnewhorizons/angelica/mixins/early/angelica/hudcaching/GuiIngameAccessor.java
+++ b/src/main/java/com/gtnewhorizons/angelica/mixins/early/angelica/hudcaching/GuiIngameAccessor.java
@@ -13,7 +13,6 @@ public interface GuiIngameAccessor {
 	@Invoker
 	void callRenderPumpkinBlur(int width, int height);
 	
-	// render portal
-	@Invoker
-	void callFunc_130015_b(float partialTicks, int width, int height);
+	@Invoker("func_130015_b")
+	void callRenderPortal(float partialTicks, int width, int height);
 }

--- a/src/main/java/com/gtnewhorizons/angelica/mixins/early/angelica/hudcaching/MixinGuiIngameForge_HUDCaching.java
+++ b/src/main/java/com/gtnewhorizons/angelica/mixins/early/angelica/hudcaching/MixinGuiIngameForge_HUDCaching.java
@@ -1,13 +1,14 @@
 package com.gtnewhorizons.angelica.mixins.early.angelica.hudcaching;
 
-import com.gtnewhorizons.angelica.hudcaching.HUDCaching;
-
-import net.minecraft.client.gui.Gui;
-import net.minecraftforge.client.GuiIngameForge;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import com.gtnewhorizons.angelica.hudcaching.HUDCaching;
+
+import net.minecraft.client.gui.Gui;
+import net.minecraftforge.client.GuiIngameForge;
 
 @Mixin(GuiIngameForge.class)
 public class MixinGuiIngameForge_HUDCaching {
@@ -25,6 +26,7 @@ public class MixinGuiIngameForge_HUDCaching {
     private void angelica$captureRenderCrosshair(CallbackInfo ci) {
         if (HUDCaching.renderingCacheOverride) {
         	HUDCaching.renderCrosshairsCaptured = true;
+        	HUDCaching.fixGLStateBeforeRenderingCache();
         	ci.cancel();
         }
     }

--- a/src/main/java/net/coderbot/iris/pipeline/HandRenderer.java
+++ b/src/main/java/net/coderbot/iris/pipeline/HandRenderer.java
@@ -10,6 +10,8 @@ import net.minecraft.entity.EntityLiving;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemBlock;
+import net.minecraft.item.ItemStack;
+
 import org.joml.Matrix4f;
 
 public class HandRenderer {
@@ -58,7 +60,11 @@ public class HandRenderer {
 	public boolean isHandTranslucent(InteractionHand hand) {
         // TODO: Offhand
 //        Item item = Minecraft.getMinecraft().thePlayer.getItemBySlot(hand == InteractionHand.OFF_HAND ? EquipmentSlot.OFFHAND : EquipmentSlot.MAINHAND).getItem();
-        Item item = Minecraft.getMinecraft().thePlayer.getHeldItem().getItem();
+        ItemStack heldItem = Minecraft.getMinecraft().thePlayer.getHeldItem();
+        if (heldItem == null) {
+        	return false;
+        }
+		Item item = heldItem.getItem();
 
 		if (item instanceof ItemBlock itemBlock) {
             // TODO: RenderType


### PR DESCRIPTION

### Problem
The HUD caching depth buffer is reset to 1.0 instead of what the MC framebuffer's depth is. This breaks depth test in some conditions (shaders)

### Fix
- Copy the depth buffer from MC after resetting
- Cleaned up GL state changes. Now the GL state should be the same as when HUD caching is off, when calling different parts of `renderGameOverlay`
- Null check in HandRenderer. Fixes game crash when pressing F5 with no item in hand
 