### PR TITLE
Make RedirectorTransformer handle block subclasses correctly (fixes TFC+)

### DIFF
--- a/src/main/java/com/gtnewhorizons/angelica/transform/BlockTransformer.java
+++ b/src/main/java/com/gtnewhorizons/angelica/transform/BlockTransformer.java
@@ -11,6 +11,7 @@ import java.util.List;
 
 public class BlockTransformer implements IClassTransformer {
     public static final String BlockClass = "net/minecraft/block/Block";
+    public static final String BlockPackage = BlockClass.substring(0, BlockClass.lastIndexOf('/') + 1);
     private static final String BlockClassFriendly = BlockClass.replace('/', '.');
     public static final List<Pair<String, String>> BlockBoundsFields = ImmutableList.of(
         Pair.of("minX", "field_149759_B"),

--- a/src/main/java/com/gtnewhorizons/angelica/transform/ClassConstantPoolParser.java
+++ b/src/main/java/com/gtnewhorizons/angelica/transform/ClassConstantPoolParser.java
@@ -61,6 +61,16 @@ public class ClassConstantPoolParser {
      * for
      */
     public boolean find(byte[] basicClass) {
+        return find(basicClass, false);
+    }
+    /**
+     * Returns true if the constant pool of the class represented by this byte array contains one of the Strings we are looking
+     * for.
+     *
+     * @param prefixes If true, it is enough for a constant pool entry to <i>start</i> with one of our Strings to count as a match -
+     * otherwise, the entire String has to match.
+     */
+    public boolean find(byte[] basicClass, boolean prefixes) {
         if (basicClass == null || basicClass.length == 0) {
             return false;
         }
@@ -92,9 +102,9 @@ public class ClassConstantPoolParser {
                     final int strLen = readUnsignedShort(index + 1, basicClass);
                     size = 3 + strLen;
                     for (byte[] bytes : BYTES_TO_SEARCH) {
-                        if (strLen == bytes.length) {
+                        if (prefixes ? strLen >= bytes.length : strLen == bytes.length) {
                             boolean found = true;
-                            for (int j = index + 3; j < index + 3 + strLen; j++) {
+                            for (int j = index + 3; j < index + 3 + bytes.length; j++) {
                                 if (basicClass[j] != bytes[j - (index + 3)]) {
                                     found = false;
                                     break;


### PR DESCRIPTION
Fixes #248

`RedirectorTransformer` hinges on the assumption that superclasses always get loaded before subclasses. It turns out this is not the always the case, as `net.minecraft.block.BlockLeaves` gets loaded before its superclass, `net.minecraft.block.BlockLeavesBase`. (This happens even in vanilla, and can be easily verified using D-Tools's class load logger.) This caused `BlockLeaves` and all of its subclasses to not get detected as block classes, causing a crash like #248.

The naive solution would be to scan the superclasses of every class recursively to determine the class hierarchy, using something like RFB's [FastAccessor](https://github.com/GTNewHorizons/RetroFuturaBootstrap/blob/master/src/main/java/com/gtnewhorizons/retrofuturabootstrap/api/FastClassAccessor.java). But to avoid the overhead this would add, I have chosen a different solution based on these observations:

- For modded classes, we can assume the superclass *does* always get loaded first, because FML's [EventSubscriptionTransformer](https://github.com/MinecraftForge/FML/blob/a099592d3d1418245e3af65eda195da244287188/src/main/java/cpw/mods/fml/common/asm/transformers/EventSubscriptionTransformer.java#L88-L90) loads them. Therefore we can keep using the same algorithm for them. (But note that [it skips vanilla classes](https://github.com/MinecraftForge/FML/blob/a099592d3d1418245e3af65eda195da244287188/src/main/java/cpw/mods/fml/common/asm/transformers/EventSubscriptionTransformer.java#L56).)

- This leaves vanilla block classes. These are all known at compile time (assuming no mod changes the hierarchy or adds shadow fields): they are all in the `net.minecraft.block.` package, and all classes in that package are blocks with the exception of four.

With this in mind, my solution in this PR is to detect vanilla block classes by class name, and modded classes using the old algorithm.

To make this possible, I had to add an option for `ClassConstantPoolParser` to match prefixes rather than full strings, so I can search for the entire `net/minecraft/block/` package.

I tested this in a minimal instance with and without TFC+.