### PR TITLE
Add dependency hints

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -7,6 +7,7 @@
 
 
 # Required Dependencies
+* [UniMixins](https://github.com/LegacyModdingMC/UniMixins/releases) >= 0.1.14
 * [GTNHLib](https://github.com/GTNewHorizons/GTNHLib/releases) >= 0.2.1
 
 # Known (temporary) Incompatibilities

--- a/src/main/java/com/gtnewhorizons/angelica/loading/MixinCompatHackTweaker.java
+++ b/src/main/java/com/gtnewhorizons/angelica/loading/MixinCompatHackTweaker.java
@@ -20,9 +20,17 @@ public class MixinCompatHackTweaker implements ITweaker {
     public static final boolean DISABLE_OPTIFINE_AND_FASTCRAFT = true;
     @Override
     public void acceptOptions(List<String> args, File gameDir, File assetsDir, String profile) {
+        verifyDependencies();
+        
         if(DISABLE_OPTIFINE_AND_FASTCRAFT) {
             LOGGER.info("Disabling Optifine and Fastcraft (if present)");
             disableOptifineAndFastcraft();
+        }
+    }
+    
+    private void verifyDependencies() {
+        if(MixinCompatHackTweaker.class.getResource("/it/unimi/dsi/fastutil/ints/Int2ObjectMap.class") == null) {
+            throw new RuntimeException("Missing dependency: Angelica requires GTNHLib 0.2.1 or newer! Download: https://modrinth.com/mod/gtnhlib");
         }
     }
 


### PR DESCRIPTION
No one asked for this, it just bothered me how cryptic the error message you get when you try to run Angelica without GTNHLib is. This PR makes it so a helpful exception gets thrown in the tweaker early on if FastUtil is missing.
<details>
<summary>Example stack trace</summary>

```
[08:19:59] [main/ERROR] [LaunchWrapper]: Unable to launch
java.lang.RuntimeException: Missing dependency: Angelica requires GTNHLib 0.2.1 or newer! Download: https://modrinth.com/mod/gtnhlib
	at com.gtnewhorizons.angelica.loading.MixinCompatHackTweaker.verifyDependencies(MixinCompatHackTweaker.java:33) ~[angelica-1.0.0-alpha18-master.5+9a0974d6a6.jar:?]
	at com.gtnewhorizons.angelica.loading.MixinCompatHackTweaker.acceptOptions(MixinCompatHackTweaker.java:23) ~[angelica-1.0.0-alpha18-master.5+9a0974d6a6.jar:?]
	at net.minecraft.launchwrapper.Launch.launch(Launch.java:114) [launchwrapper-1.12.jar:?]
	at net.minecraft.launchwrapper.Launch.main(Launch.java:28) [launchwrapper-1.12.jar:?]
	at org.prismlauncher.launcher.impl.StandardLauncher.launch(StandardLauncher.java:87) [NewLaunch.jar:?]
	at org.prismlauncher.EntryPoint.listen(EntryPoint.java:130) [NewLaunch.jar:?]
	at org.prismlauncher.EntryPoint.main(EntryPoint.java:70) [NewLaunch.jar:?]
Exception caught from launcher
cpw.mods.fml.relauncher.FMLSecurityManager$ExitTrappedException
	at cpw.mods.fml.relauncher.FMLSecurityManager.checkPermission(FMLSecurityManager.java:25)
	at java.lang.SecurityManager.checkExit(SecurityManager.java:761)
	at java.lang.Runtime.exit(Runtime.java:101)
	at java.lang.System.exit(System.java:987)
	at net.minecraft.launchwrapper.Launch.launch(Launch.java:138)
	at net.minecraft.launchwrapper.Launch.main(Launch.java:28)
	at org.prismlauncher.launcher.impl.StandardLauncher.launch(StandardLauncher.java:87)
	at org.prismlauncher.EntryPoint.listen(EntryPoint.java:130)
	at org.prismlauncher.EntryPoint.main(EntryPoint.java:70)
Exiting with ERROR
Exception in thread "main" [08:19:59] [main/INFO] [STDERR]: [java.lang.Throwable$WrappedPrintStream:println:749]: java.lang.ArrayIndexOutOfBoundsException: 5
[08:19:59] [main/INFO] [STDERR]: [java.lang.Throwable$WrappedPrintStream:println:749]: 	at cpw.mods.fml.relauncher.FMLSecurityManager.checkPermission(FMLSecurityManager.java:21)
[08:19:59] [main/INFO] [STDERR]: [java.lang.Throwable$WrappedPrintStream:println:749]: 	at java.lang.SecurityManager.checkExit(SecurityManager.java:761)
[08:19:59] [main/INFO] [STDERR]: [java.lang.Throwable$WrappedPrintStream:println:749]: 	at java.lang.Runtime.exit(Runtime.java:101)
[08:19:59] [main/INFO] [STDERR]: [java.lang.Throwable$WrappedPrintStream:println:749]: 	at java.lang.System.exit(System.java:987)
[08:19:59] [main/INFO] [STDERR]: [java.lang.Throwable$WrappedPrintStream:println:749]: 	at org.prismlauncher.EntryPoint.main(EntryPoint.java:75)
Process exited with code 1.
```

</details>

While I was at it, I also noticed the UniMixins dependency is not noted in the readme, so I added it.