### PR TITLE
Only coerce facing in Quad#getFace

### DIFF
--- a/src/main/java/com/gtnewhorizons/angelica/compat/nd/Quad.java
+++ b/src/main/java/com/gtnewhorizons/angelica/compat/nd/Quad.java
@@ -57,8 +57,9 @@ public class Quad implements ModelQuadView {
         return this.hasNormals;
     }
 
-    public ForgeDirection getFace() {
-        return this.face != null ? this.face : ForgeDirection.DOWN;
+    /** Returns the face, forced to take one of 6 directions to mirror the behavior of baked quads in 1.16.5. */
+    public ForgeDirection getCoercedFace() {
+        return this.face != ForgeDirection.UNKNOWN ? this.face : ForgeDirection.UP;
     }
 
     @Override

--- a/src/main/java/me/jellysquid/mods/sodium/client/model/quad/properties/ModelQuadFacing.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/model/quad/properties/ModelQuadFacing.java
@@ -61,7 +61,7 @@ public enum ModelQuadFacing {
                 return WEST;
             }
         }
-        return UP; // Default in 1.16.5
+        return UNASSIGNED;
     }
 
     public ModelQuadFacing getOpposite() {

--- a/src/main/java/me/jellysquid/mods/sodium/client/model/quad/properties/ModelQuadFlags.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/model/quad/properties/ModelQuadFlags.java
@@ -33,8 +33,8 @@ public class ModelQuadFlags {
      * certain optimizations.
      */
     public static int getQuadFlags(Quad quad) {
-        final ForgeDirection face = quad.getFace();
-        final Axis axis = Axis.fromDirection(quad.normal);
+        final ForgeDirection face = quad.getCoercedFace();
+        final Axis axis = Axis.fromDirection(ModelQuadFacing.fromDirection(face));
 
         float minX = 32.0F;
         float minY = 32.0F;

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/pipeline/BlockRenderer.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/pipeline/BlockRenderer.java
@@ -124,7 +124,7 @@ public class BlockRenderer {
             final QuadLightData light = this.cachedQuadLightData;
 
             if (useSodiumLight || this.useSeparateAo)
-                lighter.calculate(quad, pos, light, cullFace, quad.getFace(), quad.hasShade());
+                lighter.calculate(quad, pos, light, cullFace, quad.getCoercedFace(), quad.hasShade());
 
             this.renderQuad(sink, quad, light, renderData, useSodiumLight);
         }


### PR DESCRIPTION
Mirrors 1.16's face handling more accurately.
Fixes face culling not working properly for blocks like tall grass