### PR TITLE
Bump GTNH gradle plugin version

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -17,7 +17,5 @@ pluginManagement {
 }
 
 plugins {
-    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.8'
+    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.9'
 }
-
-


### PR DESCRIPTION
`1.0.8` doesn't use `repositories.gradle` and fails to build, bump it.