### PR TITLE
Compat with NotEnoughIDs 16-bit Metadata

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -81,7 +81,7 @@ dependencies {
     compileOnly(rfg.deobf("curse.maven:extrautils-225561:2264383"))
     compileOnly(rfg.deobf("curse.maven:dynamiclights-227874:2337326"))
 
-    compileOnly("com.github.GTNewHorizons:NotEnoughIds:1.5.3:dev") // Mixin Version
+    compileOnly("com.github.GTNewHorizons:NotEnoughIds:2.0.0:dev") // Mixin Version
     compileOnly("com.github.GTNewHorizons:NotEnoughIds-Legacy:1.4.7:dev") // ASM Version
 
     compileOnly(rfg.deobf("curse.maven:campfirebackport-387444:4611675"))

--- a/src/main/java/com/gtnewhorizons/angelica/compat/ExtendedBlockStorageExt.java
+++ b/src/main/java/com/gtnewhorizons/angelica/compat/ExtendedBlockStorageExt.java
@@ -36,6 +36,10 @@ public class ExtendedBlockStorageExt extends ExtendedBlockStorage {
                     copyNibbleArray((ExtendedNibbleArray) storage.getBlockMSBArray(), (ExtendedNibbleArray) this.getBlockMSBArray());
                 }
                 arrayLen = block16BArray.length;
+                if (ModStatus.isNEIDMetadataExtended) {
+                    final short[] block16BMetaArray = ((IExtendedBlockStorageMixin)(Object)this).getBlock16BMetaArray();
+                    System.arraycopy(((IExtendedBlockStorageMixin)(Object)storage).getBlock16BMetaArray(), 0, block16BMetaArray, 0, block16BMetaArray.length);
+                }
             }
             else if (ModStatus.isOldNEIDLoaded){
                 final short[] blockLSBArray = Hooks.get(this);
@@ -54,7 +58,7 @@ public class ExtendedBlockStorageExt extends ExtendedBlockStorage {
             }
 
 
-            copyNibbleArray((ExtendedNibbleArray) storage.getMetadataArray(), (ExtendedNibbleArray)this.getMetadataArray());
+            if (!ModStatus.isNEIDMetadataExtended) copyNibbleArray((ExtendedNibbleArray) storage.getMetadataArray(), (ExtendedNibbleArray)this.getMetadataArray());
             copyNibbleArray((ExtendedNibbleArray) storage.getBlocklightArray(), (ExtendedNibbleArray)this.getBlocklightArray());
             if(storage.getSkylightArray() != null) {
                 hasSky = true;

--- a/src/main/java/com/gtnewhorizons/angelica/compat/ModStatus.java
+++ b/src/main/java/com/gtnewhorizons/angelica/compat/ModStatus.java
@@ -11,6 +11,8 @@ public class ModStatus {
      * ASM Version
      */
     public static boolean isOldNEIDLoaded;
+
+    public static boolean isNEIDMetadataExtended;
     public static boolean isLotrLoaded;
     public static boolean isChunkAPILoaded;
     public static boolean isEIDBiomeLoaded;
@@ -21,5 +23,13 @@ public class ModStatus {
         isLotrLoaded = Loader.isModLoaded("lotr");
         isChunkAPILoaded = Loader.isModLoaded("chunkapi");
         isEIDBiomeLoaded = Loader.isModLoaded("endlessids_biome");
+
+        isNEIDMetadataExtended = false;
+        if (isNEIDLoaded) {
+            int majorVersion = Character.getNumericValue(Loader.instance().getIndexedModList().get("neid").getVersion().charAt(0));
+            if (majorVersion >= 2) {
+                isNEIDMetadataExtended = true;
+            }
+        }
     }
 }

--- a/src/main/java/com/gtnewhorizons/angelica/compat/ModStatus.java
+++ b/src/main/java/com/gtnewhorizons/angelica/compat/ModStatus.java
@@ -26,7 +26,7 @@ public class ModStatus {
 
         isNEIDMetadataExtended = false;
         if (isNEIDLoaded) {
-            int majorVersion = Character.getNumericValue(Loader.instance().getIndexedModList().get("neid").getVersion().charAt(0));
+            int majorVersion = Integer.parseInt(Loader.instance().getIndexedModList().get("neid").getVersion().split("\\.")[0]);
             if (majorVersion >= 2) {
                 isNEIDMetadataExtended = true;
             }


### PR DESCRIPTION
This adds compatibility with the upcoming 16-bit block metadata extension in [NotEnoughIDs](https://github.com/GTNewHorizons/NotEnoughIds).

This makes an assumption that version 2.X.X and above of NotEnoughIDs has the metadata extension, this will fail to build for the moment, because 2.0.0 of NotEnoughIDs hasn't actually been published yet, but wanted to get this PR ready to go ahead of that, and we can come back and merge this when it's ready.

For now if anyone cares to test it, you'll have to build the 16-bit metadata PR on NEID and `publishToMavenLocal` as 2.0.0.

Wanted to get this in in case anyone conceptually has input or tweaks they'd like to make.