### PR TITLE
Use a RFB plugin for GLSM transforms when available

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,6 +14,13 @@ tasks.test {
     jvmArgs("-Djava.library.path=${tasks.extractNatives2.get().destinationFolder.asFile.get().path}")
 }
 
+tasks.processResources {
+    inputs.property("version", project.version.toString())
+    filesMatching("META-INF/rfb-plugin/*") {
+        expand("version" to project.version.toString())
+    }
+}
+
 tasks.register<Copy>("copyDependencies") {
     group = "Angelica"
     description = "Collect dependencies into the testDependencies folder"

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -51,7 +51,9 @@ configurations {
 dependencies {
     compileOnly("com.github.GTNewHorizons:Hodgepodge:2.4.4")
 
-    compileOnly("org.projectlombok:lombok:1.18.22") {transitive = false }
+    compileOnly("com.gtnewhorizons.retrofuturabootstrap:RetroFuturaBootstrap:0.4.0") { transitive = false }
+
+    compileOnly("org.projectlombok:lombok:1.18.22") { transitive = false }
     annotationProcessor("org.projectlombok:lombok:1.18.22")
 
     // Iris Shaders
@@ -71,7 +73,7 @@ dependencies {
     // Notfine Deps
     compileOnly("thaumcraft:Thaumcraft:1.7.10-4.2.3.5:dev")
     runtimeOnlyNonPublishable("com.github.GTNewHorizons:Baubles:1.0.1.16:dev")
-    compileOnly("com.github.GTNewHorizons:twilightforest:2.5.1:dev") {transitive = false }
+    compileOnly("com.github.GTNewHorizons:twilightforest:2.5.1:dev") { transitive = false }
     compileOnly(rfg.deobf('curse.maven:witchery-69673:2234410'))
 
     compileOnly("com.falsepattern:chunkapi-mc1.7.10:0.5.0:api")

--- a/src/main/java/com/gtnewhorizons/angelica/loading/MixinCompatHackTweaker.java
+++ b/src/main/java/com/gtnewhorizons/angelica/loading/MixinCompatHackTweaker.java
@@ -21,13 +21,13 @@ public class MixinCompatHackTweaker implements ITweaker {
     @Override
     public void acceptOptions(List<String> args, File gameDir, File assetsDir, String profile) {
         verifyDependencies();
-        
+
         if(DISABLE_OPTIFINE_AND_FASTCRAFT) {
             LOGGER.info("Disabling Optifine and Fastcraft (if present)");
             disableOptifineAndFastcraft();
         }
     }
-    
+
     private void verifyDependencies() {
         if(MixinCompatHackTweaker.class.getResource("/it/unimi/dsi/fastutil/ints/Int2ObjectMap.class") == null) {
             throw new RuntimeException("Missing dependency: Angelica requires GTNHLib 0.2.1 or newer! Download: https://modrinth.com/mod/gtnhlib");
@@ -82,8 +82,12 @@ public class MixinCompatHackTweaker implements ITweaker {
     @Override
     public String[] getLaunchArguments() {
         if (FMLLaunchHandler.side().isClient()) {
-            // Run after Mixins, but before LWJGl3ify
-            Launch.classLoader.registerTransformer(RedirectorTransformer.class.getName());
+            final boolean rfbLoaded = Launch.blackboard.getOrDefault("angelica.rfbPluginLoaded", Boolean.FALSE) == Boolean.TRUE;
+
+            if (!rfbLoaded) {
+                // Run after Mixins, but before LWJGl3ify
+                Launch.classLoader.registerTransformer(RedirectorTransformer.class.getName());
+            }
             if(AngelicaConfig.enableSodium) {
                 Launch.classLoader.registerTransformer(BlockTransformer.class.getName());
             }

--- a/src/main/java/com/gtnewhorizons/angelica/loading/rfb/AngelicaRfbPlugin.java
+++ b/src/main/java/com/gtnewhorizons/angelica/loading/rfb/AngelicaRfbPlugin.java
@@ -1,0 +1,28 @@
+package com.gtnewhorizons.angelica.loading.rfb;
+
+import com.gtnewhorizons.retrofuturabootstrap.api.PluginContext;
+import com.gtnewhorizons.retrofuturabootstrap.api.RetroFuturaBootstrap;
+import com.gtnewhorizons.retrofuturabootstrap.api.RfbClassTransformer;
+import com.gtnewhorizons.retrofuturabootstrap.api.RfbPlugin;
+import net.minecraft.launchwrapper.Launch;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class AngelicaRfbPlugin implements RfbPlugin {
+
+    @Override
+    public void onConstruction(@NotNull PluginContext ctx) {
+        Launch.blackboard.put("angelica.rfbPluginLoaded", Boolean.TRUE);
+    }
+
+    @Override
+    public @NotNull RfbClassTransformer @Nullable [] makeTransformers() {
+        final boolean isServer = (null == RetroFuturaBootstrap.API.launchClassLoader().findClassMetadata("net.minecraft.client.main.Main"));
+        if (isServer) {
+            return null;
+        }
+        return new RfbClassTransformer[] {
+            new RedirectorTransformerWrapper()
+        };
+    }
+}

--- a/src/main/java/com/gtnewhorizons/angelica/loading/rfb/RedirectorTransformerWrapper.java
+++ b/src/main/java/com/gtnewhorizons/angelica/loading/rfb/RedirectorTransformerWrapper.java
@@ -1,0 +1,61 @@
+package com.gtnewhorizons.angelica.loading.rfb;
+
+import com.gtnewhorizons.angelica.transform.RedirectorTransformer;
+import com.gtnewhorizons.retrofuturabootstrap.api.ClassNodeHandle;
+import com.gtnewhorizons.retrofuturabootstrap.api.ExtensibleClassLoader;
+import com.gtnewhorizons.retrofuturabootstrap.api.RfbClassTransformer;
+import org.intellij.lang.annotations.Pattern;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.jar.Manifest;
+
+/** RFB wrapper for {@link com.gtnewhorizons.angelica.transform.RedirectorTransformer} */
+public class RedirectorTransformerWrapper implements RfbClassTransformer {
+
+    public final RedirectorTransformer inner = new RedirectorTransformer();
+
+    @Pattern("[a-z0-9-]+")
+    @Override
+    public @NotNull String id() {
+        return "redirector";
+    }
+
+    @Override
+    public @NotNull String @Nullable [] sortAfter() {
+        return new String[] {"*", "mixin:mixin"};
+    }
+
+    @Override
+    public @NotNull String @Nullable [] sortBefore() {
+        return new String[] {"lwjgl3ify:redirect"};
+    }
+
+    @Override
+    public @NotNull String @Nullable [] additionalExclusions() {
+        return RedirectorTransformer.getTransformerExclusions().toArray(new String[0]);
+    }
+
+    @Override
+    public boolean shouldTransformClass(@NotNull ExtensibleClassLoader classLoader,
+        @NotNull RfbClassTransformer.Context context, @Nullable Manifest manifest, @NotNull String className,
+        @NotNull ClassNodeHandle classNode) {
+        if (!classNode.isPresent()) {
+            return false;
+        }
+        if (!classNode.isOriginal()) {
+            // If a class is already a transformed ClassNode, conservatively continue processing.
+            return true;
+        }
+        return inner.shouldRfbTransform(classNode.getOriginalBytes());
+    }
+
+    @Override
+    public void transformClass(@NotNull ExtensibleClassLoader classLoader, @NotNull RfbClassTransformer.Context context,
+        @Nullable Manifest manifest, @NotNull String className, @NotNull ClassNodeHandle classNode) {
+        final boolean changed = inner.transformClassNode(className, classNode.getNode());
+        if (changed) {
+            classNode.computeMaxs();
+        }
+    }
+}

--- a/src/main/java/com/gtnewhorizons/angelica/transform/BlockTransformer.java
+++ b/src/main/java/com/gtnewhorizons/angelica/transform/BlockTransformer.java
@@ -3,9 +3,9 @@ package com.gtnewhorizons.angelica.transform;
 import com.google.common.collect.ImmutableList;
 import net.minecraft.launchwrapper.IClassTransformer;
 import org.apache.commons.lang3.tuple.Pair;
-import org.spongepowered.asm.lib.ClassReader;
-import org.spongepowered.asm.lib.ClassWriter;
-import org.spongepowered.asm.lib.tree.ClassNode;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.tree.ClassNode;
 
 import java.util.List;
 

--- a/src/main/resources/META-INF/rfb-plugin/angelica.properties
+++ b/src/main/resources/META-INF/rfb-plugin/angelica.properties
@@ -1,0 +1,9 @@
+name=Angelica
+version=${version}
+additionalVersions=
+className=com.gtnewhorizons.angelica.loading.rfb.AngelicaRfbPlugin
+transformerExclusions=com.gtnewhorizons.angelica.transform.RedirectorTransformer
+versionConstraints=
+loadBefore=
+loadAfter=mixin; lwjgl3ify
+loadRequires=


### PR DESCRIPTION
Registers a RFB plugin when available, the RFB plugin disables the GLSM transformer via a launch blackboard entry.
Tested with lwjgl3ify 2.0.0 alpha 9 and locally with runClient to confirm both code paths still work.