### PR TITLE
Only track rendered sprites on specific RenderBlocks instances

### DIFF
--- a/src/main/java/com/gtnewhorizons/angelica/mixins/early/angelica/animation/MixinChunkCache.java
+++ b/src/main/java/com/gtnewhorizons/angelica/mixins/early/angelica/animation/MixinChunkCache.java
@@ -18,4 +18,9 @@ public class MixinChunkCache implements ITexturesCache {
     public HashSet<IIcon> getRenderedTextures() {
         return renderedIcons;
     }
+
+    @Override
+    public void enableTextureTracking() {
+
+    }
 }

--- a/src/main/java/com/gtnewhorizons/angelica/mixins/early/angelica/animation/MixinWorldRenderer.java
+++ b/src/main/java/com/gtnewhorizons/angelica/mixins/early/angelica/animation/MixinWorldRenderer.java
@@ -26,6 +26,7 @@ public class MixinWorldRenderer implements ITexturesCache {
 
     @ModifyArg(method = "updateRenderer", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/RenderBlocks;<init>(Lnet/minecraft/world/IBlockAccess;)V"))
     private IBlockAccess angelica$onUpdateRenderer(IBlockAccess chunkCache) {
+        ((ITexturesCache) chunkCache).enableTextureTracking();
         renderedIcons = ((ITexturesCache) chunkCache).getRenderedTextures();
         return chunkCache;
     }
@@ -42,5 +43,10 @@ public class MixinWorldRenderer implements ITexturesCache {
     @Override
     public Set<IIcon> getRenderedTextures() {
         return renderedIcons;
+    }
+
+    @Override
+    public void enableTextureTracking() {
+
     }
 }

--- a/src/main/java/com/gtnewhorizons/angelica/mixins/interfaces/ITexturesCache.java
+++ b/src/main/java/com/gtnewhorizons/angelica/mixins/interfaces/ITexturesCache.java
@@ -7,4 +7,5 @@ import java.util.Set;
 public interface ITexturesCache {
 
     Set<IIcon> getRenderedTextures();
+    void enableTextureTracking();
 }

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/tasks/ChunkRenderRebuildTask.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/tasks/ChunkRenderRebuildTask.java
@@ -116,6 +116,7 @@ public class ChunkRenderRebuildTask<T extends ChunkGraphicsState> extends ChunkR
 
         final WorldSlice slice = cache.getWorldSlice();
         final RenderBlocks renderBlocks = new RenderBlocks(slice);
+        if(renderBlocks instanceof ITexturesCache) ((ITexturesCache)renderBlocks).enableTextureTracking();
 
         final int baseX = this.render.getOriginX();
         final int baseY = this.render.getOriginY();
@@ -246,6 +247,7 @@ public class ChunkRenderRebuildTask<T extends ChunkGraphicsState> extends ChunkR
         final int baseZ = this.render.getOriginZ();
         final BlockPosImpl renderOffset = this.offset;
         final RenderBlocks rb = new RenderBlocks(slice.getWorld());
+        if(rb instanceof ITexturesCache) ((ITexturesCache)rb).enableTextureTracking();
         while(!mainThreadBlocks.isEmpty()) {
             final long longPos = mainThreadBlocks.dequeueLong();
             if (cancellationSource.isCancelled()) {


### PR DESCRIPTION
This avoids global `RenderBlocks` instances having the set grow unbounded.