### PR TITLE
Initialize toggle keybind when registering

### DIFF
--- a/src/main/java/com/gtnewhorizons/angelica/hudcaching/HUDCaching.java
+++ b/src/main/java/com/gtnewhorizons/angelica/hudcaching/HUDCaching.java
@@ -63,9 +63,10 @@ public class HUDCaching {
 
     private final List<Long> updateTimeList = new ArrayList<>(21);
     private static boolean isEnabled = true;
-    private static final KeyBinding toggle = new KeyBinding("Toggle HUDCaching", 0, "Debug");
+    private static KeyBinding toggle;
 
     public static void registerKeyBindings() {
+        toggle = new KeyBinding("Toggle HUDCaching", 0, "Debug");
         ClientRegistry.registerKeyBinding(toggle);
     }
 
@@ -86,7 +87,7 @@ public class HUDCaching {
 
     @SubscribeEvent
     public void onKeypress(InputEvent.KeyInputEvent event) {
-        if (toggle.isPressed()) {
+        if (toggle != null && toggle.isPressed()) {
             isEnabled = !isEnabled;
             final String msg = isEnabled ? "Enabled HUDCaching" : "Disabled HUDCaching";
             if (mc.thePlayer != null) mc.thePlayer.addChatMessage(new ChatComponentText(msg));

--- a/src/main/java/com/gtnewhorizons/angelica/hudcaching/HUDCaching.java
+++ b/src/main/java/com/gtnewhorizons/angelica/hudcaching/HUDCaching.java
@@ -63,6 +63,9 @@ public class HUDCaching {
 
     private final List<Long> updateTimeList = new ArrayList<>(21);
     private static boolean isEnabled = true;
+
+    // moved initialization to when its registered to avoid an empty Debug category, which can cause crashes when
+    // opening the controls menu and hudcaching is disabled in the config
     private static KeyBinding toggle;
 
     public static void registerKeyBindings() {


### PR DESCRIPTION
Fixes https://github.com/GTNewHorizons/Angelica/issues/365

The keybind was creating the Debug category as a part of the static initialization of that class. Apparently minecraft does not like empty keybind categories.