### PR TITLE
Use vanilla field to count number of chunk updates

### DIFF
--- a/src/main/java/com/gtnewhorizons/angelica/mixins/early/sodium/MixinMinecraft.java
+++ b/src/main/java/com/gtnewhorizons/angelica/mixins/early/sodium/MixinMinecraft.java
@@ -25,11 +25,6 @@ public class MixinMinecraft {
         }
     }
 
-    @Redirect(method="runGameLoop", at=@At(value="FIELD", target="Lnet/minecraft/client/renderer/WorldRenderer;chunksUpdated:I", ordinal=0))
-    private int sodium$chunksUpdated() {
-        return ((IRenderGlobalExt)this.renderGlobal).getChunksSubmitted();
-    }
-
     @Redirect(method = "runGameLoop", at = @At(value = "FIELD", target = "Lnet/minecraft/client/settings/GameSettings;fancyGraphics:Z"))
     private boolean sodium$overrideFancyGrass(GameSettings gameSettings) {
         return SodiumClientMod.options().quality.grassQuality.isFancy();

--- a/src/main/java/com/gtnewhorizons/angelica/mixins/early/sodium/MixinRenderGlobal.java
+++ b/src/main/java/com/gtnewhorizons/angelica/mixins/early/sodium/MixinRenderGlobal.java
@@ -60,11 +60,6 @@ public class MixinRenderGlobal implements IRenderGlobalExt {
         this.renderer.scheduleTerrainUpdate();
     }
 
-    @Override
-    public int getChunksSubmitted() {
-        return this.renderer.getChunksSubmitted();
-    }
-
     @Inject(method="<init>", at=@At("RETURN"))
     private void sodium$initRenderer(Minecraft mc, CallbackInfo ci) {
         this.renderer = SodiumWorldRenderer.create(mc);

--- a/src/main/java/com/gtnewhorizons/angelica/mixins/interfaces/IRenderGlobalExt.java
+++ b/src/main/java/com/gtnewhorizons/angelica/mixins/interfaces/IRenderGlobalExt.java
@@ -2,6 +2,5 @@ package com.gtnewhorizons.angelica.mixins.interfaces;
 
 public interface IRenderGlobalExt {
     void scheduleTerrainUpdate();
-    int getChunksSubmitted();
 
 }

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/SodiumWorldRenderer.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/SodiumWorldRenderer.java
@@ -124,10 +124,6 @@ public class SodiumWorldRenderer implements ChunkStatusListener {
         }
     }
 
-    public int getChunksSubmitted() {
-        return this.chunkRenderManager != null ? this.chunkRenderManager.getAndResetSubmitted() : 0;
-    }
-
     private void loadWorld(WorldClient world) {
         this.world = world;
 

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/ChunkRenderManager.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/ChunkRenderManager.java
@@ -37,6 +37,7 @@ import me.jellysquid.mods.sodium.common.util.IdTable;
 import me.jellysquid.mods.sodium.common.util.collections.FutureDequeDrain;
 import net.coderbot.iris.shadows.ShadowRenderingState;
 import net.minecraft.client.multiplayer.WorldClient;
+import net.minecraft.client.renderer.WorldRenderer;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.chunk.storage.ExtendedBlockStorage;
 import net.minecraftforge.common.util.ForgeDirection;
@@ -97,7 +98,6 @@ public class ChunkRenderManager<T extends ChunkGraphicsState> implements ChunkSt
 
     @Getter
     private int submitted;
-    private int totalSubmitted;
 
     private final boolean translucencySorting;
 
@@ -580,7 +580,7 @@ public class ChunkRenderManager<T extends ChunkGraphicsState> implements ChunkSt
             sortedAnything = true;
             submitted++;
         }
-        totalSubmitted += submitted;
+        WorldRenderer.chunksUpdated += submitted;
 
         this.dirty |= submitted > 0;
 
@@ -594,13 +594,6 @@ public class ChunkRenderManager<T extends ChunkGraphicsState> implements ChunkSt
             this.dirty = true;
             this.backend.upload(RenderDevice.INSTANCE.createCommandList(), this.builder.filterChunkBuilds(new FutureDequeDrain<>(futures)));
         }
-    }
-
-    public int getAndResetSubmitted() {
-        // Return how many chunks were submitted since the last call to this method
-        final int submitted = totalSubmitted;
-        totalSubmitted = 0;
-        return submitted;
     }
 
     public void markDirty() {


### PR DESCRIPTION
I'm working on adding some benchmarking functionality to D-Tools, and I need to retrieve the number of chunk updates that were performed in each frame. Currently I do this by comparing the value of `WorldRenderer#chunksUpdated` at the start and end of each frame, which works for vanilla and FalseTweaks. But since Angelica bypasses the field, 0 is always returned.

This PR changes Angelica to use the same field. I have verified that this produces the same value as the old code path.

For the record, all the code I removed was added by Mitch during The Mergening.