### PR TITLE
Use ByteBuffer overload when indirect buffer is in client memory

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/gl/device/DrawCommandList.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gl/device/DrawCommandList.java
@@ -1,10 +1,12 @@
 package me.jellysquid.mods.sodium.client.gl.device;
 
+import java.nio.ByteBuffer;
 import java.nio.IntBuffer;
 
 public interface DrawCommandList extends AutoCloseable {
     void multiDrawArrays(IntBuffer first, IntBuffer count);
 
+    void multiDrawArraysIndirect(ByteBuffer pointer, int count, int stride);
     void multiDrawArraysIndirect(long pointer, int count, int stride);
 
     void endTessellating();

--- a/src/main/java/me/jellysquid/mods/sodium/client/gl/device/GLRenderDevice.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gl/device/GLRenderDevice.java
@@ -198,6 +198,12 @@ public class GLRenderDevice implements RenderDevice {
         }
 
         @Override
+        public void multiDrawArraysIndirect(ByteBuffer pointer, int count, int stride) {
+            final GlPrimitiveType primitiveType = GLRenderDevice.this.activeTessellation.getPrimitiveType();
+            GlFunctions.INDIRECT_DRAW.glMultiDrawArraysIndirect(primitiveType.getId(), pointer, count, stride);
+        }
+
+        @Override
         public void multiDrawArraysIndirect(long pointer, int count, int stride) {
             final GlPrimitiveType primitiveType = GLRenderDevice.this.activeTessellation.getPrimitiveType();
             GlFunctions.INDIRECT_DRAW.glMultiDrawArraysIndirect(primitiveType.getId(), pointer, count, stride);

--- a/src/main/java/me/jellysquid/mods/sodium/client/gl/func/GlIndirectMultiDrawFunctions.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gl/func/GlIndirectMultiDrawFunctions.java
@@ -1,5 +1,7 @@
 package me.jellysquid.mods.sodium.client.gl.func;
 
+import java.nio.ByteBuffer;
+
 import org.lwjgl.opengl.ARBMultiDrawIndirect;
 import org.lwjgl.opengl.ContextCapabilities;
 import org.lwjgl.opengl.GL43;
@@ -7,17 +9,32 @@ import org.lwjgl.opengl.GL43;
 public enum GlIndirectMultiDrawFunctions {
     CORE {
         @Override
+        public void glMultiDrawArraysIndirect(int mode, ByteBuffer indirect, int primcount, int stride) {
+            GL43.glMultiDrawArraysIndirect(mode, indirect, primcount, stride);
+        }
+
+        @Override
         public void glMultiDrawArraysIndirect(int mode, long indirect, int primcount, int stride) {
             GL43.glMultiDrawArraysIndirect(mode, indirect, primcount, stride);
         }
     },
     ARB {
         @Override
+        public void glMultiDrawArraysIndirect(int mode, ByteBuffer indirect, int primcount, int stride) {
+            ARBMultiDrawIndirect.glMultiDrawArraysIndirect(mode, indirect, primcount, stride);
+        }
+
+        @Override
         public void glMultiDrawArraysIndirect(int mode, long indirect, int primcount, int stride) {
             ARBMultiDrawIndirect.glMultiDrawArraysIndirect(mode, indirect, primcount, stride);
         }
     },
     UNSUPPORTED {
+        @Override
+        public void glMultiDrawArraysIndirect(int mode, ByteBuffer indirect, int primcount, int stride) {
+            throw new UnsupportedOperationException();
+        }
+
         @Override
         public void glMultiDrawArraysIndirect(int mode, long indirect, int primcount, int stride) {
             throw new UnsupportedOperationException();
@@ -34,5 +51,7 @@ public enum GlIndirectMultiDrawFunctions {
         }
     }
 
+    public abstract void glMultiDrawArraysIndirect(int mode, ByteBuffer indirect, int primcount, int stride);
     public abstract void glMultiDrawArraysIndirect(int mode, long indirect, int primcount, int stride);
+
 }


### PR DESCRIPTION
Fixes #373

Sodium uses a buffer object to store the indirect buffer normally, but on Windows with Intel drivers, it uses a pointer into client memory instead.

On LWJGL3, `glMultiDrawArraysIndirect(..., long indirect, ...)` can be called with a pointer into client memory or a buffer offset, so Sodium simply called this method in both cases.

On LWJGL2, only a buffer offset is supported, so the code didn't translate properly in the pointer case. This PR changes it to use the `ByteBuffer` overload in this case, which is the only valid way with LWJGL2.