### PR TITLE
Allow the user to select more gui scales

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumGameOptionPages.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumGameOptionPages.java
@@ -92,12 +92,12 @@ public class SodiumGameOptionPages {
         firstGroupBuilder.add(Settings.VOID_FOG.option);
         groups.add(firstGroupBuilder.build());
 
-
+        int maxGuiScale = Math.max(3, Math.min(Minecraft.getMinecraft().displayWidth / 320, Minecraft.getMinecraft().displayHeight / 240));
         groups.add(OptionGroup.createBuilder()
                 .add(OptionImpl.createBuilder(int.class, vanillaOpts)
                         .setName(I18n.format("options.guiScale"))
                         .setTooltip(I18n.format("sodium.options.gui_scale.tooltip"))
-                        .setControl(option -> new SliderControl(option, 0, 3, 1, ControlValueFormatter.guiScale()))
+                        .setControl(option -> new SliderControl(option, 0, maxGuiScale, 1, ControlValueFormatter.guiScale()))
                         .setBinding((opts, value) -> {
                             opts.guiScale = value;
                             // Resizing our window


### PR DESCRIPTION
This sets the maximum gui scale to a dynamic number based on the user's screen resolution, with the largest available option being the same scale given by selecting auto. This is very convenient for people with 4k monitors especially, since they currently have to go into the options.txt file and manually change it. The method is called every time the video options page is opened, so it'll adapt if the user changes the size of their window.