### PR TITLE
Fix crash when Sodium is disabled

### DIFF
--- a/src/main/java/com/gtnewhorizons/angelica/proxy/ClientProxy.java
+++ b/src/main/java/com/gtnewhorizons/angelica/proxy/ClientProxy.java
@@ -78,13 +78,15 @@ public class ClientProxy extends CommonProxy {
             LOGGER.info("World loaded - Enabling GLSM Cache");
         }
 
-        // Register all blocks. Because blockids are unique to a world, this must be done each load
-        GameData.getBlockRegistry().forEach(o -> {
-
-            final Block b = (Block) o;
-            AngelicaBlockSafetyRegistry.canBlockRenderOffThread(b, true, true);
-            AngelicaBlockSafetyRegistry.canBlockRenderOffThread(b, false, true);
-        });
+        if(AngelicaConfig.enableSodium) {
+            // Register all blocks. Because blockids are unique to a world, this must be done each load
+            GameData.getBlockRegistry().forEach(o -> {
+    
+                final Block b = (Block) o;
+                AngelicaBlockSafetyRegistry.canBlockRenderOffThread(b, true, true);
+                AngelicaBlockSafetyRegistry.canBlockRenderOffThread(b, false, true);
+            });
+        }
     }
 
 


### PR DESCRIPTION
The `IRenderingRegistryExt` duck is only mixed into `RenderingRegistry` if Sodium is enabled, but it's referenced by the block safety registry init code which runs unconditionally, causing the below exception on world load. Since this registry is only used by Sodium, this PR puts its initialization behind an `enableSodium` check.

Note that the mod is still potentially unusable when Sodium is disabled, at least on my machine: mobs flash while chunks are loading when GLSM is enabled, and translucent textures are opaque when it's not. However, these issues don't happen when Neodymium is present.

### Stack trace
```
java.lang.ClassCastException: cpw.mods.fml.client.registry.RenderingRegistry cannot be cast to com.gtnewhorizons.angelica.mixins.interfaces.IRenderingRegistryExt
	at com.gtnewhorizons.angelica.rendering.AngelicaBlockSafetyRegistry.populateCanRenderOffThread(AngelicaBlockSafetyRegistry.java:35) ~[AngelicaBlockSafetyRegistry.class:?]
	at com.gtnewhorizons.angelica.rendering.AngelicaBlockSafetyRegistry.canBlockRenderOffThread(AngelicaBlockSafetyRegistry.java:27) ~[AngelicaBlockSafetyRegistry.class:?]
	at com.gtnewhorizons.angelica.proxy.ClientProxy.lambda$worldLoad$0(ClientProxy.java:85) ~[ClientProxy.class:?]
	at java.lang.Iterable.forEach(Iterable.java:75) ~[?:1.8.0_392]
	at com.gtnewhorizons.angelica.proxy.ClientProxy.worldLoad(ClientProxy.java:82) ~[ClientProxy.class:?]
	at cpw.mods.fml.common.eventhandler.ASMEventHandler_9_ClientProxy_worldLoad_Load.invoke(.dynamic) ~[?:?]
	at cpw.mods.fml.common.eventhandler.ASMEventHandler.invoke(ASMEventHandler.java:54) ~[ASMEventHandler.class:?]
	at cpw.mods.fml.common.eventhandler.EventBus.post(EventBus.java:140) ~[EventBus.class:?]
	at net.minecraft.server.integrated.IntegratedServer.func_71247_a(IntegratedServer.java:73) ~[bsx.class:?]
	at net.minecraft.server.integrated.IntegratedServer.func_71197_b(IntegratedServer.java:92) ~[bsx.class:?]
	at net.minecraft.server.MinecraftServer.run(MinecraftServer.java:387) [MinecraftServer.class:?]
	at net.minecraft.server.MinecraftServer$2.run(MinecraftServer.java:685) [?:?]
```