### PR TITLE
Fix flickering of HoloInventory and Xaero's Map Waypoints

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -90,6 +90,8 @@ dependencies {
     compileOnly(rfg.deobf("curse.maven:journeymap-32274:2367915"))
     compileOnly(rfg.deobf("curse.maven:xaeros-minimap-263420:5060684"))
 
+    devOnlyNonPublishable("com.github.GTNewHorizons:HoloInventory:2.4.4-GTNH:dev")
+
     runtimeOnlyNonPublishable(rfg.deobf("CoreTweaks:CoreTweaks:0.3.3.2"))
 
     // Hodgepodge

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -88,6 +88,7 @@ dependencies {
     compileOnly(rfg.deobf("curse.maven:campfirebackport-387444:4611675"))
     // HMMMMM
     compileOnly(rfg.deobf("curse.maven:journeymap-32274:2367915"))
+    compileOnly(rfg.deobf("curse.maven:xaeros-minimap-263420:5060684"))
 
     runtimeOnlyNonPublishable(rfg.deobf("CoreTweaks:CoreTweaks:0.3.3.2"))
 

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -90,7 +90,7 @@ dependencies {
     compileOnly(rfg.deobf("curse.maven:journeymap-32274:2367915"))
     compileOnly(rfg.deobf("curse.maven:xaeros-minimap-263420:5060684"))
 
-    devOnlyNonPublishable("com.github.GTNewHorizons:HoloInventory:2.4.4-GTNH:dev")
+    compileOnly("com.github.GTNewHorizons:HoloInventory:2.4.4-GTNH:dev")
 
     runtimeOnlyNonPublishable(rfg.deobf("CoreTweaks:CoreTweaks:0.3.3.2"))
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -117,7 +117,7 @@ minimizeShadowedDependencies = true
 # If disabled, won't rename the shadowed classes.
 relocateShadowedDependencies = true
 
-# Adds the GTNH maven, CurseMaven, IC2/Player maven, and some more well-known 1.7.10 repositories.
+# Adds the GTNH maven, CurseMaven, Modrinth, and some more well-known 1.7.10 repositories.
 includeWellKnownRepositories = true
 
 # Change these to your Maven coordinates if you want to publish to a custom Maven repository instead of the default GTNH Maven.
@@ -141,7 +141,7 @@ modrinthProjectId = angelica
 #       and the name is the Modrinth project or version slug/id of the other mod.
 # Example: required-project:fplib;optional-project:gasstation;incompatible-project:gregtech
 # Note: GTNH Mixins is automatically set as a required dependency if usesMixins = true
-modrinthRelations = required-project:gtnhlib
+modrinthRelations = required-project\:gtnhlib
 
 # Publishing to CurseForge requires you to set the CURSEFORGE_TOKEN environment variable to one of your CurseForge API tokens.
 #
@@ -155,7 +155,7 @@ curseForgeProjectId = 988067
 #       and the name is the CurseForge project slug of the other mod.
 # Example: requiredDependency:railcraft;embeddedLibrary:cofhlib;incompatible:buildcraft
 # Note: UniMixins is automatically set as a required dependency if usesMixins = true.
-curseForgeRelations = requiredDependency:gtnhlib
+curseForgeRelations = requiredDependency\:gtnhlib
 
 # Optional parameter to customize the produced artifacts. Use this to preserve artifact naming when migrating older
 # projects. New projects should not use this parameter.

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/settings.gradle
+++ b/settings.gradle
@@ -16,5 +16,5 @@ pluginManagement {
 }
 
 plugins {
-    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.18'
+    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.21'
 }

--- a/src/main/java/com/gtnewhorizons/angelica/compat/ModStatus.java
+++ b/src/main/java/com/gtnewhorizons/angelica/compat/ModStatus.java
@@ -16,6 +16,7 @@ public class ModStatus {
     public static boolean isLotrLoaded;
     public static boolean isChunkAPILoaded;
     public static boolean isEIDBiomeLoaded;
+    public static boolean isXaerosMinimapLoaded;
 
     public static void preInit(){
         isNEIDLoaded = Loader.isModLoaded("neid");
@@ -23,6 +24,7 @@ public class ModStatus {
         isLotrLoaded = Loader.isModLoaded("lotr");
         isChunkAPILoaded = Loader.isModLoaded("chunkapi");
         isEIDBiomeLoaded = Loader.isModLoaded("endlessids_biome");
+        isXaerosMinimapLoaded = Loader.isModLoaded("XaeroMinimap");
 
         isNEIDMetadataExtended = false;
         if (isNEIDLoaded) {

--- a/src/main/java/com/gtnewhorizons/angelica/compat/ModStatus.java
+++ b/src/main/java/com/gtnewhorizons/angelica/compat/ModStatus.java
@@ -30,11 +30,15 @@ public class ModStatus {
         isChunkAPILoaded = Loader.isModLoaded("chunkapi");
         isEIDBiomeLoaded = Loader.isModLoaded("endlessids_biome");
         isXaerosMinimapLoaded = Loader.isModLoaded("XaeroMinimap");
-        isHoloInventoryLoaded = Loader.isModLoaded("holoinventory") &&
-            new DefaultArtifactVersion("2.4.4-GTNH")
+        isHoloInventoryLoaded = Loader.isModLoaded("holoinventory");
+
+        if (isHoloInventoryLoaded){
+            isHoloInventoryLoaded = new DefaultArtifactVersion("2.4.4-GTNH")
                 .compareTo(
                     LoadControllerHelper.getOwningMod(HoloInventory.class).getProcessedVersion()
                 ) <= 0;
+        }
+
 
         isNEIDMetadataExtended = false;
         if (isNEIDLoaded) {

--- a/src/main/java/com/gtnewhorizons/angelica/compat/ModStatus.java
+++ b/src/main/java/com/gtnewhorizons/angelica/compat/ModStatus.java
@@ -17,6 +17,7 @@ public class ModStatus {
     public static boolean isChunkAPILoaded;
     public static boolean isEIDBiomeLoaded;
     public static boolean isXaerosMinimapLoaded;
+    public static boolean isHoloInventoryLoaded;
 
     public static void preInit(){
         isNEIDLoaded = Loader.isModLoaded("neid");
@@ -25,6 +26,7 @@ public class ModStatus {
         isChunkAPILoaded = Loader.isModLoaded("chunkapi");
         isEIDBiomeLoaded = Loader.isModLoaded("endlessids_biome");
         isXaerosMinimapLoaded = Loader.isModLoaded("XaeroMinimap");
+        isHoloInventoryLoaded = Loader.isModLoaded("holoinventory");
 
         isNEIDMetadataExtended = false;
         if (isNEIDLoaded) {

--- a/src/main/java/com/gtnewhorizons/angelica/compat/ModStatus.java
+++ b/src/main/java/com/gtnewhorizons/angelica/compat/ModStatus.java
@@ -1,6 +1,10 @@
 package com.gtnewhorizons.angelica.compat;
 
+import com.gtnewhorizons.angelica.helpers.LoadControllerHelper;
 import cpw.mods.fml.common.Loader;
+import cpw.mods.fml.common.versioning.ArtifactVersion;
+import cpw.mods.fml.common.versioning.DefaultArtifactVersion;
+import net.dries007.holoInventory.HoloInventory;
 
 public class ModStatus {
     /**
@@ -26,7 +30,11 @@ public class ModStatus {
         isChunkAPILoaded = Loader.isModLoaded("chunkapi");
         isEIDBiomeLoaded = Loader.isModLoaded("endlessids_biome");
         isXaerosMinimapLoaded = Loader.isModLoaded("XaeroMinimap");
-        isHoloInventoryLoaded = Loader.isModLoaded("holoinventory");
+        isHoloInventoryLoaded = Loader.isModLoaded("holoinventory") &&
+            new DefaultArtifactVersion("2.4.4-GTNH")
+                .compareTo(
+                    LoadControllerHelper.getOwningMod(HoloInventory.class).getProcessedVersion()
+                ) <= 0;
 
         isNEIDMetadataExtended = false;
         if (isNEIDLoaded) {

--- a/src/main/java/com/gtnewhorizons/angelica/hudcaching/HUDCaching.java
+++ b/src/main/java/com/gtnewhorizons/angelica/hudcaching/HUDCaching.java
@@ -4,8 +4,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import com.gtnewhorizons.angelica.compat.ModStatus;
+import com.gtnewhorizons.angelica.mixins.early.angelica.hudcaching.RenderGameOverlayEventAccessor;
 import cpw.mods.fml.common.eventhandler.EventPriority;
-import net.dries007.holoInventory.HoloInventory;
 import net.dries007.holoInventory.client.Renderer;
 import net.minecraftforge.client.event.RenderGameOverlayEvent;
 import net.minecraftforge.event.world.WorldEvent;
@@ -58,6 +58,8 @@ public class HUDCaching {
     public static float renderPortalCapturedTicks;
     // Crosshairs need to be blended with the scene
     public static boolean renderCrosshairsCaptured;
+
+    private static RenderGameOverlayEvent fakeHoloInventoryEvent = new RenderGameOverlayEvent.Pre(new RenderGameOverlayEvent(0, null, 0, 0), RenderGameOverlayEvent.ElementType.HELMET);
 
     public static final HUDCaching INSTANCE = new HUDCaching();
 
@@ -168,9 +170,9 @@ public class HUDCaching {
         		guiForge.callRenderHelmet(resolution, partialTicks, hasScreen, mouseX, mouseY);
                 if (ModStatus.isHoloInventoryLoaded){
                     Renderer.INSTANCE.angelicaOverride = false;
-                    RenderGameOverlayEvent fakeEvent = new RenderGameOverlayEvent(partialTicks, resolution, mouseX, mouseY);
-                    fakeEvent = new RenderGameOverlayEvent.Pre(fakeEvent, RenderGameOverlayEvent.ElementType.HELMET);
-                    Renderer.INSTANCE.renderEvent(fakeEvent);
+                    // only settings the partial ticks as mouseX and mouseY are not used in renderEvent
+                    ((RenderGameOverlayEventAccessor) fakeHoloInventoryEvent).setPartialTicks(partialTicks);
+                    Renderer.INSTANCE.renderEvent(fakeHoloInventoryEvent);
                 }
         	}
         	if (renderPortalCapturedTicks > 0) {

--- a/src/main/java/com/gtnewhorizons/angelica/hudcaching/HUDCaching.java
+++ b/src/main/java/com/gtnewhorizons/angelica/hudcaching/HUDCaching.java
@@ -5,6 +5,9 @@ import java.util.List;
 
 import com.gtnewhorizons.angelica.compat.ModStatus;
 import cpw.mods.fml.common.eventhandler.EventPriority;
+import net.dries007.holoInventory.HoloInventory;
+import net.dries007.holoInventory.client.Renderer;
+import net.minecraftforge.client.event.RenderGameOverlayEvent;
 import net.minecraftforge.event.world.WorldEvent;
 import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.GL30;
@@ -159,11 +162,16 @@ public class HUDCaching {
         } else {
         	GLStateManager.tryBlendFuncSeparate(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA, 1, 0);
         }
-
         if (ingame instanceof GuiIngameForge) {
         	GuiIngameForgeAccessor guiForge = ((GuiIngameForgeAccessor) ingame);
         	if (renderHelmetCaptured) {
         		guiForge.callRenderHelmet(resolution, partialTicks, hasScreen, mouseX, mouseY);
+                if (ModStatus.isHoloInventoryLoaded){
+                    Renderer.INSTANCE.angelicaOverride = false;
+                    RenderGameOverlayEvent fakeEvent = new RenderGameOverlayEvent(partialTicks, resolution, mouseX, mouseY);
+                    fakeEvent = new RenderGameOverlayEvent.Pre(fakeEvent, RenderGameOverlayEvent.ElementType.HELMET);
+                    Renderer.INSTANCE.renderEvent(fakeEvent);
+                }
         	}
         	if (renderPortalCapturedTicks > 0) {
         		guiForge.callRenderPortal(width, height, partialTicks);

--- a/src/main/java/com/gtnewhorizons/angelica/hudcaching/HUDCaching.java
+++ b/src/main/java/com/gtnewhorizons/angelica/hudcaching/HUDCaching.java
@@ -245,4 +245,11 @@ public class HUDCaching {
         GL11.glTexParameteri(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_MAG_FILTER, GL11.GL_NEAREST);
     }
 
+    // moved to here due to the method being called from a mixin
+    public static void disableHoloInventory() {
+        if (ModStatus.isHoloInventoryLoaded){
+            Renderer.INSTANCE.angelicaOverride = true;
+        }
+    }
+
 }

--- a/src/main/java/com/gtnewhorizons/angelica/hudcaching/HUDCaching.java
+++ b/src/main/java/com/gtnewhorizons/angelica/hudcaching/HUDCaching.java
@@ -3,6 +3,7 @@ package com.gtnewhorizons.angelica.hudcaching;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.gtnewhorizons.angelica.compat.ModStatus;
 import cpw.mods.fml.common.eventhandler.EventPriority;
 import net.minecraftforge.event.world.WorldEvent;
 import org.lwjgl.opengl.GL11;
@@ -28,6 +29,7 @@ import net.minecraft.client.settings.KeyBinding;
 import net.minecraft.client.shader.Framebuffer;
 import net.minecraft.util.ChatComponentText;
 import net.minecraftforge.client.GuiIngameForge;
+import xaero.common.core.XaeroMinimapCore;
 
 import static com.gtnewhorizons.angelica.loading.AngelicaTweaker.LOGGER;
 
@@ -119,6 +121,11 @@ public class HUDCaching {
     @SuppressWarnings("unused")
     public static void renderCachedHud(EntityRenderer renderer, GuiIngame ingame, float partialTicks, boolean hasScreen, int mouseX, int mouseY) {
 
+        if (ModStatus.isXaerosMinimapLoaded && ingame instanceof GuiIngameForge) {
+            // this used to be called by asming into renderGameOverlay, but we removed it
+            XaeroMinimapCore.beforeIngameGuiRender(partialTicks);
+        }
+
         if (!OpenGlHelper.isFramebufferEnabled() || !isEnabled || framebuffer == null) {
             ingame.renderGameOverlay(partialTicks, hasScreen, mouseX, mouseY);
             return;
@@ -164,6 +171,7 @@ public class HUDCaching {
         	if (renderCrosshairsCaptured) {
         		guiForge.callRenderCrosshairs(width, height);
         	}
+
         } else {
             if (renderHelmetCaptured)
             {

--- a/src/main/java/com/gtnewhorizons/angelica/loading/MixinCompatHackTweaker.java
+++ b/src/main/java/com/gtnewhorizons/angelica/loading/MixinCompatHackTweaker.java
@@ -26,11 +26,31 @@ public class MixinCompatHackTweaker implements ITweaker {
             LOGGER.info("Disabling Optifine and Fastcraft (if present)");
             disableOptifineAndFastcraft();
         }
+        disableXaerosMinimapWaypointTransformer();
     }
 
     private void verifyDependencies() {
         if(MixinCompatHackTweaker.class.getResource("/it/unimi/dsi/fastutil/ints/Int2ObjectMap.class") == null) {
             throw new RuntimeException("Missing dependency: Angelica requires GTNHLib 0.2.1 or newer! Download: https://modrinth.com/mod/gtnhlib");
+        }
+    }
+
+    private void disableXaerosMinimapWaypointTransformer(){
+        try {
+            LaunchClassLoader lcl = Launch.classLoader;
+            Field xformersField = lcl.getClass().getDeclaredField("transformers");
+            xformersField.setAccessible(true);
+            @SuppressWarnings("unchecked")
+            List<IClassTransformer> xformers = (List<IClassTransformer>) xformersField.get(lcl);
+            for (int idx = xformers.size() - 1; idx >= 0; idx--) {
+                final String name = xformers.get(idx).getClass().getName();
+                if (name.startsWith("xaero.common.core.transformer.GuiIngameForgeTransformer")) {
+                    LOGGER.info("Removing transformer " + name);
+                    xformers.remove(idx);
+                }
+            }
+        } catch (Exception e) {
+            throw new RuntimeException(e);
         }
     }
 

--- a/src/main/java/com/gtnewhorizons/angelica/mixins/Mixins.java
+++ b/src/main/java/com/gtnewhorizons/angelica/mixins/Mixins.java
@@ -163,6 +163,7 @@ public enum Mixins {
         .setApplyIf(() -> AngelicaConfig.enableHudCaching).addMixinClasses(
         	"angelica.hudcaching.GuiIngameAccessor",
         	"angelica.hudcaching.GuiIngameForgeAccessor",
+            "angelica.hudcaching.RenderGameOverlayEventAccessor",
             "angelica.hudcaching.MixinEntityRenderer_HUDCaching",
             "angelica.hudcaching.MixinFramebuffer_HUDCaching",
             "angelica.hudcaching.MixinGuiIngame_HUDCaching",

--- a/src/main/java/com/gtnewhorizons/angelica/mixins/early/angelica/hudcaching/MixinGuiIngameForge_HUDCaching.java
+++ b/src/main/java/com/gtnewhorizons/angelica/mixins/early/angelica/hudcaching/MixinGuiIngameForge_HUDCaching.java
@@ -1,5 +1,9 @@
 package com.gtnewhorizons.angelica.mixins.early.angelica.hudcaching;
 
+import com.gtnewhorizons.angelica.compat.ModStatus;
+import net.dries007.holoInventory.client.Renderer;
+import net.minecraft.client.gui.ScaledResolution;
+import net.minecraftforge.client.event.RenderGameOverlayEvent;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -21,7 +25,7 @@ public class MixinGuiIngameForge_HUDCaching {
         	HUDCaching.renderCrosshairsCaptured = false;
         }
     }
-	
+
     @Inject(method = "renderCrosshairs", at = @At("HEAD"), cancellable = true, remap = false)
     private void angelica$captureRenderCrosshair(CallbackInfo ci) {
         if (HUDCaching.renderingCacheOverride) {
@@ -30,15 +34,20 @@ public class MixinGuiIngameForge_HUDCaching {
         	ci.cancel();
         }
     }
-    
+
     @Inject(method = "renderHelmet", at = @At("HEAD"), cancellable = true, remap = false)
-    private void angelica$captureRenderHelmet(CallbackInfo ci) {
+    private void angelica$captureRenderHelmet(ScaledResolution res, float partialTicks, boolean hasScreen, int mouseX, int mouseY, CallbackInfo ci) {
     	if (HUDCaching.renderingCacheOverride) {
     		HUDCaching.renderHelmetCaptured = true;
         	ci.cancel();
+            return;
+        }
+
+        if (ModStatus.isHoloInventoryLoaded){
+            Renderer.INSTANCE.angelicaOverride = true;
         }
     }
-    
+
     @Inject(method = "renderPortal", at = @At("HEAD"), cancellable = true, remap = false)
     private void angelica$captureRenderPortal(int width, int height, float partialTicks, CallbackInfo ci) {
     	if (HUDCaching.renderingCacheOverride) {
@@ -46,7 +55,7 @@ public class MixinGuiIngameForge_HUDCaching {
         	ci.cancel();
         }
     }
-    
+
     @Inject(method = "renderBossHealth", at = @At("HEAD"))
     private void angelica$bindBossHealthTexture(CallbackInfo ci) {
     	// boss health texture is bind in renderCrosshairs

--- a/src/main/java/com/gtnewhorizons/angelica/mixins/early/angelica/hudcaching/MixinGuiIngameForge_HUDCaching.java
+++ b/src/main/java/com/gtnewhorizons/angelica/mixins/early/angelica/hudcaching/MixinGuiIngameForge_HUDCaching.java
@@ -1,9 +1,6 @@
 package com.gtnewhorizons.angelica.mixins.early.angelica.hudcaching;
 
-import com.gtnewhorizons.angelica.compat.ModStatus;
-import net.dries007.holoInventory.client.Renderer;
 import net.minecraft.client.gui.ScaledResolution;
-import net.minecraftforge.client.event.RenderGameOverlayEvent;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -40,12 +37,9 @@ public class MixinGuiIngameForge_HUDCaching {
     	if (HUDCaching.renderingCacheOverride) {
     		HUDCaching.renderHelmetCaptured = true;
         	ci.cancel();
-            return;
         }
 
-        if (ModStatus.isHoloInventoryLoaded){
-            Renderer.INSTANCE.angelicaOverride = true;
-        }
+        HUDCaching.disableHoloInventory();
     }
 
     @Inject(method = "renderPortal", at = @At("HEAD"), cancellable = true, remap = false)

--- a/src/main/java/com/gtnewhorizons/angelica/mixins/early/angelica/hudcaching/RenderGameOverlayEventAccessor.java
+++ b/src/main/java/com/gtnewhorizons/angelica/mixins/early/angelica/hudcaching/RenderGameOverlayEventAccessor.java
@@ -1,0 +1,12 @@
+package com.gtnewhorizons.angelica.mixins.early.angelica.hudcaching;
+
+import net.minecraftforge.client.event.RenderGameOverlayEvent;
+import net.minecraftforge.event.terraingen.BiomeEvent;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(RenderGameOverlayEvent.class)
+public interface RenderGameOverlayEventAccessor {
+    @Accessor(value = "partialTicks", remap = false)
+    void setPartialTicks(float value);
+}

--- a/src/main/resources/META-INF/angelica_at.cfg
+++ b/src/main/resources/META-INF/angelica_at.cfg
@@ -49,3 +49,5 @@ public net.minecraft.client.gui.GuiSlot func_148121_k()V # void bindAmountScroll
 public net.minecraft.client.gui.GuiSlot func_148136_c(IIII)V # void overlayBackground()
 
 public net.minecraft.util.MathHelper func_151241_e(I)I # int calculateLogBaseTwoDeBruijn()
+
+


### PR DESCRIPTION
Depends on https://github.com/GTNewHorizons/HoloInventory/pull/42

Fixes https://github.com/GTNewHorizons/Angelica/issues/223
Fixes https://github.com/GTNewHorizons/Angelica/issues/413

HoloInventory:
Controls a flag that determines when the inventory is rendered so that it can be rendered every tick instead of being cached


Xaeros Minimap:
The waypoints were being rendering at the start of renderGameOverlay which is not called every frame with HUD caching enabled.
This removes the ASM transformer and calls it every frame instead.

![image](https://github.com/GTNewHorizons/Angelica/assets/18713839/3a49432f-f7a0-4208-b524-d65f94446c21)

