### PR TITLE
Check if hudcaching is enabled before removing xaeros ASM

### DIFF
--- a/src/main/java/com/gtnewhorizons/angelica/loading/MixinCompatHackTweaker.java
+++ b/src/main/java/com/gtnewhorizons/angelica/loading/MixinCompatHackTweaker.java
@@ -26,7 +26,10 @@ public class MixinCompatHackTweaker implements ITweaker {
             LOGGER.info("Disabling Optifine and Fastcraft (if present)");
             disableOptifineAndFastcraft();
         }
-        disableXaerosMinimapWaypointTransformer();
+
+        if (AngelicaConfig.enableHudCaching){
+            disableXaerosMinimapWaypointTransformer();
+        }
     }
 
     private void verifyDependencies() {


### PR DESCRIPTION
Fixes a bug where waypoints wouldnt render because we removed the ASM, but never called it because its in the HudCaching mixins