### PR TITLE
Fix render distance being capped at 20

### DIFF
--- a/src/main/java/com/gtnewhorizons/angelica/mixins/Mixins.java
+++ b/src/main/java/com/gtnewhorizons/angelica/mixins/Mixins.java
@@ -113,6 +113,7 @@ public enum Mixins {
             ,"sodium.MixinLongHashMap"
             ,"sodium.MixinRender"
             ,"sodium.MixinRenderingRegistry"
+            ,"sodium.MixinPlayerManager"
         )
     ),
 

--- a/src/main/java/com/gtnewhorizons/angelica/mixins/early/sodium/MixinPlayerManager.java
+++ b/src/main/java/com/gtnewhorizons/angelica/mixins/early/sodium/MixinPlayerManager.java
@@ -1,22 +1,11 @@
 package com.gtnewhorizons.angelica.mixins.early.sodium;
 
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
-
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
-import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.ModifyArgs;
 import org.spongepowered.asm.mixin.injection.invoke.arg.Args;
 
-import com.gtnewhorizons.angelica.loading.AngelicaTweaker;
-
-import org.spongepowered.asm.mixin.injection.At;
-
-import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.server.management.PlayerManager;
-import net.minecraft.util.MathHelper;
 
 @Mixin(PlayerManager.class)
 public class MixinPlayerManager {

--- a/src/main/java/com/gtnewhorizons/angelica/mixins/early/sodium/MixinPlayerManager.java
+++ b/src/main/java/com/gtnewhorizons/angelica/mixins/early/sodium/MixinPlayerManager.java
@@ -1,0 +1,29 @@
+package com.gtnewhorizons.angelica.mixins.early.sodium;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.ModifyArgs;
+import org.spongepowered.asm.mixin.injection.invoke.arg.Args;
+
+import com.gtnewhorizons.angelica.loading.AngelicaTweaker;
+
+import org.spongepowered.asm.mixin.injection.At;
+
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.server.management.PlayerManager;
+import net.minecraft.util.MathHelper;
+
+@Mixin(PlayerManager.class)
+public class MixinPlayerManager {
+
+    @ModifyArgs(method = "func_152622_a(I)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/util/MathHelper;clamp_int(III)I"))
+    public void clamp_int(Args args) {
+        args.set(2, 32);
+    }
+
+}


### PR DESCRIPTION
This PR fixes an issue where if you set your render distance >20, the game will not load any chunks more than 20 chunks away. This can be verified by checking the number of loaded chunk segments in the F3 debug view after changing the render distance, any render distance above 20 will report 26,896 segments loaded.