### PR TITLE
Only disable holoinventory when hudcaching is enabled

### DIFF
--- a/src/main/java/com/gtnewhorizons/angelica/hudcaching/HUDCaching.java
+++ b/src/main/java/com/gtnewhorizons/angelica/hudcaching/HUDCaching.java
@@ -248,7 +248,7 @@ public class HUDCaching {
     // moved to here due to the method being called from a mixin
     public static void disableHoloInventory() {
         if (ModStatus.isHoloInventoryLoaded){
-            Renderer.INSTANCE.angelicaOverride = true;
+            Renderer.INSTANCE.angelicaOverride = isEnabled;
         }
     }
 


### PR DESCRIPTION
Fixes part of https://github.com/GTNewHorizons/Angelica/issues/431  

Unable to replicate the issues with items rotating in a dev environment or in the full pack