### PR TITLE
Fix glMultMatrix using the wrong variable for multiplication

### DIFF
--- a/src/main/java/com/gtnewhorizons/angelica/glsm/GLStateManager.java
+++ b/src/main/java/com/gtnewhorizons/angelica/glsm/GLStateManager.java
@@ -1112,8 +1112,8 @@ public class GLStateManager {
     }
 
     public static void glLoadMatrix(DoubleBuffer m) {
-        conersionMatrix4d.set(m);
-        getMatrixStack().set(conersionMatrix4d);
+        conversionMatrix4d.set(m);
+        getMatrixStack().set(conversionMatrix4d);
         GL11.glLoadMatrix(m);
     }
 
@@ -1163,13 +1163,13 @@ public class GLStateManager {
         getMatrixStack().mul(tempMatrix4f);
     }
 
-    public static final Matrix4d conersionMatrix4d = new Matrix4d();
-    public static final Matrix4f conersionMatrix4f = new Matrix4f();
+    public static final Matrix4d conversionMatrix4d = new Matrix4d();
+    public static final Matrix4f conversionMatrix4f = new Matrix4f();
     public static void glMultMatrix(DoubleBuffer matrix) {
         GL11.glMultMatrix(matrix);
-        conersionMatrix4d.set(matrix);
-        conersionMatrix4f.set(conersionMatrix4d);
-        getMatrixStack().mul(conersionMatrix4f);
+        conversionMatrix4d.set(matrix);
+        conversionMatrix4f.set(conversionMatrix4d);
+        getMatrixStack().mul(conversionMatrix4f);
     }
 
     private static final Vector3f rotation = new Vector3f();

--- a/src/main/java/com/gtnewhorizons/angelica/glsm/GLStateManager.java
+++ b/src/main/java/com/gtnewhorizons/angelica/glsm/GLStateManager.java
@@ -1160,7 +1160,7 @@ public class GLStateManager {
     public static void glMultMatrix(FloatBuffer floatBuffer) {
         GL11.glMultMatrix(floatBuffer);
         tempMatrix4f.set(floatBuffer);
-        getMatrixStack().mul(conersionMatrix4f);
+        getMatrixStack().mul(tempMatrix4f);
     }
 
     public static final Matrix4d conersionMatrix4d = new Matrix4d();


### PR DESCRIPTION
A copy-paste mistake caused the wrong matrix to be used for glMultMatrix float overload, leading to random garbage matrices being loaded.
Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/15957