### PR TITLE
Small NotFine style settings menu fix

### DIFF
--- a/src/main/java/com/gtnewhorizons/angelica/render/CloudRenderer.java
+++ b/src/main/java/com/gtnewhorizons/angelica/render/CloudRenderer.java
@@ -30,7 +30,6 @@ import com.gtnewhorizons.angelica.glsm.TessellatorManager;
 import com.gtnewhorizons.angelica.glsm.VBOManager;
 import jss.notfine.core.Settings;
 import jss.notfine.gui.options.named.GraphicsQualityOff;
-import me.jellysquid.mods.sodium.client.SodiumClientMod;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.EntityRenderer;
 import net.minecraft.client.renderer.OpenGlHelper;

--- a/src/main/java/jss/notfine/gui/NotFineGameOptionPages.java
+++ b/src/main/java/jss/notfine/gui/NotFineGameOptionPages.java
@@ -257,7 +257,7 @@ public class NotFineGameOptionPages {
                 .setBinding((opts, value) -> opts.anaglyph = value, opts -> opts.anaglyph)
                 .setImpact(OptionImpact.HIGH)
                 .setFlags(OptionFlag.REQUIRES_RENDERER_RELOAD)
-                .setEnabled(NotFineConfig.allowAdvancedOpenGL)
+                .setEnabled(NotFineConfig.allowToggle3DAnaglyph)
                 .build())
             .add(OptionImpl.createBuilder(boolean.class, vanillaOpts)
                 .setName(I18n.format("options.showCape"))


### PR DESCRIPTION
 The Sodium style menu did not have a similar problem.
Uses allowToggle3DAnaglyph instead of allowAdvancedOpenGL for 3D Anaglyph 