### PR TITLE
Mark chunk graph as dirty when FOV changes

### DIFF
--- a/src/main/java/com/gtnewhorizons/angelica/mixins/early/angelica/MixinEntityRenderer.java
+++ b/src/main/java/com/gtnewhorizons/angelica/mixins/early/angelica/MixinEntityRenderer.java
@@ -7,6 +7,7 @@ import net.minecraft.entity.EntityLivingBase;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(EntityRenderer.class)
@@ -23,4 +24,9 @@ public abstract class MixinEntityRenderer {
         );
     }
 
+    @ModifyArg(method = "setupCameraTransform", at = @At(value = "INVOKE", target = "Lorg/lwjgl/util/glu/Project;gluPerspective(FFFF)V", ordinal = 0), index = 0)
+    private float captureFov(float fov) {
+        RenderingState.INSTANCE.setFov(fov);
+        return fov;
+    }
 }

--- a/src/main/java/com/gtnewhorizons/angelica/rendering/RenderingState.java
+++ b/src/main/java/com/gtnewhorizons/angelica/rendering/RenderingState.java
@@ -2,6 +2,7 @@ package com.gtnewhorizons.angelica.rendering;
 
 import com.gtnewhorizons.angelica.glsm.GLStateManager;
 import lombok.Getter;
+import lombok.Setter;
 import org.joml.Matrix4f;
 import org.joml.Vector3d;
 import org.lwjgl.BufferUtils;
@@ -21,6 +22,9 @@ public class RenderingState {
     private final Matrix4f projectionMatrix = new Matrix4f().identity();
     @Getter
     private final Matrix4f modelViewMatrix = new Matrix4f().identity();
+    @Getter
+    @Setter
+    private float fov;
 
 
     public void setCameraPosition(double x, double y, double z) {

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/SodiumWorldRenderer.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/SodiumWorldRenderer.java
@@ -7,6 +7,7 @@ import com.gtnewhorizons.angelica.compat.toremove.RenderLayer;
 import com.gtnewhorizons.angelica.config.AngelicaConfig;
 import com.gtnewhorizons.angelica.dynamiclights.DynamicLights;
 import com.gtnewhorizons.angelica.glsm.GLStateManager;
+import com.gtnewhorizons.angelica.rendering.RenderingState;
 import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
 import it.unimi.dsi.fastutil.longs.LongSet;
 import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
@@ -64,6 +65,7 @@ public class SodiumWorldRenderer implements ChunkStatusListener {
     private int renderDistance;
 
     private double lastCameraX, lastCameraY, lastCameraZ;
+    private float lastFov;
     private double lastCameraPitch, lastCameraYaw;
     private float lastFogDistance;
 
@@ -213,8 +215,10 @@ public class SodiumWorldRenderer implements ChunkStatusListener {
 
         float fogDistance = FogHelper.getFogCutoff();
 
+        float fov = RenderingState.INSTANCE.getFov();
+
         boolean dirty = pos.x != this.lastCameraX || pos.y != this.lastCameraY || pos.z != this.lastCameraZ ||
-                pitch != this.lastCameraPitch || yaw != this.lastCameraYaw || fogDistance != this.lastFogDistance;
+                pitch != this.lastCameraPitch || yaw != this.lastCameraYaw || fogDistance != this.lastFogDistance || fov != this.lastFov;
 
         if(AngelicaConfig.enableIris) {
             iris$ensureStateSwapped();
@@ -232,6 +236,7 @@ public class SodiumWorldRenderer implements ChunkStatusListener {
         this.lastCameraPitch = pitch;
         this.lastCameraYaw = yaw;
         this.lastFogDistance = fogDistance;
+        this.lastFov = fov;
 
         profiler.endStartSection("chunk_update");
 


### PR DESCRIPTION
This fixes chunks outside the old FOV remaining invisible until the graph is marked dirty through other means (such as turning the camera).

An easy way to reproduce the issue is to pause the game and then increase the FOV from default to Quake Pro.