### PR TITLE
Fixed crash with EndlessIDs when joining a multiplayer server

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -78,8 +78,8 @@ dependencies {
     compileOnly("com.github.GTNewHorizons:TinkersConstruct:1.12.0-GTNH:dev")
     compileOnly("com.github.GTNewHorizons:Natura:2.6.1:dev")
 
-    compileOnly("com.falsepattern:chunkapi-mc1.7.10:0.5.0:api") { transitive = false }
-    compileOnly("com.falsepattern:endlessids-mc1.7.10:1.5-beta0002:dev") { transitive = false }
+    compileOnly("com.falsepattern:chunkapi-mc1.7.10:0.5.1:api") { transitive = false }
+    compileOnly("com.falsepattern:endlessids-mc1.7.10:1.5-beta0003:dev") { transitive = false }
 
     compileOnly(rfg.deobf("curse.maven:extrautils-225561:2264383"))
     compileOnly(rfg.deobf("curse.maven:dynamiclights-227874:2337326"))

--- a/src/main/java/com/gtnewhorizons/angelica/compat/endlessids/EndlessIDsCompat.java
+++ b/src/main/java/com/gtnewhorizons/angelica/compat/endlessids/EndlessIDsCompat.java
@@ -1,0 +1,37 @@
+package com.gtnewhorizons.angelica.compat.endlessids;
+
+import com.falsepattern.endlessids.mixin.helpers.ChunkBiomeHook;
+import lombok.val;
+
+import net.minecraft.world.chunk.Chunk;
+
+import static com.falsepattern.endlessids.constants.ExtendedConstants.biomeIDMask;
+import static com.falsepattern.endlessids.constants.ExtendedConstants.biomeIDNull;
+
+public class EndlessIDsCompat {
+    public static void sodium$populateBiomes(Chunk chunk) {
+        if (!(chunk instanceof ChunkBiomeHook hook))
+            return;
+
+        val biomes = hook.getBiomeShortArray();
+        if (biomes == null)
+            return;
+
+        val cX = chunk.xPosition << 4;
+        val cZ = chunk.zPosition << 4;
+
+        val manager = chunk.worldObj.getWorldChunkManager();
+        for(var z = 0; z < 16; z++) {
+            for(var x = 0; x < 16; x++) {
+                val idx = (z << 4) + x;
+                val biome = biomes[idx] & biomeIDMask;
+                if(biome == biomeIDNull) {
+                    val generated = manager.getBiomeGenAt(cX + x, cZ + z);
+                    if (generated == null)
+                        continue;
+                    biomes[idx] = (short)(generated.biomeID & biomeIDMask);
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/com/gtnewhorizons/angelica/mixins/early/sodium/MixinChunk.java
+++ b/src/main/java/com/gtnewhorizons/angelica/mixins/early/sodium/MixinChunk.java
@@ -5,6 +5,9 @@ import net.minecraft.world.World;
 import net.minecraft.world.biome.BiomeGenBase;
 import net.minecraft.world.biome.WorldChunkManager;
 import net.minecraft.world.chunk.Chunk;
+
+import com.gtnewhorizons.angelica.compat.ModStatus;
+import com.gtnewhorizons.angelica.compat.endlessids.EndlessIDsCompat;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -29,14 +32,18 @@ public abstract class MixinChunk {
         if(this.worldObj.isRemote && !Minecraft.getMinecraft().isSingleplayer()) {
             // We are in multiplayer, the server might not have sent all biomes to the client.
             // Populate them now while we're on the main thread.
-            WorldChunkManager manager =  this.worldObj.getWorldChunkManager();
-            for(int z = 0; z < 16; z++) {
-                for(int x = 0; x < 16; x++) {
-                    int idx = (z << 4) + x;
-                    int biome = this.blockBiomeArray[idx] & 255;
-                    if(biome == 255) {
-                        BiomeGenBase generated = manager.getBiomeGenAt((this.xPosition << 4) + x, (this.zPosition << 4) + z);
-                        this.blockBiomeArray[idx] = (byte)(generated.biomeID & 255);
+            if (ModStatus.isEIDBiomeLoaded) {
+                EndlessIDsCompat.sodium$populateBiomes((Chunk) (Object) this);
+            } else {
+                WorldChunkManager manager = this.worldObj.getWorldChunkManager();
+                for (int z = 0; z < 16; z++) {
+                    for (int x = 0; x < 16; x++) {
+                        int idx = (z << 4) + x;
+                        int biome = this.blockBiomeArray[idx] & 255;
+                        if (biome == 255) {
+                            BiomeGenBase generated = manager.getBiomeGenAt((this.xPosition << 4) + x, (this.zPosition << 4) + z);
+                            this.blockBiomeArray[idx] = (byte) (generated.biomeID & 255);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Fixes `java.lang.NullPointerException: Cannot load from byte/boolean array because "this.field_76651_r" is null` when joining a server with EndlessIDs biome ID extension module enabled.

Related issue in EndlessIDs: https://github.com/GTMEGA/EndlessIDs/issues/180

Also bumped the ChunkAPI/EndlessIDs dependencies, so Angelica now compiles against the fully FOSS versions.