### PR TITLE
Fix culling state leaking and giving graphical issues

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/render/SodiumWorldRenderer.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/SodiumWorldRenderer.java
@@ -269,6 +269,10 @@ public class SodiumWorldRenderer implements ChunkStatusListener {
      * Performs a render pass for the given {@link RenderLayer} and draws all visible chunks for it.
      */
     public void drawChunkLayer(BlockRenderPass pass, MatrixStack matrixStack, double x, double y, double z) {
+        // This fix a long-standing issue with culling state leaking because of mods,
+        // or other factors as having clouds disabled.
+        GLStateManager.enableCull();
+
         if(AngelicaConfig.enableIris) iris$ensureStateSwapped();
         // startDrawing/endDrawing are handled by 1.7 already
         // pass.startDrawing();


### PR DESCRIPTION
It appears that for some reason, possibly because of the difference in rendering with vanilla, the OpenGL culling state gets leaked sometimes. Issue that can occur with clouds disabled or with the combination of other mods which produce graphical issues and reduced GPU performance. 

Comparison below with OpenGL back-face culling ON and OFF before drawing:

**OFF**:
![2024-08-31_12 51 17](https://github.com/user-attachments/assets/f40711f2-2b00-4d27-9b67-f5613636e3fc)

**ON**:
![2024-08-31_12 52 12](https://github.com/user-attachments/assets/d0c4ac85-8e31-4f6e-887f-6f6c70a5033a)
