### PR TITLE
Handle FMLRenderAccessLibrary obfuscation properly

### DIFF
--- a/src/mixin/java/com/gtnewhorizons/angelica/mixins/early/sodium/MixinRenderBlocks.java
+++ b/src/mixin/java/com/gtnewhorizons/angelica/mixins/early/sodium/MixinRenderBlocks.java
@@ -32,6 +32,18 @@ public abstract class MixinRenderBlocks {
         this.isRenderingByType = false;
     }
 
+    /**
+     * This mixin and the one below(wrapRenderWorldBlockDeobfuscated) achieve the same goal. The goal is to wrap ISBRH rendering in a try/catch
+     * to ignore NPE, as mods commonly like to not null-guard the tile entity casting, and Sodium introduces a race condition where when a block
+     * is broken, the TE can be removed from the world before the render thread gets to it, but the block data is deep copied to the thread, so
+     * it still tries to render the block.
+
+     * The reason there's two mixins to the same thing for this, is because FMLRenderAccessLibrary is an old Forge remnant of Optifine compat
+     * whereby they provided this class for Optifine to be able to access Forge's rendering methods. For some reason, in a deobfuscated environment,
+     * that class lives in net.minecraft.src.FMLRenderAccessLibrary. However in an obfuscated prod environment, it gets moved into the root unnamed
+     * package. So basically, only one of these two redirects will actually end up getting applied, and the other will fail, based on what environment
+     * you're running in.
+     */
     @Redirect(
         method = "renderBlockByRenderType",
         at = @At(


### PR DESCRIPTION
`FMLRenderAccessLibrary` is a bit of a special class.

It would seem due to some kind of version mismatch between obfuscated and deobfuscated environments. During deobfuscated runs this class is in `net.minecraft.src`, but in obfuscated it is moved into the unnamed root package.

This adds two separate mixins to handle this for each environment, they have been set to be allowed to fail, so if they fail to apply they will not throw an error, even in the presence of mixin debug being enabled and enforcing apply counts.