### PR TITLE
fix entities being rendered completely black

### DIFF
--- a/src/mixin/java/com/gtnewhorizons/angelica/mixins/early/shaders/MixinRendererLivingEntity.java
+++ b/src/mixin/java/com/gtnewhorizons/angelica/mixins/early/shaders/MixinRendererLivingEntity.java
@@ -24,7 +24,7 @@ public class MixinRendererLivingEntity {
         final float r = (j >> 16 & 255) / 255.0F;
         final float g = (j >> 8 & 255) / 255.0F;
         final float b = (j & 255) / 255.0F;
-        CapturedRenderingState.INSTANCE.setCurrentEntityColor(r, g, b, 1.0F - a);
+        CapturedRenderingState.INSTANCE.setCurrentEntityColor(r, g, b, a);
         return j;
     }
 


### PR DESCRIPTION
Currently when the creeper fusing animation triggers (either by exploding, or by taking damage), all entities will get rendered completely black the shader is reloaded:

https://github.com/user-attachments/assets/8c822336-6436-4d11-bd07-a3cf650ce6a2

Not sure why it even was `1 - alpha` as the default value for alpha that `getColorMultiplier` returns is 0.
Without it, it looks correct:

https://github.com/user-attachments/assets/93f16ebc-2d01-474f-a6ac-16b444dd4b45

