### PR TITLE
fix in-world text rendering + GL immediate mode rendering

### DIFF
--- a/src/main/java/com/gtnewhorizons/angelica/glsm/GLStateManager.java
+++ b/src/main/java/com/gtnewhorizons/angelica/glsm/GLStateManager.java
@@ -971,6 +971,20 @@ public class GLStateManager {
         GL11.glDrawBuffer(mode);
     }
 
+    public static void glDrawElements(int mode, IntBuffer indices) {
+        if(AngelicaConfig.enableIris) {
+            Iris.getPipelineManager().getPipeline().ifPresent(WorldRenderingPipeline::syncProgram);
+        }
+        GL11.glDrawElements(mode, indices);
+    }
+
+    public static void glBegin(int mode) {
+        if (AngelicaConfig.enableIris) {
+            Iris.getPipelineManager().getPipeline().ifPresent(WorldRenderingPipeline::syncProgram);
+        }
+        GL11.glBegin(mode);
+    }
+
     public static void glLogicOp(int opcode) {
         GL11.glLogicOp(opcode);
     }

--- a/src/main/java/com/gtnewhorizons/angelica/transform/RedirectorTransformer.java
+++ b/src/main/java/com/gtnewhorizons/angelica/transform/RedirectorTransformer.java
@@ -97,6 +97,7 @@ public class RedirectorTransformer implements IClassTransformer {
         glCapRedirects.put(org.lwjgl.opengl.GL11.GL_SCISSOR_TEST, "ScissorTest");
         methodRedirects.put(GL11, RedirectMap.newMap()
             .add("glAlphaFunc")
+            .add("glBegin")
             .add("glBindTexture")
             .add("glBlendFunc")
             .add("glCallList")
@@ -119,6 +120,7 @@ public class RedirectorTransformer implements IClassTransformer {
             .add("glDepthRange")
             .add("glDrawArrays")
             .add("glDrawBuffer")
+            .add("glDrawElements")
             .add("glEdgeFlag")
             .add("glEndList")
             .add("glFog")


### PR DESCRIPTION
`glBegin` and `glDrawElements` did not call `WorldRenderingPipeline::syncProgram` which caused everything that used those calls to render in the wrong state.
In 1.16 mc seems to only have used glDrawArrays, which is probably why this was overlooked.

I only added these two for now, as they seem to be the only ones used.