### PR TITLE
implement Iris HandRenderer

### DIFF
--- a/src/main/java/com/gtnewhorizons/angelica/mixins/Mixins.java
+++ b/src/main/java/com/gtnewhorizons/angelica/mixins/Mixins.java
@@ -143,6 +143,7 @@ public enum Mixins {
             ,"shaders.MixinGuiIngameForge"
             ,"shaders.MixinFramebuffer"
             ,"shaders.MixinItem"
+            ,"shaders.MixinItemRenderer"
             ,"shaders.MixinLocale"
             ,"shaders.MixinOpenGlHelper"
             ,"shaders.MixinRender"

--- a/src/main/resources/META-INF/angelica_at.cfg
+++ b/src/main/resources/META-INF/angelica_at.cfg
@@ -1,6 +1,13 @@
 public net.minecraft.block.Block func_149641_N()Ljava/lang/String; # getTextureName
 
 public net.minecraft.client.renderer.EntityRenderer func_78476_b(FI)V # void renderHand(float, int)
+public net.minecraft.client.renderer.EntityRenderer func_78481_a(FZ)F # float getFOVModifier(float, boolean)
+public net.minecraft.client.renderer.EntityRenderer func_78482_e(F)V # void hurtCameraEffect(float)
+public net.minecraft.client.renderer.EntityRenderer func_78475_f(F)V # void setupViewBobbing(float)
+public net.minecraft.client.renderer.EntityRenderer field_78503_V # cameraZoom
+public net.minecraft.client.renderer.EntityRenderer field_78502_W # cameraYaw
+public net.minecraft.client.renderer.EntityRenderer field_78509_X # cameraPitch
+public net.minecraft.client.renderer.EntityRenderer field_78530_s # farPlaneDistance
 
 public net.minecraft.client.renderer.RenderGlobal field_72765_l # worldRenderers
 

--- a/src/mixin/java/com/gtnewhorizons/angelica/mixins/early/shaders/MixinItemRenderer.java
+++ b/src/mixin/java/com/gtnewhorizons/angelica/mixins/early/shaders/MixinItemRenderer.java
@@ -1,0 +1,26 @@
+package com.gtnewhorizons.angelica.mixins.early.shaders;
+
+import com.gtnewhorizons.angelica.compat.mojang.InteractionHand;
+import net.coderbot.iris.pipeline.HandRenderer;
+import net.irisshaders.iris.api.v0.IrisApi;
+import net.minecraft.client.renderer.ItemRenderer;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(ItemRenderer.class)
+public class MixinItemRenderer {
+    @Inject(method = "renderItemInFirstPerson", at = @At("HEAD"), cancellable = true)
+    private void iris$skipTranslucentHands(float partialTicks, CallbackInfo ci) {
+        if (IrisApi.getInstance().isShaderPackInUse()) {
+            // TODO: Offhand
+            boolean isHandTranslucent = HandRenderer.INSTANCE.isHandTranslucent(InteractionHand.MAIN_HAND);
+            if (HandRenderer.INSTANCE.isRenderingSolid() && isHandTranslucent) {
+                ci.cancel();
+            } else if (!HandRenderer.INSTANCE.isRenderingSolid() && !isHandTranslucent) {
+                ci.cancel();
+            }
+        }
+    }
+}

--- a/src/mixin/java/com/gtnewhorizons/angelica/mixins/early/sodium/MixinRenderGlobal.java
+++ b/src/mixin/java/com/gtnewhorizons/angelica/mixins/early/sodium/MixinRenderGlobal.java
@@ -154,13 +154,14 @@ public class MixinRenderGlobal implements IRenderGlobalExt {
             if(pass == 0) {
                 pipeline.setPhase(WorldRenderingPhase.TERRAIN_CUTOUT);
             } else if(pass == 1) {
-                pipeline.setPhase(WorldRenderingPhase.TERRAIN_TRANSLUCENT);
                 final Camera camera = new Camera(mc.renderViewEntity, (float) partialTicks);
 
                 // iris$beginTranslucents
                 pipeline.beginHand();
-                HandRenderer.INSTANCE.renderSolid(null /*poseStack*/, (float) partialTicks, camera, mc.renderGlobal, pipeline);
+                HandRenderer.INSTANCE.renderSolid((float) partialTicks, camera, mc.renderGlobal, pipeline);
+
                 mc.mcProfiler.endStartSection("iris_pre_translucent");
+                pipeline.setPhase(WorldRenderingPhase.TERRAIN_TRANSLUCENT);
                 pipeline.beginTranslucents();
                 this.renderEngine.bindTexture(TextureMap.locationBlocksTexture);
             }


### PR DESCRIPTION
This fixes:
- shaders applying to stuff rendered in the WorldRenderLast forge event (and therefore waypoints being blindingly bright)
- shaders applying to overlays (water overlay etc.)
- held items being rendered transparent sometimes (maybe, couldnt test)