### PR TITLE
Properly set frame start time for Iris

### DIFF
--- a/src/mixin/java/com/gtnewhorizons/angelica/mixins/early/shaders/MixinEntityRenderer.java
+++ b/src/mixin/java/com/gtnewhorizons/angelica/mixins/early/shaders/MixinEntityRenderer.java
@@ -35,7 +35,7 @@ public abstract class MixinEntityRenderer implements IResourceManagerReloadListe
     private void iris$beginRender(float partialTicks, long startTime, CallbackInfo ci, @Share("pipeline") LocalRef<WorldRenderingPipeline> pipeline) {
         CapturedRenderingState.INSTANCE.setTickDelta(partialTicks);
         SystemTimeUniforms.COUNTER.beginFrame();
-        SystemTimeUniforms.TIMER.beginFrame(startTime);
+        SystemTimeUniforms.TIMER.beginFrame(System.nanoTime());
 
         Program.unbind();
 


### PR DESCRIPTION
We were previously capturing the frame start time using a mostly broken garbage variable captured from vanilla MC code which was incorrect. Modern Iris/MC uses GLFW's nano time function for this, but since LWJGL2 does not have this, I've made it use `System.nanoTime()`.

This should fix most "waving" and animated things in shaders which are not based on world time. Things like waving leaves, water, foliage, etc