### PR TITLE
Add reserved keywords and replace GLSLPreParser with regex

### DIFF
--- a/src/main/java/net/coderbot/iris/pipeline/transform/ShaderTransformer.java
+++ b/src/main/java/net/coderbot/iris/pipeline/transform/ShaderTransformer.java
@@ -151,9 +151,14 @@ public class ShaderTransformer {
 
             String profileString = "#version " + versionString + " " + profile + "\n";
 
-            for (String reservedWord : reservedWords) {
-                String newName = "iris_renamed_" + reservedWord;
-                input = input.replaceAll("\\b" + reservedWord + "\\b", newName);
+            // This handles some reserved keywords which cause the AST parser to fail
+            // but aren't necessarily invalid for GLSL versions prior to 400. This simple
+            // renames the matching strings and prefixes them with iris_renamed_
+            if (versionInt < 400) {
+                for (String reservedWord : reservedWords) {
+                    String newName = "iris_renamed_" + reservedWord;
+                    input = input.replaceAll("\\b" + reservedWord + "\\b", newName);
+                }
             }
 
             GLSLLexer lexer = new GLSLLexer(CharStreams.fromString(input));

--- a/src/main/java/net/coderbot/iris/pipeline/transform/ShaderTransformer.java
+++ b/src/main/java/net/coderbot/iris/pipeline/transform/ShaderTransformer.java
@@ -149,7 +149,7 @@ public class ShaderTransformer {
                 }
             }
 
-            String profileString = "#version " + versionString + " " + profile;
+            String profileString = "#version " + versionString + " " + profile + "\n";
 
             for (String reservedWord : reservedWords) {
                 String newName = "iris_renamed_" + reservedWord;


### PR DESCRIPTION
Handles reserved keywords like `sample` and `texture` in GLSL by renaming with a simple string match. This is done prior to AST transformation by glsl-transformation-lib.

It also removes GLSLPreParser from glsl-transformation-lib, which was only used to parse out the version/profile from each shader. Instead it has been replaced with a regex based version. The GLSLPreParser has a bug which when it uses the same lexer as the rest of the parsing, causes the first node in the parsetree to be removed/missed.

This can probably be fixed in glsl-transformation-lib, but it's overkill probably for parsing out the version string anyways. Iris was using regex for this prior to switching to glsl-transformation-lib anyways.