### PR TITLE
Forcibly disable separateAo

### DIFF
--- a/src/main/java/net/coderbot/iris/shaderpack/PackDirectives.java
+++ b/src/main/java/net/coderbot/iris/shaderpack/PackDirectives.java
@@ -71,7 +71,7 @@ public class PackDirectives {
 		sun = properties.getSun().orElse(true);
 		moon = properties.getMoon().orElse(true);
 		rainDepth = properties.getRainDepth().orElse(false);
-		separateAo = properties.getSeparateAo().orElse(false);
+		separateAo = false; //properties.getSeparateAo().orElse(false);
 		oldLighting = properties.getOldLighting().orElse(false);
 		concurrentCompute = properties.getConcurrentCompute().orElse(false);
 		oldHandLight = properties.getOldHandLight().orElse(true);


### PR DESCRIPTION
Disabling this entirely until we have a fix, no reason to use it outside of dev environment right now