### PR TITLE
Add a config to the total world time patch

### DIFF
--- a/src/main/java/com/gtnewhorizons/angelica/config/AngelicaConfig.java
+++ b/src/main/java/com/gtnewhorizons/angelica/config/AngelicaConfig.java
@@ -138,6 +138,11 @@ public class AngelicaConfig {
     @Config.RangeInt(min = 32, max = 2048)
     public static int droppedItemLimit;
 
+    @Config.Comment("Use total world time instead of normal world time. Allows most shader animations to play when "
+                  + "doDaylightCycle is off, but causes shader animations to desync from time of day.")
+    @Config.DefaultBoolean(false)
+    public static boolean useTotalWorldTime;
+
     @Config.Comment("Enable Debug Logging")
     @Config.DefaultBoolean(false)
     @Config.RequiresMcRestart

--- a/src/main/java/net/coderbot/iris/gl/program/ProgramUniforms.java
+++ b/src/main/java/net/coderbot/iris/gl/program/ProgramUniforms.java
@@ -1,9 +1,15 @@
 package net.coderbot.iris.gl.program;
 
-import static com.gtnewhorizons.angelica.config.AngelicaConfig.useTotalWorldTime;
-
 import com.google.common.collect.ImmutableList;
+import com.gtnewhorizons.angelica.config.AngelicaConfig;
 import com.gtnewhorizons.angelica.glsm.RenderSystem;
+import java.nio.IntBuffer;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.OptionalInt;
 import net.coderbot.iris.Iris;
 import net.coderbot.iris.gl.state.ValueUpdateNotifier;
 import net.coderbot.iris.gl.uniform.DynamicLocationalUniformHolder;
@@ -19,14 +25,6 @@ import org.lwjgl.opengl.ARBShaderImageLoadStore;
 import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.GL20;
 import org.lwjgl.opengl.GL30;
-
-import java.nio.IntBuffer;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.OptionalInt;
 
 public class ProgramUniforms {
 	private static ProgramUniforms active;
@@ -57,7 +55,7 @@ public class ProgramUniforms {
 	private static long getCurrentTick() {
         final WorldClient world = Minecraft.getMinecraft().theWorld;
 		if (world != null) {
-            return useTotalWorldTime
+            return AngelicaConfig.useTotalWorldTime
                 ? world.getWorldTime()
                 : world.getTotalWorldTime();
 		} else {

--- a/src/main/java/net/coderbot/iris/gl/program/ProgramUniforms.java
+++ b/src/main/java/net/coderbot/iris/gl/program/ProgramUniforms.java
@@ -1,5 +1,7 @@
 package net.coderbot.iris.gl.program;
 
+import static com.gtnewhorizons.angelica.config.AngelicaConfig.useTotalWorldTime;
+
 import com.google.common.collect.ImmutableList;
 import com.gtnewhorizons.angelica.glsm.RenderSystem;
 import net.coderbot.iris.Iris;
@@ -11,6 +13,7 @@ import net.coderbot.iris.gl.uniform.UniformType;
 import net.coderbot.iris.gl.uniform.UniformUpdateFrequency;
 import net.coderbot.iris.uniforms.SystemTimeUniforms;
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.multiplayer.WorldClient;
 import org.lwjgl.BufferUtils;
 import org.lwjgl.opengl.ARBShaderImageLoadStore;
 import org.lwjgl.opengl.GL11;
@@ -52,8 +55,11 @@ public class ProgramUniforms {
 	}
 
 	private static long getCurrentTick() {
-		if (Minecraft.getMinecraft().theWorld != null) {
-			return Minecraft.getMinecraft().theWorld.getTotalWorldTime();
+        final WorldClient world = Minecraft.getMinecraft().theWorld;
+		if (world != null) {
+            return useTotalWorldTime
+                ? world.getWorldTime()
+                : world.getTotalWorldTime();
 		} else {
 			return 0L;
 		}

--- a/src/main/java/net/coderbot/iris/uniforms/HardcodedCustomUniforms.java
+++ b/src/main/java/net/coderbot/iris/uniforms/HardcodedCustomUniforms.java
@@ -1,10 +1,13 @@
 package net.coderbot.iris.uniforms;
 
+import static com.gtnewhorizons.angelica.config.AngelicaConfig.useTotalWorldTime;
+
 import com.gtnewhorizons.angelica.rendering.RenderingState;
 import net.coderbot.iris.gl.uniform.UniformHolder;
 import net.coderbot.iris.gl.uniform.UniformUpdateFrequency;
 import net.coderbot.iris.uniforms.transforms.SmoothedFloat;
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.multiplayer.WorldClient;
 import net.minecraft.entity.player.EntityPlayer;
 import org.joml.Math;
 import org.joml.Vector3d;
@@ -157,7 +160,8 @@ public class HardcodedCustomUniforms {
 	}
 
 	private static int getWorldDayTime() {
-        return (int) (Minecraft.getMinecraft().theWorld.getTotalWorldTime() % 24000L);
+        final WorldClient world = Minecraft.getMinecraft().theWorld;
+        return (int) ((useTotalWorldTime ? world.getWorldTime() : world.getTotalWorldTime()) % 24000L);
 //		Level level = Minecraft.getMinecraft().theWorld;
 //		long  timeOfDay = level.getDayTime();
 //		long dayTime = ((DimensionTypeAccessor) level.dimensionType()).getFixedTime().orElse(timeOfDay % 24000L);

--- a/src/main/java/net/coderbot/iris/uniforms/HardcodedCustomUniforms.java
+++ b/src/main/java/net/coderbot/iris/uniforms/HardcodedCustomUniforms.java
@@ -1,7 +1,6 @@
 package net.coderbot.iris.uniforms;
 
-import static com.gtnewhorizons.angelica.config.AngelicaConfig.useTotalWorldTime;
-
+import com.gtnewhorizons.angelica.config.AngelicaConfig;
 import com.gtnewhorizons.angelica.rendering.RenderingState;
 import net.coderbot.iris.gl.uniform.UniformHolder;
 import net.coderbot.iris.gl.uniform.UniformUpdateFrequency;
@@ -161,7 +160,7 @@ public class HardcodedCustomUniforms {
 
 	private static int getWorldDayTime() {
         final WorldClient world = Minecraft.getMinecraft().theWorld;
-        return (int) ((useTotalWorldTime ? world.getWorldTime() : world.getTotalWorldTime()) % 24000L);
+        return (int) ((AngelicaConfig.useTotalWorldTime ? world.getWorldTime() : world.getTotalWorldTime()) % 24000L);
 //		Level level = Minecraft.getMinecraft().theWorld;
 //		long  timeOfDay = level.getDayTime();
 //		long dayTime = ((DimensionTypeAccessor) level.dimensionType()).getFixedTime().orElse(timeOfDay % 24000L);

--- a/src/main/java/net/coderbot/iris/uniforms/WorldTimeUniforms.java
+++ b/src/main/java/net/coderbot/iris/uniforms/WorldTimeUniforms.java
@@ -1,12 +1,12 @@
 package net.coderbot.iris.uniforms;
 
+import static com.gtnewhorizons.angelica.config.AngelicaConfig.useTotalWorldTime;
+import static net.coderbot.iris.gl.uniform.UniformUpdateFrequency.PER_TICK;
+
+import java.util.Objects;
 import net.coderbot.iris.gl.uniform.UniformHolder;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.multiplayer.WorldClient;
-
-import java.util.Objects;
-
-import static net.coderbot.iris.gl.uniform.UniformUpdateFrequency.PER_TICK;
 
 public final class WorldTimeUniforms {
 	private WorldTimeUniforms() {
@@ -25,7 +25,8 @@ public final class WorldTimeUniforms {
 	}
 
 	static int getWorldDayTime() {
-    		return (int) (getWorld().getTotalWorldTime() % 24000L);
+        final WorldClient world = getWorld();
+        return (int) ((useTotalWorldTime ? world.getWorldTime() : world.getTotalWorldTime()) % 24000L);
 
     //  long dayTime = ((DimensionTypeAccessor) getWorld().dimensionType()).getFixedTime().orElse(timeOfDay % 24000L);
 	}

--- a/src/main/java/net/coderbot/iris/uniforms/WorldTimeUniforms.java
+++ b/src/main/java/net/coderbot/iris/uniforms/WorldTimeUniforms.java
@@ -1,8 +1,8 @@
 package net.coderbot.iris.uniforms;
 
-import static com.gtnewhorizons.angelica.config.AngelicaConfig.useTotalWorldTime;
 import static net.coderbot.iris.gl.uniform.UniformUpdateFrequency.PER_TICK;
 
+import com.gtnewhorizons.angelica.config.AngelicaConfig;
 import java.util.Objects;
 import net.coderbot.iris.gl.uniform.UniformHolder;
 import net.minecraft.client.Minecraft;
@@ -26,7 +26,7 @@ public final class WorldTimeUniforms {
 
 	static int getWorldDayTime() {
         final WorldClient world = getWorld();
-        return (int) ((useTotalWorldTime ? world.getWorldTime() : world.getTotalWorldTime()) % 24000L);
+        return (int) ((AngelicaConfig.useTotalWorldTime ? world.getWorldTime() : world.getTotalWorldTime()) % 24000L);
 
     //  long dayTime = ((DimensionTypeAccessor) getWorld().dimensionType()).getFixedTime().orElse(timeOfDay % 24000L);
 	}


### PR DESCRIPTION
Shaders will still desync from time of day, but only when the (default off) setting is enabled.