### PR TITLE
Cursor based positioning for shader setting tooltips

### DIFF
--- a/src/main/java/net/coderbot/iris/gui/screen/ShaderPackScreen.java
+++ b/src/main/java/net/coderbot/iris/gui/screen/ShaderPackScreen.java
@@ -140,8 +140,10 @@ public class ShaderPackScreen extends GuiScreen implements HudHideable {
             if (this.isDisplayingComment()) {
                 // Determine panel height and position
                 final int panelHeight = Math.max(50, 18 + (this.hoveredElementCommentBody.size() * 10));
-                final int x = (int) (0.5 * this.width) - 157;
-                final int y = this.height - (panelHeight + 4);
+                int x = mouseX + 5;
+                if (x + 314 >= (this.width - 4)) x = this.width - (318);
+                int y = mouseY + 8;
+                if (y + panelHeight >= (this.height - 4)) y = this.height - (panelHeight + 4);
                 // Draw panel
                 GuiUtil.drawPanel(x, y, COMMENT_PANEL_WIDTH, panelHeight);
                 // Draw text
@@ -381,7 +383,7 @@ public class ShaderPackScreen extends GuiScreen implements HudHideable {
         final ShaderPackEntry entry = this.shaderPackList.getSelected();
 
         if (entry == null) return;
-        
+
         this.shaderPackList.setApplied(entry);
 
         final String name = entry.getPackName();


### PR DESCRIPTION
Changes the tooltips of shader settings to follow the cursor(with screen edge boundary limits) instead of always rendering at the bottom middle of the screen.

Before:
![image](https://github.com/user-attachments/assets/a366df47-ef40-469b-a661-a24b4eea1950)


After:
![image](https://github.com/user-attachments/assets/c86ec292-66dc-4288-aee3-5b1b7b1899a3)
