### PR TITLE
ASM for null guard on getTileEntity

### DIFF
--- a/src/main/java/com/gtnewhorizons/angelica/transform/compat/CompatASMTransformers.java
+++ b/src/main/java/com/gtnewhorizons/angelica/transform/compat/CompatASMTransformers.java
@@ -16,6 +16,7 @@ public enum CompatASMTransformers {
     ),
     STACKS_ON_STACKS_ISBRH("RenderTilePile Transformer", () -> AngelicaConfig.fixStacksOnStacksSodiumCompat, Side.CLIENT, "com.gtnewhorizons.angelica.transform.compat.StacksOnStacksTransformer"),
     FIELD_LEVEL_TESSELLATOR("Field Level Tessellator Transformer", () -> AngelicaConfig.enableSodium, Side.CLIENT, "com.gtnewhorizons.angelica.transform.compat.FieldLevelTessellatorTransformer"),
+    GET_TILE_ENTITY_NULL_GUARD("getTileEntity Null Guard Transformer", () -> AngelicaConfig.enableSodium, Side.CLIENT, "com.gtnewhorizons.angelica.transform.compat.GetTileEntityNullGuardTransformer"),
     HUD_CACHING("HUDCaching Early Return Transformer", () -> AngelicaConfig.enableHudCaching && AngelicaConfig.enableHudCachingEventTransformer, Side.CLIENT,
         "com.gtnewhorizons.angelica.transform.HUDCachingTransformer")
     ;

--- a/src/main/java/com/gtnewhorizons/angelica/transform/compat/GetTileEntityNullGuardTransformer.java
+++ b/src/main/java/com/gtnewhorizons/angelica/transform/compat/GetTileEntityNullGuardTransformer.java
@@ -7,7 +7,16 @@ import net.minecraft.launchwrapper.IClassTransformer;
 import org.spongepowered.asm.lib.ClassReader;
 import org.spongepowered.asm.lib.ClassWriter;
 import org.spongepowered.asm.lib.Opcodes;
-import org.spongepowered.asm.lib.tree.*;
+import org.spongepowered.asm.lib.tree.AbstractInsnNode;
+import org.spongepowered.asm.lib.tree.ClassNode;
+import org.spongepowered.asm.lib.tree.InsnList;
+import org.spongepowered.asm.lib.tree.InsnNode;
+import org.spongepowered.asm.lib.tree.JumpInsnNode;
+import org.spongepowered.asm.lib.tree.LabelNode;
+import org.spongepowered.asm.lib.tree.MethodInsnNode;
+import org.spongepowered.asm.lib.tree.MethodNode;
+import org.spongepowered.asm.lib.tree.TypeInsnNode;
+import org.spongepowered.asm.lib.tree.VarInsnNode;
 
 import java.util.List;
 import java.util.Map;

--- a/src/main/java/com/gtnewhorizons/angelica/transform/compat/GetTileEntityNullGuardTransformer.java
+++ b/src/main/java/com/gtnewhorizons/angelica/transform/compat/GetTileEntityNullGuardTransformer.java
@@ -1,0 +1,106 @@
+package com.gtnewhorizons.angelica.transform.compat;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.gtnewhorizons.angelica.loading.AngelicaTweaker;
+import net.minecraft.launchwrapper.IClassTransformer;
+import org.spongepowered.asm.lib.ClassReader;
+import org.spongepowered.asm.lib.ClassWriter;
+import org.spongepowered.asm.lib.Opcodes;
+import org.spongepowered.asm.lib.tree.*;
+
+import java.util.List;
+import java.util.Map;
+
+public class GetTileEntityNullGuardTransformer implements IClassTransformer {
+
+    private static final Map<String, List<String>> patchMethods = ImmutableMap.of(
+        "com.tierzero.stacksonstacks.client.render.RenderTilePile", ImmutableList.of("renderWorldBlock")
+    );
+
+    public byte[] transform(final String className, String transformedName, byte[] basicClass) {
+        if (basicClass == null) return null;
+
+        if (!patchMethods.containsKey(transformedName)) {
+            return basicClass;
+        }
+
+        ClassReader cr = new ClassReader(basicClass);
+        ClassNode cn = new ClassNode();
+        cr.accept(cn, 0);
+
+        for (String targetMethod : patchMethods.get(transformedName)) {
+            for (MethodNode method : cn.methods) {
+                if (!method.name.equals(targetMethod)) continue;
+                injectGetTileEntityNullGuard(method);
+            }
+        }
+
+        ClassWriter cw = new ClassWriter(ClassWriter.COMPUTE_FRAMES);
+        cn.accept(cw);
+        final byte[] bytes = cw.toByteArray();
+        AngelicaTweaker.dumpClass(transformedName, basicClass, bytes, this);
+        return bytes;
+    }
+
+    public static void injectGetTileEntityNullGuard(MethodNode mn) {
+/*
+          Searching for the following pattern:
+          L0 {
+              ...
+              INVOKEINTERFACE net/minecraft/world/IBlockAccess.getTileEntity(III)Lnet/minecraft/tileentity/TileEntity;
+              CHECKCAST *
+              ASTORE x
+          }
+          L1 {...
+
+          Then injecting the following after the ASTORE such that we get
+          L0 {
+              ASTORE x
+              ALOAD x
+              IFNONNULL L1
+              ICONST_0
+              IRETURN
+          }
+          L1 {...
+
+          Ultimately this converts:
+          MyTileEntity tile = (MyTileEntity) world.getTileEntity(x, y, z);
+          doSomethingWithTileEntity(tile);
+
+          into:
+          MyTileEntity tile = (MyTileEntity) world.getTileEntity(x, y, z);
+          if (tile == null) {
+              return false;
+          } else {
+              doSomethingWithTileEntity(tile);
+          }
+ */
+        for (int i = 0; i < mn.instructions.size(); i++) {
+            AbstractInsnNode in = mn.instructions.get(i);
+            if (in instanceof MethodInsnNode min) {
+                if (min.getOpcode() == Opcodes.INVOKEINTERFACE && min.name.equals(AngelicaTweaker.isObfEnv() ? "func_147438_o" : "getTileEntity") && min.owner.equals("net/minecraft/world/IBlockAccess")) {
+                    AbstractInsnNode castNodeAbstract = min.getNext();
+                    if (castNodeAbstract instanceof TypeInsnNode castNodeType) {
+                        if (castNodeType.getOpcode() == Opcodes.CHECKCAST) {
+                            AbstractInsnNode astoreNodeAbstract = castNodeType.getNext();
+                            if (astoreNodeAbstract instanceof VarInsnNode astoreNodeVar) {
+                                if (astoreNodeVar.getOpcode() == Opcodes.ASTORE) {
+                                    InsnList list = new InsnList();
+                                    LabelNode exit = new LabelNode();
+                                    list.add(new VarInsnNode(Opcodes.ALOAD, astoreNodeVar.var));
+                                    list.add(new JumpInsnNode(Opcodes.IFNONNULL, exit));
+                                    list.add(new InsnNode(Opcodes.ICONST_0));
+                                    list.add(new InsnNode(Opcodes.IRETURN));
+                                    list.add(exit);
+                                    mn.instructions.insert(astoreNodeVar, list);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+}

--- a/src/main/java/com/gtnewhorizons/angelica/transform/compat/StacksOnStacksTransformer.java
+++ b/src/main/java/com/gtnewhorizons/angelica/transform/compat/StacksOnStacksTransformer.java
@@ -110,19 +110,6 @@ public class StacksOnStacksTransformer implements IClassTransformer {
                             mn.instructions.remove(fin);
                         }
                     }
-                    // Adds a null guard for the IBlockAccess.getTileEntity call
-                    if (in instanceof VarInsnNode vin) {
-                        if (vin.getOpcode() == Opcodes.ASTORE && vin.var == 8) {
-                            InsnList list = new InsnList();
-                            LabelNode exit = new LabelNode();
-                            list.add(new VarInsnNode(Opcodes.ALOAD, 8));
-                            list.add(new JumpInsnNode(Opcodes.IFNONNULL, exit));
-                            list.add(new InsnNode(Opcodes.ICONST_0));
-                            list.add(new InsnNode(Opcodes.IRETURN));
-                            list.add(exit);
-                            mn.instructions.insert(vin, list);
-                        }
-                    }
                 }
             }
         }

--- a/src/main/java/com/gtnewhorizons/angelica/transform/compat/StacksOnStacksTransformer.java
+++ b/src/main/java/com/gtnewhorizons/angelica/transform/compat/StacksOnStacksTransformer.java
@@ -13,7 +13,6 @@ import org.spongepowered.asm.lib.tree.FieldInsnNode;
 import org.spongepowered.asm.lib.tree.FieldNode;
 import org.spongepowered.asm.lib.tree.InsnList;
 import org.spongepowered.asm.lib.tree.InsnNode;
-import org.spongepowered.asm.lib.tree.JumpInsnNode;
 import org.spongepowered.asm.lib.tree.LabelNode;
 import org.spongepowered.asm.lib.tree.MethodInsnNode;
 import org.spongepowered.asm.lib.tree.MethodNode;


### PR DESCRIPTION
Adds a new generic ASM transformer to add null-guards to TileEntities retrieved from `IBlockAccess.getTileEntity`. This solves the most typical problem that causes NPE in `renderWorldBlock` when a block is removed from the world before the render thread gets to it and causes the TileEntity to be null.