### PR TITLE
fix ArrayOutOfBounds in F3 debug text handler

### DIFF
--- a/src/main/java/com/gtnewhorizons/angelica/proxy/ClientProxy.java
+++ b/src/main/java/com/gtnewhorizons/angelica/proxy/ClientProxy.java
@@ -193,7 +193,7 @@ public class ClientProxy extends CommonProxy {
 
             if (srv != null) {
                 String s = String.format("Integrated server @ %.0f ms ticks", lastIntegratedTickTime);
-                event.left.add(1, s);
+                event.left.add(Math.min(event.left.size(), 1), s);
             }
         }
         if (AngelicaConfig.showBlockDebugInfo && mc.objectMouseOver != null && mc.objectMouseOver.typeOfHit == MovingObjectPosition.MovingObjectType.BLOCK) {
@@ -250,6 +250,8 @@ public class ClientProxy extends CommonProxy {
                 }
             }
             event.setCanceled(true);
+            // TODO don't cancel the event and render is here
+            //  instead mixin into the vanilla code and a background to it
             /* render ourselves for modern background */
             FontRenderer fontrenderer = mc.fontRenderer;
             int fontColor = 0xe0e0e0;

--- a/src/main/java/com/gtnewhorizons/angelica/proxy/ClientProxy.java
+++ b/src/main/java/com/gtnewhorizons/angelica/proxy/ClientProxy.java
@@ -250,8 +250,8 @@ public class ClientProxy extends CommonProxy {
                 }
             }
             event.setCanceled(true);
-            // TODO don't cancel the event and render is here
-            //  instead mixin into the vanilla code and a background to it
+            // TODO don't cancel the event and render here,
+            //  instead mixin into the vanilla code and add a background to it
             /* render ourselves for modern background */
             FontRenderer fontrenderer = mc.fontRenderer;
             int fontColor = 0xe0e0e0;

--- a/src/main/java/me/jellysquid/mods/sodium/client/SodiumDebugScreenHandler.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/SodiumDebugScreenHandler.java
@@ -17,7 +17,7 @@ public class SodiumDebugScreenHandler {
     public void onRenderGameOverlayTextEvent(RenderGameOverlayEvent.Text event) {
         final Minecraft mc = Minecraft.getMinecraft();
         if (mc.gameSettings.showDebugInfo) {
-            event.right.add(2, "Off-Heap: +" + ManagementFactory.getMemoryMXBean().getNonHeapMemoryUsage().getUsed() / 1024L / 1024L + "MB");
+            event.right.add(Math.min(event.right.size(), 2), "Off-Heap: +" + ManagementFactory.getMemoryMXBean().getNonHeapMemoryUsage().getUsed() / 1024L / 1024L + "MB");
 
             event.right.add("");
             event.right.add("Sodium (Embeddium) Renderer");

--- a/src/main/java/net/coderbot/iris/client/IrisDebugScreenHandler.java
+++ b/src/main/java/net/coderbot/iris/client/IrisDebugScreenHandler.java
@@ -2,7 +2,6 @@ package net.coderbot.iris.client;
 
 import com.gtnewhorizons.angelica.AngelicaMod;
 import com.gtnewhorizons.angelica.config.AngelicaConfig;
-import com.mitchej123.hodgepodge.client.HodgepodgeClient;
 import cpw.mods.fml.common.eventhandler.EventPriority;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import net.coderbot.iris.Iris;
@@ -39,7 +38,7 @@ public class IrisDebugScreenHandler {
     public void onRenderGameOverlayTextEvent(RenderGameOverlayEvent.Text event) {
         final Minecraft mc = Minecraft.getMinecraft();
         if (mc.gameSettings.showDebugInfo) {
-            event.right.add(2, "Direct Buffers: +" + iris$humanReadableByteCountBin(iris$directPool.getMemoryUsed()));
+            event.right.add(Math.min(event.right.size(), 2), "Direct Buffers: +" + iris$humanReadableByteCountBin(iris$directPool.getMemoryUsed()));
 
             event.right.add("");
 
@@ -49,8 +48,8 @@ public class IrisDebugScreenHandler {
             } else {
                 event.right.add("[" + Iris.MODNAME + "] Shaders are disabled");
             }
-            if(AngelicaConfig.speedupAnimations) {
-                event.right.add(9, "animationsMode: " + AngelicaMod.animationsMode);
+            if (AngelicaConfig.speedupAnimations) {
+                event.right.add(Math.min(event.right.size(), 9), "animationsMode: " + AngelicaMod.animationsMode);
             }
 
             Iris.getPipelineManager().getPipeline().ifPresent(pipeline -> pipeline.addDebugText(event.left));


### PR DESCRIPTION
If a mod cancels the `RenderGameOverlayEvent.Pre` for `type == DEBUG`, the lists `event.left` and `event.right` will be empty, therefore we need to check the sizes before adding to a specific index.