### PR TITLE
Backport F3 crosshair directions

### DIFF
--- a/src/main/java/com/gtnewhorizons/angelica/debug/F3Direction.java
+++ b/src/main/java/com/gtnewhorizons/angelica/debug/F3Direction.java
@@ -1,0 +1,82 @@
+package com.gtnewhorizons.angelica.debug;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.ScaledResolution;
+import net.minecraft.client.renderer.Tessellator;
+import net.minecraft.entity.Entity;
+import net.minecraftforge.client.event.RenderGameOverlayEvent;
+import org.lwjgl.opengl.GL11;
+
+public class F3Direction {
+    public static void renderWorldDirectionsEvent(Minecraft mc, RenderGameOverlayEvent.Pre event) {
+        if (mc.gameSettings.showDebugInfo && mc.gameSettings.thirdPersonView == 0) {
+            ScaledResolution scaledresolution = new ScaledResolution(mc, mc.displayWidth, mc.displayHeight);
+            int width = scaledresolution.getScaledWidth();
+            int height = scaledresolution.getScaledHeight();
+
+            GL11.glPushMatrix();
+
+            GL11.glTranslatef((float) (width / 2), (float) (height / 2), -90);
+
+            Entity entity = mc.renderViewEntity;
+            GL11.glRotatef(entity.prevRotationPitch + (entity.rotationPitch - entity.prevRotationPitch) * event.partialTicks, -1.0F, 0.0F, 0.0F);
+            GL11.glRotatef(entity.prevRotationYaw + (entity.rotationYaw - entity.prevRotationYaw) * event.partialTicks, 0.0F, 1.0F, 0.0F);
+
+            GL11.glScalef(-1.0F, -1.0F, -1.0F);
+
+            renderWorldDirections();
+
+            GL11.glPopMatrix();
+        }
+    }
+    public static void renderWorldDirections() {
+        GL11.glDisable(GL11.GL_TEXTURE_2D);
+        GL11.glDepthMask(false);
+        Tessellator tessellator = Tessellator.instance;
+
+        GL11.glLineWidth(2);
+        tessellator.startDrawing(GL11.GL_LINES);
+
+        //X
+        tessellator.setColorRGBA_F(255, 0, 0, 1);
+        tessellator.addVertex(0.0D, 0.0D, 0.0D);
+        tessellator.addVertex(10, 0.0D, 0.0D);
+
+        //Z
+        tessellator.setColorRGBA_F(0, 0, 255, 1);
+        tessellator.addVertex(0.0D, 0.0D, 0.0D);
+        tessellator.addVertex(0.0D, 0.0D, 10);
+
+        //Y
+        tessellator.setColorRGBA_F(0, 255, 0, 1);
+        tessellator.addVertex(0.0D, 0.0D, 0.0D);
+        tessellator.addVertex(0.0D, 10, 0.0D);
+
+        tessellator.draw();
+
+
+        GL11.glLineWidth(2);
+        tessellator.startDrawing(GL11.GL_LINES);
+
+        //X
+        tessellator.setColorRGBA_F(255, 0, 0, 1);
+        tessellator.addVertex(0.0D, 0.0D, 0.0D);
+        tessellator.addVertex(10, 0.0D, 0.0D);
+
+        //Z
+        tessellator.setColorRGBA_F(0, 0, 255, 1);
+        tessellator.addVertex(0.0D, 0.0D, 0.0D);
+        tessellator.addVertex(0.0D, 0.0D, 10);
+
+        //Y
+        tessellator.setColorRGBA_F(0, 255, 0, 1);
+        tessellator.addVertex(0.0D, 0.0D, 0.0D);
+        tessellator.addVertex(0.0D, 10, 0.0D);
+
+        tessellator.draw();
+
+        GL11.glLineWidth(1.0F);
+        GL11.glDepthMask(true);
+        GL11.glEnable(GL11.GL_TEXTURE_2D);
+    }
+}

--- a/src/main/java/com/gtnewhorizons/angelica/debug/F3Direction.java
+++ b/src/main/java/com/gtnewhorizons/angelica/debug/F3Direction.java
@@ -34,28 +34,7 @@ public class F3Direction {
         GL11.glDepthMask(false);
         Tessellator tessellator = Tessellator.instance;
 
-        GL11.glLineWidth(2);
-        tessellator.startDrawing(GL11.GL_LINES);
-
-        //X
-        tessellator.setColorRGBA_F(255, 0, 0, 1);
-        tessellator.addVertex(0.0D, 0.0D, 0.0D);
-        tessellator.addVertex(10, 0.0D, 0.0D);
-
-        //Z
-        tessellator.setColorRGBA_F(0, 0, 255, 1);
-        tessellator.addVertex(0.0D, 0.0D, 0.0D);
-        tessellator.addVertex(0.0D, 0.0D, 10);
-
-        //Y
-        tessellator.setColorRGBA_F(0, 255, 0, 1);
-        tessellator.addVertex(0.0D, 0.0D, 0.0D);
-        tessellator.addVertex(0.0D, 10, 0.0D);
-
-        tessellator.draw();
-
-
-        GL11.glLineWidth(2);
+        GL11.glLineWidth(2.0F);
         tessellator.startDrawing(GL11.GL_LINES);
 
         //X

--- a/src/main/java/com/gtnewhorizons/angelica/proxy/ClientProxy.java
+++ b/src/main/java/com/gtnewhorizons/angelica/proxy/ClientProxy.java
@@ -9,6 +9,7 @@ import com.gtnewhorizons.angelica.compat.ModStatus;
 import com.gtnewhorizons.angelica.compat.bettercrashes.BetterCrashesCompat;
 import com.gtnewhorizons.angelica.config.AngelicaConfig;
 import com.gtnewhorizons.angelica.config.CompatConfig;
+import com.gtnewhorizons.angelica.debug.F3Direction;
 import com.gtnewhorizons.angelica.debug.FrametimeGraph;
 import com.gtnewhorizons.angelica.debug.TPSGraph;
 import com.gtnewhorizons.angelica.mixins.interfaces.IGameSettingsExt;
@@ -184,6 +185,15 @@ public class ClientProxy extends CommonProxy {
                 long currentTickTime = srv.tickTimeArray[srv.getTickCounter() % 100];
                 lastIntegratedTickTime = lastIntegratedTickTime * 0.8F + (float) currentTickTime / 1000000.0F * 0.2F;
             } else lastIntegratedTickTime = 0;
+        }
+    }
+
+    @SubscribeEvent(priority = EventPriority.LOWEST)
+    public void onRenderOverlay(RenderGameOverlayEvent.Pre event) {
+        if (event.isCanceled() || !mc.gameSettings.showDebugInfo) return;
+        if (AngelicaConfig.modernizeF3Screen && event.type == RenderGameOverlayEvent.ElementType.CROSSHAIRS) {
+            F3Direction.renderWorldDirectionsEvent(mc, event);
+            event.setCanceled(true);
         }
     }
 


### PR DESCRIPTION
Maybe not the best implementation, but it works:

https://github.com/user-attachments/assets/3843f126-b323-48f6-b451-ae195e396d2e




Probably should have done it via mixins, but `ClientProxy` already has an `onRenderOverlay` event, so I left it as is. (Had to create a new `onRenderOverlay` event, because the existing one is `RenderGameOverlayEvent.Text` and `RenderGameOverlayEvent.ElementType` in it is always `TEXT`, not `CROSSHAIRS`)