### PR TITLE
Gracefully handle nested display list compilations in GLSM

### DIFF
--- a/src/main/java/com/gtnewhorizons/angelica/glsm/GLStateManager.java
+++ b/src/main/java/com/gtnewhorizons/angelica/glsm/GLStateManager.java
@@ -172,6 +172,7 @@ public class GLStateManager {
     @Setter @Getter private static boolean runningSplash = true;
 
     private static int glListMode = 0;
+    private static int glListNesting = 0;
     private static int glListId = -1;
     private static final Map<IStateStack<?>, ISettableState<?>> glListStates = new Object2ObjectArrayMap<>();
     private static final Int2ObjectMap<Set<Map.Entry<IStateStack<?>, ISettableState<?>>>> glListChanges = new Int2ObjectOpenHashMap<>();
@@ -1187,7 +1188,8 @@ public class GLStateManager {
 
     public static void glNewList(int list, int mode) {
         if(glListMode > 0) {
-            throw new RuntimeException("glNewList called inside of a display list!");
+            glListNesting += 1;
+            return;
         }
         glListId = list;
         glListMode = mode;
@@ -1202,6 +1204,11 @@ public class GLStateManager {
     }
 
     public static void glEndList() {
+        if (glListNesting > 0) {
+            glListNesting -= 1;
+            return;
+        }
+
         if(glListMode == 0) {
             throw new RuntimeException("glEndList called outside of a display list!");
         }


### PR DESCRIPTION
Normally GLSM causes a crash if a displaylist compilation is started within another displaylist. This is something that isn't supported by OpenGL, but minus Angelica, this error usually just gets swallowed and thrown away, and some OpenGL implementations may not even error at all, so there are a number of cases where mods may draw something that uses a display list, which in turn draws another item/block/tesr from potentially even a completely different mod, which might also use it's own display list.

This adds a nesting counter to GLSM, which increments whenever we start a display list compilation from within another displaylist, and then causes the nested glNewList call to no-op. Then, in glEndList if the nesting counter is above 0, we decrement it and no-op the glEndList call, so essentially whatever would have been in the nested displaylist, is just consumed directly into the top level parent display list.