### PR TITLE
Fix for Extra Utilities ethereal blocks with connected textures

### DIFF
--- a/src/mixin/java/com/gtnewhorizons/angelica/mixins/late/client/extrautils/MixinRenderBlockConnectedTexturesEthereal.java
+++ b/src/mixin/java/com/gtnewhorizons/angelica/mixins/late/client/extrautils/MixinRenderBlockConnectedTexturesEthereal.java
@@ -34,8 +34,8 @@ public abstract class MixinRenderBlockConnectedTexturesEthereal extends RenderBl
         getFakeRender().setRenderBoundsFromBlock(block);
         boolean render = getFakeRender().renderStandardBlock(block, x, y, z);
         newFakeRenderEthereal.setWorld(renderer.blockAccess);
-        newFakeRenderEthereal.curBlock = fakeRender.curBlock;
-        newFakeRenderEthereal.curMeta = fakeRender.curMeta;
+        newFakeRenderEthereal.curBlock = getFakeRender().curBlock;
+        newFakeRenderEthereal.curMeta = getFakeRender().curMeta;
         double h = 0.05D;
         newFakeRenderEthereal.setRenderBounds(h, h, h, 1.0D - h, 1.0D - h, 1.0D - h);
         render &= newFakeRenderEthereal.renderStandardBlock(block, x, y, z);


### PR DESCRIPTION
There was a bug where the mixin for ethereal connected textures in extra utilities was still using the old static field for the connected textures instead of the getter created for the new thread safe field.

Before:
![image](https://github.com/user-attachments/assets/6dd853d5-6067-4aa5-9b6d-9f3dceba84c1)

After:
![image](https://github.com/user-attachments/assets/63272de7-2b71-4930-8640-6f52b21c7ef5)

