### PR TITLE
Null check frametime mixin

### DIFF
--- a/src/mixin/java/com/gtnewhorizons/angelica/mixins/early/angelica/MixinMinecraft.java
+++ b/src/mixin/java/com/gtnewhorizons/angelica/mixins/early/angelica/MixinMinecraft.java
@@ -34,6 +34,8 @@ public class MixinMinecraft {
         at = @At(value = "INVOKE", target = "Lorg/lwjgl/opengl/Display;update()V", shift = At.Shift.AFTER, remap = false)
     )
     private void angelica$trackFrametimes(CallbackInfo ci) {
+        if (AngelicaMod.proxy == null) return;
+
         long time = System.nanoTime();
         AngelicaMod.proxy.putFrametime(time - angelica$lastFrameTime);
         angelica$lastFrameTime = time;


### PR DESCRIPTION
If the proxy hasn't been constructed, we shouldn't crash. There's no null check on the server version because if you manage to load into a singleplayer world without creating the proxy something else has gone seriously wrong.