### PR TITLE
Refresh Notfine options on world load

### DIFF
--- a/src/main/java/jss/notfine/proxy/ClientProxy.java
+++ b/src/main/java/jss/notfine/proxy/ClientProxy.java
@@ -1,19 +1,23 @@
 package jss.notfine.proxy;
 
-import cpw.mods.fml.common.event.FMLInitializationEvent;
+import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.common.event.FMLPostInitializationEvent;
 import cpw.mods.fml.common.event.FMLPreInitializationEvent;
-import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import jss.notfine.config.NotFineConfig;
 import jss.notfine.core.Settings;
 import jss.notfine.core.SettingsManager;
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.settings.GameSettings;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.world.WorldEvent;
 
 public class ClientProxy extends CommonProxy {
 
     @Override
     public void preInit(FMLPreInitializationEvent event) {
+        FMLCommonHandler.instance().bus().register(this);
+        MinecraftForge.EVENT_BUS.register(this);
+
         if(!NotFineConfig.allowAdvancedOpenGL) {
             Minecraft.getMinecraft().gameSettings.advancedOpengl = false;
         }
@@ -30,11 +34,12 @@ public class ClientProxy extends CommonProxy {
     }
 
     @Override
-    public void init(FMLInitializationEvent event) { }
-
-    @Override
     public void postInit(FMLPostInitializationEvent event) {
         SettingsManager.settingsFile.loadSettings();
     }
 
+    @SubscribeEvent
+    public void worldLoad(WorldEvent.Load event) {
+        SettingsManager.graphicsUpdated();
+    }
 }


### PR DESCRIPTION
Notfine options require a manual refresh to sync with the global fast/fancy. This adds one sync point as you load into the world, as previously there was none if the user just booted the mod and didn't change settings.
