### PR TITLE
add missing Pipeline::syncProgram for glCallList

### DIFF
--- a/src/main/java/com/gtnewhorizons/angelica/glsm/GLStateManager.java
+++ b/src/main/java/com/gtnewhorizons/angelica/glsm/GLStateManager.java
@@ -1240,6 +1240,9 @@ public class GLStateManager {
         if(list < 0) {
             VBOManager.get(list).render();
         } else {
+            if (AngelicaConfig.enableIris) {
+                Iris.getPipelineManager().getPipeline().ifPresent(WorldRenderingPipeline::syncProgram);
+            }
             GL11.glCallList(list);
             if(glListChanges.containsKey(list)) {
                 for(Map.Entry<IStateStack<?>, ISettableState<?>> entry : glListChanges.get(list)) {


### PR DESCRIPTION
missed this in #677
fixes #755, fixes #758
might fix (not tested) GTNewHorizons/GT-New-Horizons-Modpack#18162

this issue became more obvious because of the ItemRenderOptimization using call lists for item rendering now, but it always existed