### PR TITLE
Cache AxisAlignedBB for tile entity render frustrum check

### DIFF
--- a/src/main/java/com/gtnewhorizons/angelica/mixins/interfaces/TileEntityExt.java
+++ b/src/main/java/com/gtnewhorizons/angelica/mixins/interfaces/TileEntityExt.java
@@ -1,0 +1,9 @@
+package com.gtnewhorizons.angelica.mixins.interfaces;
+
+import net.minecraft.util.AxisAlignedBB;
+
+public interface TileEntityExt {
+
+    AxisAlignedBB sodium$getCachedRenderBoundingBox();
+
+}

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/SodiumWorldRenderer.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/SodiumWorldRenderer.java
@@ -1,12 +1,12 @@
 package me.jellysquid.mods.sodium.client.render;
 
 import com.gtnewhorizons.angelica.compat.mojang.Camera;
-import com.gtnewhorizons.angelica.compat.mojang.ChunkPos;
 import com.gtnewhorizons.angelica.compat.toremove.MatrixStack;
 import com.gtnewhorizons.angelica.compat.toremove.RenderLayer;
 import com.gtnewhorizons.angelica.config.AngelicaConfig;
 import com.gtnewhorizons.angelica.dynamiclights.DynamicLights;
 import com.gtnewhorizons.angelica.glsm.GLStateManager;
+import com.gtnewhorizons.angelica.mixins.interfaces.TileEntityExt;
 import com.gtnewhorizons.angelica.rendering.RenderingState;
 import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
 import it.unimi.dsi.fastutil.longs.LongSet;
@@ -29,7 +29,6 @@ import me.jellysquid.mods.sodium.client.render.chunk.map.ChunkTrackerHolder;
 import me.jellysquid.mods.sodium.client.render.chunk.passes.BlockRenderPass;
 import me.jellysquid.mods.sodium.client.render.pipeline.context.ChunkRenderCacheShared;
 import me.jellysquid.mods.sodium.client.util.math.FrustumExtended;
-import me.jellysquid.mods.sodium.client.world.ChunkStatusListener;
 import me.jellysquid.mods.sodium.common.util.ListUtil;
 import net.coderbot.iris.block_rendering.BlockRenderingSettings;
 import net.coderbot.iris.layer.GbufferPrograms;
@@ -348,7 +347,7 @@ public class SodiumWorldRenderer {
     }
 
     private boolean checkBEVisibility(TileEntity entity) {
-        return frustum.isBoundingBoxInFrustum(entity.getRenderBoundingBox());
+        return frustum.isBoundingBoxInFrustum(((TileEntityExt) entity).sodium$getCachedRenderBoundingBox());
     }
 
     private void renderTE(TileEntity tileEntity, int pass, float partialTicks) {

--- a/src/mixin/java/com/gtnewhorizons/angelica/mixins/early/sodium/MixinTileEntity.java
+++ b/src/mixin/java/com/gtnewhorizons/angelica/mixins/early/sodium/MixinTileEntity.java
@@ -1,20 +1,41 @@
 package com.gtnewhorizons.angelica.mixins.early.sodium;
 
+import com.gtnewhorizons.angelica.mixins.interfaces.TileEntityExt;
 import net.minecraft.block.Block;
 import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.AxisAlignedBB;
 import net.minecraft.world.World;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Overwrite;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
 
 @Mixin(TileEntity.class)
-public class MixinTileEntity {
-    @Shadow private Block blockType;
-    @Shadow private int blockMetadata;
-    @Shadow World worldObj;
-    @Shadow int xCoord;
-    @Shadow int yCoord;
-    @Shadow int zCoord;
+public abstract class MixinTileEntity implements TileEntityExt {
+
+    @Shadow
+    public Block blockType;
+    @Shadow
+    public int blockMetadata;
+    @Shadow
+    protected World worldObj;
+    @Shadow
+    public int xCoord;
+    @Shadow
+    public int yCoord;
+    @Shadow
+    public int zCoord;
+    @Unique
+    private int sodium$renderxCoord = -1;
+    @Unique
+    private int sodium$renderyCoord = -1;
+    @Unique
+    private int sodium$renderzCoord = -1;
+    @Unique
+    private AxisAlignedBB sodium$cachedRenderAABB;
+
+    @Shadow
+    public abstract AxisAlignedBB getRenderBoundingBox();
 
     /**
      * @author mitchej123
@@ -26,7 +47,6 @@ public class MixinTileEntity {
         if (block == null) {
             this.blockType = block = this.worldObj.getBlock(this.xCoord, this.yCoord, this.zCoord);
         }
-
         return block;
     }
 
@@ -40,7 +60,20 @@ public class MixinTileEntity {
         if (metadata == -1) {
             this.blockMetadata = metadata = this.worldObj.getBlockMetadata(this.xCoord, this.yCoord, this.zCoord);
         }
-
         return metadata;
+    }
+
+    // cache the render bounding box, otherwise the vanilla code
+    // creates a new AxisAlignedBB object everytime and that
+    // spams allocations
+    @Override
+    public AxisAlignedBB sodium$getCachedRenderBoundingBox() {
+        if (sodium$cachedRenderAABB == null || xCoord != sodium$renderxCoord || yCoord != sodium$renderyCoord || zCoord != sodium$renderzCoord) {
+            sodium$renderxCoord = xCoord;
+            sodium$renderyCoord = yCoord;
+            sodium$renderzCoord = zCoord;
+            sodium$cachedRenderAABB = this.getRenderBoundingBox();
+        }
+        return sodium$cachedRenderAABB;
     }
 }


### PR DESCRIPTION
The vanilla code creates a new AxisAlignedBB instance everytime `TileEntity#getRenderBoundingBox()` is called, this spams allocation a lot during rendering.
I made it cache and return the same bounding box if the coordinates of the tile entity are the same.
This might introduce a bug if the implementation of getRenderBoundingBox is overwritten and depends on other parameters than just the tile entity position.

Needs to be tested with the TE that change the default implementation of `TileEntity#getRenderBoundingBox()`

Fixes : https://github.com/GTNewHorizons/Angelica/issues/689