### PR TITLE
Fix rebuild check being wrong when shaders are on

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/ChunkRenderManager.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/ChunkRenderManager.java
@@ -249,7 +249,11 @@ public class ChunkRenderManager<T extends ChunkGraphicsState> implements ChunkSt
     }
 
     private void addChunk(ChunkRenderContainer<T> render) {
-        final boolean canRebuild = AngelicaConfig.enableIris ? !ShadowRenderingState.areShadowsCurrentlyBeingRendered() : render.canRebuild();
+        boolean canRebuild = render.canRebuild();
+
+        if (AngelicaConfig.enableIris && ShadowRenderingState.areShadowsCurrentlyBeingRendered()) {
+            canRebuild = false;
+        }
 
         if (render.needsRebuild() && canRebuild) {
             if (!this.alwaysDeferChunkUpdates && render.needsImportantRebuild()) {


### PR DESCRIPTION
This was translated incorrectly from the original mixin: https://github.com/Asek3/Oculus/blob/a2ed79988284940bf3f72e1321f6c36530ccbf97/src/main/java/net/coderbot/iris/compat/sodium/mixin/shadow_map/MixinChunkRenderManager.java#L121-L131