### PR TITLE
Fix terrain rendering incorrectly when far from origin

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/tasks/ChunkRenderRebuildTask.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/tasks/ChunkRenderRebuildTask.java
@@ -3,6 +3,7 @@ package me.jellysquid.mods.sodium.client.render.chunk.tasks;
 import com.gtnewhorizon.gtnhlib.blockpos.BlockPos;
 import com.gtnewhorizon.gtnhlib.client.renderer.util.WorldUtil;
 import com.gtnewhorizons.angelica.compat.mojang.ChunkOcclusionDataBuilder;
+import com.gtnewhorizons.angelica.compat.mojang.ChunkSectionPos;
 import com.gtnewhorizons.angelica.compat.toremove.RenderLayer;
 import com.gtnewhorizons.angelica.config.AngelicaConfig;
 import com.gtnewhorizons.angelica.mixins.interfaces.ITexturesCache;
@@ -131,7 +132,7 @@ public class ChunkRenderRebuildTask<T extends ChunkGraphicsState> extends ChunkR
         cache.init(this.context);
 
         final WorldSlice slice = cache.getWorldSlice();
-        final RenderBlocks renderBlocks = new RenderBlocks(slice);
+        final RenderBlocks renderBlocks = new RenderBlocks(slice.getSubChunkRelativeAccess());
         if(renderBlocks instanceof ITexturesCache) ((ITexturesCache)renderBlocks).enableTextureTracking();
 
         final int baseX = this.render.getOriginX();
@@ -262,7 +263,7 @@ public class ChunkRenderRebuildTask<T extends ChunkGraphicsState> extends ChunkR
         final int baseY = this.render.getOriginY();
         final int baseZ = this.render.getOriginZ();
         final BlockPos renderOffset = this.offset;
-        final RenderBlocks rb = new RenderBlocks(slice.getWorld());
+        final RenderBlocks rb = new RenderBlocks(new WorldSlice.SubchunkRelative(slice.getWorld(), this.render.getChunkPos()));
         if(rb instanceof ITexturesCache) ((ITexturesCache)rb).enableTextureTracking();
         while(!mainThreadBlocks.isEmpty()) {
             final long longPos = mainThreadBlocks.dequeueLong();
@@ -294,7 +295,7 @@ public class ChunkRenderRebuildTask<T extends ChunkGraphicsState> extends ChunkR
                     final long seed = MathUtil.hashPos(pos.x, pos.y, pos.z);
                     if(AngelicaConfig.enableIris) buffers.iris$setMaterialId(block, ExtendedDataHelper.BLOCK_RENDER_TYPE);
 
-                    if (cache.getBlockRenderer().renderModel(slice.getWorld(), rb, block, meta, pos, buffers.get(pass), true, seed)) {
+                    if (cache.getBlockRenderer().renderModel(slice, rb, block, meta, pos, buffers.get(pass), true, seed)) {
                         bounds.addBlock(relX, relY, relZ);
                     }
                 }

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/pipeline/BlockRenderer.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/pipeline/BlockRenderer.java
@@ -25,6 +25,7 @@ import me.jellysquid.mods.sodium.client.render.occlusion.BlockOcclusionCache;
 import me.jellysquid.mods.sodium.client.util.ModelQuadUtil;
 import me.jellysquid.mods.sodium.client.util.color.ColorABGR;
 import me.jellysquid.mods.sodium.client.util.rand.XoRoShiRoRandom;
+import me.jellysquid.mods.sodium.client.world.WorldSlice;
 import net.coderbot.iris.block_rendering.BlockRenderingSettings;
 import net.minecraft.block.Block;
 import net.minecraft.client.Minecraft;
@@ -51,6 +52,7 @@ public class BlockRenderer {
 
     private Object Quad;
     private final ObjectPooler<QuadView> quadPool = new ObjectPooler<>(Quad::new);
+    private final BlockPos subChunkRelativePos = new BlockPos();
     // TODO: Use modern model API, and store them here
 
 
@@ -62,7 +64,7 @@ public class BlockRenderer {
         this.occlusionCache = new BlockOcclusionCache();
     }
 
-    public boolean renderModel(IBlockAccess world, RenderBlocks renderBlocks, Block block, int meta, BlockPos pos, ChunkModelBuffers buffers, boolean cull, long seed) {
+    public boolean renderModel(WorldSlice world, RenderBlocks renderBlocks, Block block, int meta, BlockPos pos, ChunkModelBuffers buffers, boolean cull, long seed) {
         final LightMode mode = LightMode.SMOOTH; // TODO: this.getLightingMode(block); is what was previously used. The flat pipeline is busted and was only an optimization for very few blocks.
         final LightPipeline lighter = this.lighters.getLighter(mode);
 
@@ -97,10 +99,13 @@ public class BlockRenderer {
                 TessellatorManager.startCapturing();
                 final CapturingTessellator tess = (CapturingTessellator) TessellatorManager.get();
                 tess.startDrawingQuads();
-                // RenderBlocks adds the subchunk-relative coordinates as the offset, cancel it out here
 
-                tess.setOffset(pos);
-                renderBlocks.renderBlockByRenderType(block, pos.x, pos.y, pos.z);
+                var worldOrigin = world.getOrigin();
+                var subChunkRelativePos = this.subChunkRelativePos;
+                subChunkRelativePos.set(pos.x - worldOrigin.getMinX(), pos.y - worldOrigin.getMinY(), pos.z - worldOrigin.getMinZ());
+                tess.setOffset(subChunkRelativePos);
+                // RenderBlocks is expecting to get subchunk-relative coordinates, cancel the offset out here
+                renderBlocks.renderBlockByRenderType(block, subChunkRelativePos.x, subChunkRelativePos.y, subChunkRelativePos.z);
                 final List<QuadView> quads = TessellatorManager.stopCapturingToPooledQuads();
                 tess.resetOffset();
 

--- a/src/main/java/me/jellysquid/mods/sodium/client/world/WorldSlice.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/world/WorldSlice.java
@@ -91,6 +91,9 @@ public class WorldSlice implements IBlockAccess {
 
     StructureBoundingBox volume;
 
+    @Getter
+    private SubchunkRelative subChunkRelativeAccess;
+
     public static ChunkRenderContext prepare(World world, ChunkSectionPos origin, ClonedChunkSectionCache sectionCache) {
         final Chunk chunk = world.getChunkFromChunkCoords(origin.x, origin.z);
         final ExtendedBlockStorage section = chunk.getBlockStorageArray()[origin.y];
@@ -181,6 +184,8 @@ public class WorldSlice implements IBlockAccess {
                 }
             }
         }
+
+        this.subChunkRelativeAccess = new SubchunkRelative(this, this.origin);
     }
 
     @Override
@@ -416,5 +421,103 @@ public class WorldSlice implements IBlockAccess {
             y <= box.maxY &&
             z >= box.minZ &&
             z <= box.maxZ;
+    }
+
+    /**
+     * Wraps an {@link IBlockAccess} so that it can be given to RenderBlocks with subchunk-relative coordinates.
+     */
+    public static final class SubchunkRelative implements IBlockAccess {
+        private final IBlockAccess delegate;
+        private final ChunkSectionPos origin;
+
+        public SubchunkRelative(IBlockAccess delegate, ChunkSectionPos origin) {
+            this.delegate = delegate;
+            this.origin = origin;
+        }
+
+        @Override
+        public Block getBlock(int x, int y, int z) {
+            return delegate.getBlock(
+                x + this.origin.getMinX(),
+                y + this.origin.getMinY(),
+                z + this.origin.getMinZ()
+            );
+        }
+
+        @Override
+        public TileEntity getTileEntity(int x, int y, int z) {
+            return delegate.getTileEntity(
+                x + this.origin.getMinX(),
+                y + this.origin.getMinY(),
+                z + this.origin.getMinZ()
+            );
+        }
+
+        @Override
+        public int getLightBrightnessForSkyBlocks(int x, int y, int z, int p_72802_4_) {
+            return delegate.getLightBrightnessForSkyBlocks(
+                x + this.origin.getMinX(),
+                y + this.origin.getMinY(),
+                z + this.origin.getMinZ(),
+                p_72802_4_
+            );
+        }
+
+        @Override
+        public int getBlockMetadata(int x, int y, int z) {
+            return delegate.getBlockMetadata(
+                x + this.origin.getMinX(),
+                y + this.origin.getMinY(),
+                z + this.origin.getMinZ()
+            );
+        }
+
+        @Override
+        public int isBlockProvidingPowerTo(int x, int y, int z, int directionIn) {
+            return delegate.isBlockProvidingPowerTo(
+                x + this.origin.getMinX(),
+                y + this.origin.getMinY(),
+                z + this.origin.getMinZ(),
+                directionIn
+            );
+        }
+
+        @Override
+        public boolean isAirBlock(int x, int y, int z) {
+            return delegate.isAirBlock(
+                x + this.origin.getMinX(),
+                y + this.origin.getMinY(),
+                z + this.origin.getMinZ()
+            );
+        }
+
+        @Override
+        public BiomeGenBase getBiomeGenForCoords(int x, int z) {
+            return delegate.getBiomeGenForCoords(
+                x + this.origin.getMinX(),
+                z + this.origin.getMinZ()
+            );
+        }
+
+        @Override
+        public int getHeight() {
+            return delegate.getHeight();
+        }
+
+        @Override
+        public boolean extendedLevelsInChunkCache() {
+            return delegate.extendedLevelsInChunkCache();
+        }
+
+        @Override
+        public boolean isSideSolid(int x, int y, int z, ForgeDirection side, boolean _default) {
+            return delegate.isSideSolid(
+                x + this.origin.getMinX(),
+                y + this.origin.getMinY(),
+                z + this.origin.getMinZ(),
+                side,
+                _default
+            );
+        }
     }
 }


### PR DESCRIPTION
To reproduce, teleport to a far-away coordinate on one dimension (e.g. `16777216 70 320`). Blocks will start to render inaccurately. This is caused by `RenderBlocks` being given the world-space coordinates for block rendering, while using `float`s internally. The fix is to give `RenderBlocks` subchunk-relative coordinates and a fake `IBlockAccess` that translates back to world-relative coordinates that the rest of the modernized Angelica stack expects. 