### PR TITLE
Properly prevent block face culling when TS is active

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/compile/ChunkBuildBuffers.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/compile/ChunkBuildBuffers.java
@@ -142,6 +142,8 @@ public class ChunkBuildBuffers implements ChunkBuildBuffersExt {
 
         if (sortTranslucent && pass.isTranslucent()) {
             ChunkBufferSorter.sortStandardFormat(vertexType, buffer, bufferLen, x, y, z);
+            meshData.clearSlices();
+            meshData.setModelSlice(ModelQuadFacing.UNASSIGNED, new BufferSlice(0, bufferLen));
         }
 
         meshData.setVertexData(new VertexData(buffer, this.vertexType.getCustomVertexFormat()));

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/data/ChunkMeshData.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/data/ChunkMeshData.java
@@ -17,6 +17,10 @@ public class ChunkMeshData {
         this.vertexData = vertexData;
     }
 
+    public void clearSlices() {
+        this.parts.clear();
+    }
+
     public void setModelSlice(ModelQuadFacing facing, BufferSlice slice) {
         this.parts.put(facing, slice);
     }


### PR DESCRIPTION
Translucency sorting will reorder the quads in-place within the vertex buffer, which results in quads being moved into the wrong slice. Since the renderer will decide to skip groups of quads based on their slice, this can result in quads disappearing when they shouldn't. The fix is to store a single UNASSIGNED slice which effectively disables the optimization on translucency-sorted sections. This is also how modern Embeddium handles it.

Kudos to @nshepperd for debugging this issue.