### PR TITLE
Only clear the translucency sorting render queue when we're not rende…

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/ChunkRenderManager.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/ChunkRenderManager.java
@@ -371,9 +371,7 @@ public class ChunkRenderManager<T extends ChunkGraphicsState> implements ChunkSt
     private void reset() {
         if(!AngelicaConfig.enableIris || !ShadowRenderingState.areShadowsCurrentlyBeingRendered()) this.rebuildQueue.clear();
         if(!AngelicaConfig.enableIris || !ShadowRenderingState.areShadowsCurrentlyBeingRendered()) this.importantRebuildQueue.clear();
-
-
-        this.sortQueue.clear();
+        if(!AngelicaConfig.enableIris || !ShadowRenderingState.areShadowsCurrentlyBeingRendered()) this.sortQueue.clear();
 
         this.visibleTileEntities.clear();
 


### PR DESCRIPTION
…ring shadows.

This matches the behaviour of the rebuild queues. Unconditionally clearing it in reset() does not work because sorting tasks are only spawned when not rendering shadows, and this combined with the fact that SodiumWorldRenderer spawns tasks (chunkRenderManager.updateChunks) *before* updating the render queues (chunkRenderManager.update) would result in translucency sorting never being triggered.

This is the third in a series of 3 PRs that fixes translucency sorting with shaders. The first two were https://github.com/GTNewHorizons/Angelica/pull/796 and https://github.com/GTNewHorizons/Angelica/pull/797. With this, translucency sorting works and is correctly updated on camera motion.