### PR TITLE
Remove forced even unicode gui scaling

### DIFF
--- a/src/main/java/com/gtnewhorizons/angelica/config/AngelicaConfig.java
+++ b/src/main/java/com/gtnewhorizons/angelica/config/AngelicaConfig.java
@@ -157,4 +157,8 @@ public class AngelicaConfig {
         "more latency. Will never introduce more than one frame of latency, and has a lower impact at higher framerates.")
     @Config.DefaultBoolean(false)
     public static boolean sleepBeforeSwap;
+
+    @Config.Comment("Allows unicode languages to use an odd gui scale")
+    @Config.DefaultBoolean(true)
+    public static boolean removeUnicodeEvenScaling;
 }

--- a/src/main/java/com/gtnewhorizons/angelica/mixins/Mixins.java
+++ b/src/main/java/com/gtnewhorizons/angelica/mixins/Mixins.java
@@ -219,6 +219,11 @@ public enum Mixins {
             "angelica.animation.MixinWorldRenderer",
             "angelica.animation.MixinRenderItem")),
 
+    SCALED_RESOUTION_UNICODE_FIX(new Builder("Removes unicode languages gui scaling being forced to even values").setPhase(Phase.EARLY)
+        .setSide(Side.CLIENT).addTargetedMod(TargetedMod.VANILLA)
+        .setApplyIf(() -> AngelicaConfig.removeUnicodeEvenScaling)
+        .addMixinClasses("angelica.bugfixes.MixinScaledResolution_UnicodeFix")),
+
     EXTRA_UTILITIES_THREAD_SAFETY(new Builder("Enable thread safety fixes in Extra Utilities").setPhase(Phase.LATE)
         .addTargetedMod(TargetedMod.EXTRAUTILS).setSide(Side.CLIENT)
         .setApplyIf(() -> CompatConfig.fixExtraUtils)

--- a/src/mixin/java/com/gtnewhorizons/angelica/mixins/early/angelica/bugfixes/MixinScaledResolution_UnicodeFix.java
+++ b/src/mixin/java/com/gtnewhorizons/angelica/mixins/early/angelica/bugfixes/MixinScaledResolution_UnicodeFix.java
@@ -1,0 +1,21 @@
+package com.gtnewhorizons.angelica.mixins.early.angelica.bugfixes;
+
+import net.minecraft.client.gui.ScaledResolution;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
+
+@Mixin(ScaledResolution.class)
+public class MixinScaledResolution_UnicodeFix {
+
+
+    // Force unicode languages to use the calculated scaleFactor and not adjust it.
+    // Can lead to blurry text
+    @ModifyConstant(method = "<init>", constant = @Constant(intValue = 1, ordinal = 5))
+    int angelica$ScaledResolutionInit(int constant){
+        return 0;
+    }
+
+}


### PR DESCRIPTION
Context: https://discord.com/channels/181078474394566657/522098956491030558/1327273596233580575

Result
![image](https://github.com/user-attachments/assets/35cddfdb-f57e-41f1-b01e-ea643d1c59a8)
