### PR TITLE
fix crash when connected textures are disabled & custom colors are enabled

### DIFF
--- a/src/main/java/com/gtnewhorizons/angelica/mixins/Mixins.java
+++ b/src/main/java/com/gtnewhorizons/angelica/mixins/Mixins.java
@@ -525,7 +525,7 @@ public enum Mixins {
             && !MCPatcherForgeConfig.ConnectedTextures.enabled
             && MCPatcherForgeConfig.CustomColors.enabled)
         .addTargetedMod(TargetedMod.VANILLA)
-        .addMixinClasses("mcpatcherforge.cc_ctm.MixinRenderBlocksNoCTM")
+        .addMixinClasses("mcpatcherforge.ctm_cc.MixinRenderBlocksNoCTM")
     ),
     MCPATCHER_FORGE_CTM_NO_CC(new Builder("MCP:F Connected Textures, no Custom Colours")
         .setSide(Side.CLIENT).setPhase(Phase.EARLY)


### PR DESCRIPTION
If you head into MCPatcher, disable connected textures, and enable custom colors, you get a crash on load - this is due to a misnamed call to a class. Just made a small correction so that the class is named as intended. 