### PR TITLE
Fix a handful of broken animations

### DIFF
--- a/src/main/java/com/gtnewhorizons/angelica/mixins/interfaces/ITexturesCache.java
+++ b/src/main/java/com/gtnewhorizons/angelica/mixins/interfaces/ITexturesCache.java
@@ -8,4 +8,5 @@ public interface ITexturesCache {
 
     Set<IIcon> getRenderedTextures();
     void enableTextureTracking();
+    void track(IPatchedTextureAtlasSprite sprite);
 }

--- a/src/main/java/com/gtnewhorizons/angelica/utils/AnimationsRenderUtils.java
+++ b/src/main/java/com/gtnewhorizons/angelica/utils/AnimationsRenderUtils.java
@@ -1,5 +1,7 @@
 package com.gtnewhorizons.angelica.utils;
 
+import java.util.Stack;
+
 import com.gtnewhorizons.angelica.mixins.interfaces.IPatchedTextureAtlasSprite;
 import com.gtnewhorizons.angelica.mixins.interfaces.ITexturesCache;
 import net.minecraft.client.Minecraft;
@@ -27,5 +29,25 @@ public class AnimationsRenderUtils {
                 patchedSprite.markNeedsAnimationUpdate();
             }
         }
+    }
+
+    private final static ThreadLocal<Stack<ITexturesCache>> TEXTURE_CACHE_STACK = ThreadLocal.withInitial(Stack::new);
+
+    public static void onSpriteUsed(IPatchedTextureAtlasSprite sprite) {
+        Stack<ITexturesCache> stack = TEXTURE_CACHE_STACK.get();
+
+        if (stack == null || stack.isEmpty()) {
+            return;
+        }
+
+        stack.peek().track(sprite);
+    }
+
+    public static void pushCache(ITexturesCache cache) {
+        TEXTURE_CACHE_STACK.get().push(cache);
+    }
+
+    public static void popCache() {
+        TEXTURE_CACHE_STACK.get().pop();
     }
 }

--- a/src/main/java/com/gtnewhorizons/angelica/utils/AnimationsRenderUtils.java
+++ b/src/main/java/com/gtnewhorizons/angelica/utils/AnimationsRenderUtils.java
@@ -1,6 +1,6 @@
 package com.gtnewhorizons.angelica.utils;
 
-import java.util.Stack;
+import java.util.ArrayDeque;
 
 import com.gtnewhorizons.angelica.mixins.interfaces.IPatchedTextureAtlasSprite;
 import com.gtnewhorizons.angelica.mixins.interfaces.ITexturesCache;
@@ -31,10 +31,10 @@ public class AnimationsRenderUtils {
         }
     }
 
-    private final static ThreadLocal<Stack<ITexturesCache>> TEXTURE_CACHE_STACK = ThreadLocal.withInitial(Stack::new);
+    private final static ThreadLocal<ArrayDeque<ITexturesCache>> TEXTURE_CACHE_STACK = ThreadLocal.withInitial(ArrayDeque::new);
 
     public static void onSpriteUsed(IPatchedTextureAtlasSprite sprite) {
-        Stack<ITexturesCache> stack = TEXTURE_CACHE_STACK.get();
+        ArrayDeque<ITexturesCache> stack = TEXTURE_CACHE_STACK.get();
 
         if (stack == null || stack.isEmpty()) {
             // icon was used outside of chunk building, it's probably an item in an inventory or something

--- a/src/main/java/com/gtnewhorizons/angelica/utils/AnimationsRenderUtils.java
+++ b/src/main/java/com/gtnewhorizons/angelica/utils/AnimationsRenderUtils.java
@@ -37,6 +37,8 @@ public class AnimationsRenderUtils {
         Stack<ITexturesCache> stack = TEXTURE_CACHE_STACK.get();
 
         if (stack == null || stack.isEmpty()) {
+            // icon was used outside of chunk building, it's probably an item in an inventory or something
+            sprite.markNeedsAnimationUpdate();
             return;
         }
 

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/tasks/ChunkRenderRebuildTask.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/tasks/ChunkRenderRebuildTask.java
@@ -8,6 +8,7 @@ import com.gtnewhorizons.angelica.config.AngelicaConfig;
 import com.gtnewhorizons.angelica.mixins.interfaces.ITexturesCache;
 import com.gtnewhorizons.angelica.rendering.AngelicaBlockSafetyRegistry;
 import com.gtnewhorizons.angelica.rendering.AngelicaRenderQueue;
+import com.gtnewhorizons.angelica.utils.AnimationsRenderUtils;
 import it.unimi.dsi.fastutil.longs.LongArrayFIFOQueue;
 import me.jellysquid.mods.sodium.client.SodiumClientMod;
 import me.jellysquid.mods.sodium.client.render.chunk.ChunkGraphicsState;
@@ -132,7 +133,10 @@ public class ChunkRenderRebuildTask<T extends ChunkGraphicsState> extends ChunkR
 
         final WorldSlice slice = cache.getWorldSlice();
         final RenderBlocks renderBlocks = new RenderBlocks(slice);
-        if(renderBlocks instanceof ITexturesCache) ((ITexturesCache)renderBlocks).enableTextureTracking();
+        if(renderBlocks instanceof ITexturesCache textureCache) {
+            textureCache.enableTextureTracking();
+            AnimationsRenderUtils.pushCache(textureCache);
+        }
 
         final int baseX = this.render.getOriginX();
         final int baseY = this.render.getOriginY();
@@ -217,6 +221,10 @@ public class ChunkRenderRebuildTask<T extends ChunkGraphicsState> extends ChunkR
             }
         }
 
+        if(renderBlocks instanceof ITexturesCache) {
+            AnimationsRenderUtils.popCache();
+        }
+
         handleRenderBlocksTextures(renderBlocks, renderData);
 
         if(hasMainThreadBlocks) {
@@ -263,7 +271,10 @@ public class ChunkRenderRebuildTask<T extends ChunkGraphicsState> extends ChunkR
         final int baseZ = this.render.getOriginZ();
         final BlockPos renderOffset = this.offset;
         final RenderBlocks rb = new RenderBlocks(slice.getWorld());
-        if(rb instanceof ITexturesCache) ((ITexturesCache)rb).enableTextureTracking();
+        if(rb instanceof ITexturesCache textureCache) {
+            textureCache.enableTextureTracking();
+            AnimationsRenderUtils.pushCache(textureCache);
+        }
         while(!mainThreadBlocks.isEmpty()) {
             final long longPos = mainThreadBlocks.dequeueLong();
             if (cancellationSource.isCancelled()) {
@@ -301,6 +312,10 @@ public class ChunkRenderRebuildTask<T extends ChunkGraphicsState> extends ChunkR
             }
 
             if(AngelicaConfig.enableIris) buffers.iris$resetBlockContext();
+        }
+
+        if(rb instanceof ITexturesCache) {
+            AnimationsRenderUtils.popCache();
         }
 
         handleRenderBlocksTextures(rb, renderData);

--- a/src/mixin/java/com/gtnewhorizons/angelica/mixins/early/angelica/MixinMinecraft.java
+++ b/src/mixin/java/com/gtnewhorizons/angelica/mixins/early/angelica/MixinMinecraft.java
@@ -64,7 +64,7 @@ public abstract class MixinMinecraft {
         angelica$lastFrameTime = time;
     }
 
-    @WrapOperation(method = "runGameLoop", at = @At(value = "INVOKE", target = "Lorg/lwjgl/opengl/Display;sync(I)V"))
+    @WrapOperation(method = "runGameLoop", at = @At(value = "INVOKE", target = "Lorg/lwjgl/opengl/Display;sync(I)V", remap = false))
     private void angelica$noopFPSLimiter(int fps, Operation<Void> original) {
         if (AngelicaConfig.sleepBeforeSwap) return;
         original.call(fps);

--- a/src/mixin/java/com/gtnewhorizons/angelica/mixins/early/angelica/animation/MixinChunkCache.java
+++ b/src/mixin/java/com/gtnewhorizons/angelica/mixins/early/angelica/animation/MixinChunkCache.java
@@ -1,5 +1,6 @@
 package com.gtnewhorizons.angelica.mixins.early.angelica.animation;
 
+import com.gtnewhorizons.angelica.mixins.interfaces.IPatchedTextureAtlasSprite;
 import com.gtnewhorizons.angelica.mixins.interfaces.ITexturesCache;
 import net.minecraft.util.IIcon;
 import net.minecraft.world.ChunkCache;
@@ -21,6 +22,11 @@ public class MixinChunkCache implements ITexturesCache {
 
     @Override
     public void enableTextureTracking() {
+
+    }
+
+    @Override
+    public void track(IPatchedTextureAtlasSprite sprite) {
 
     }
 }

--- a/src/mixin/java/com/gtnewhorizons/angelica/mixins/early/angelica/animation/MixinRenderBlocks.java
+++ b/src/mixin/java/com/gtnewhorizons/angelica/mixins/early/angelica/animation/MixinRenderBlocks.java
@@ -53,10 +53,12 @@ public class MixinRenderBlocks implements ITexturesCache {
             icon = overrideBlockTexture;
         }
 
-        AnimationsRenderUtils.markBlockTextureForUpdate(icon, blockAccess);
+        if (icon != null) {
+            AnimationsRenderUtils.markBlockTextureForUpdate(icon, blockAccess);
 
-        if(this.enableSpriteTracking) {
-            this.renderedSprites.add(icon);
+            if(this.enableSpriteTracking) {
+                this.renderedSprites.add(icon);
+            }
         }
     }
 

--- a/src/mixin/java/com/gtnewhorizons/angelica/mixins/early/angelica/animation/MixinTextureAtlasSprite.java
+++ b/src/mixin/java/com/gtnewhorizons/angelica/mixins/early/angelica/animation/MixinTextureAtlasSprite.java
@@ -1,11 +1,17 @@
 package com.gtnewhorizons.angelica.mixins.early.angelica.animation;
 
 import com.gtnewhorizons.angelica.mixins.interfaces.IPatchedTextureAtlasSprite;
+import com.gtnewhorizons.angelica.mixins.interfaces.ISpriteExt;
+import com.gtnewhorizons.angelica.utils.AnimationsRenderUtils;
+import com.llamalad7.mixinextras.injector.ModifyReturnValue;
+
+import net.minecraft.block.BlockPortal;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.client.resources.data.AnimationMetadataSection;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
 
 import java.util.List;
 
@@ -53,5 +59,14 @@ public abstract class MixinTextureAtlasSprite implements IPatchedTextureAtlasSpr
             this.frameCounter = (this.frameCounter + 1) % j;
             this.tickCounter = 0;
         }
+    }
+
+    @ModifyReturnValue(method = "getMinU", at = @At("RETURN"))
+    private float angelica$onUVAccessed(float value) {
+        if (((ISpriteExt)this).isAnimation()) {
+            AnimationsRenderUtils.onSpriteUsed(this);
+            needsAnimationUpdate = true;
+        }
+        return value;
     }
 }

--- a/src/mixin/java/com/gtnewhorizons/angelica/mixins/early/angelica/animation/MixinWorldRenderer.java
+++ b/src/mixin/java/com/gtnewhorizons/angelica/mixins/early/angelica/animation/MixinWorldRenderer.java
@@ -49,4 +49,9 @@ public class MixinWorldRenderer implements ITexturesCache {
     public void enableTextureTracking() {
 
     }
+
+    @Override
+    public void track(IPatchedTextureAtlasSprite sprite) {
+
+    }
 }


### PR DESCRIPTION
This fixes a few of the remaining broken animations, and does so in a way that should be relatively future-proof. It hooks into the getMinU method instead of requiring renderers to mark IIcons dirty. Unfortunately this means that it requires a thread local stack, but I haven't noticed a performance hit at all. The thread local is only accessed when a chunk is rebuilt, so even if it's a slight performance hit, it shouldn't be noticeable.

In-world modded liquids are still broken, but I can't be bothered to figure out why since no one looks at them anyways.

Here's a spark profile from me spamming f3 + a. It didn't capture any of the worker threads, but I didn't notice any obvious  slowdowns or memory leaks.
https://spark.lucko.me/pkwQWC2Sfr

These gifs loop very poorly, but that's from the recording software I used. In game the animations are fine.

Some fixed animations (catalyst housing & soul fire) + sanity test:
![anim 1](https://github.com/user-attachments/assets/69db7951-d63d-4051-8a81-4723a5416813)

Fixed controller animations (they were so slow they were unnoticeable):
![anim 2](https://github.com/user-attachments/assets/bf07aa36-6ca5-468c-a5a4-5fb3a27e516c)
![anim 3](https://github.com/user-attachments/assets/5031f468-61ce-426c-a604-4f0bd3a9e2a8)
