### PR TITLE
Add functionality to fake blockId for shaders

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -15,7 +15,7 @@
 
 # Required Dependencies
 * [UniMixins](https://github.com/LegacyModdingMC/UniMixins/releases) >= 0.1.19
-* [GTNHLib](https://github.com/GTNewHorizons/GTNHLib/releases) >= 0.6.6
+* [GTNHLib](https://github.com/GTNewHorizons/GTNHLib/releases) >= 0.6.20
 * NOTE: Some mods are not required, but a specific version is required if present - see: `Permanent Incompatibilities` below.
 
 # Known (temporary) Incompatibilities

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -61,7 +61,7 @@ dependencies {
 
     // Iris Shaders
     compileOnly('org.jetbrains:annotations:26.0.2')
-    api("com.github.GTNewHorizons:GTNHLib:0.6.13:dev")
+    api("com.github.GTNewHorizons:GTNHLib:0.6.20:dev")
     shadowImplementation("org.anarres:jcpp:1.4.14") // Apache 2.0
     shadowImplementation("org.taumc:glsl-transformation-lib:0.2.0-4.g6b42bca") {
         exclude module: "antlr4" // we only want to shadow the runtime module

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/compile/buffers/ChunkModelVertexTransformer.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/compile/buffers/ChunkModelVertexTransformer.java
@@ -17,7 +17,7 @@ public class ChunkModelVertexTransformer extends AbstractVertexTransformer<Model
     }
 
     @Override
-    public void writeQuad(float x, float y, float z, int color, float u, float v, int light) {
-        this.delegate.writeQuad(x + this.offset.x, y + this.offset.y, z + this.offset.z, color, u, v, light);
+    public void writeQuad(float x, float y, float z, int color, float u, float v, int light, int shaderBlockId) {
+        this.delegate.writeQuad(x + this.offset.x, y + this.offset.y, z + this.offset.z, color, u, v, light, shaderBlockId);
     }
 }

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/format/ModelVertexSink.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/format/ModelVertexSink.java
@@ -12,6 +12,7 @@ public interface ModelVertexSink extends VertexSink {
      * @param u The u-texture of the vertex
      * @param v The y-texture of the vertex
      * @param light The packed light-map coordinates of the vertex
+     * @param shaderBlockId The blockId to be passed to the shader
      */
-    void writeQuad(float x, float y, float z, int color, float u, float v, int light);
+    void writeQuad(float x, float y, float z, int color, float u, float v, int light, int shaderBlockId);
 }

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/format/hfp/HFPModelVertexBufferWriterNio.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/format/hfp/HFPModelVertexBufferWriterNio.java
@@ -14,7 +14,7 @@ public class HFPModelVertexBufferWriterNio extends VertexBufferWriterNio impleme
     }
 
     @Override
-    public void writeQuad(float x, float y, float z, int color, float u, float v, int light) {
+    public void writeQuad(float x, float y, float z, int color, float u, float v, int light, int shaderBlockId) {
         this.writeQuadInternal(
                 ModelVertexUtil.denormalizeVertexPositionFloatAsShort(x),
                 ModelVertexUtil.denormalizeVertexPositionFloatAsShort(y),

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/format/hfp/HFPModelVertexBufferWriterUnsafe.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/format/hfp/HFPModelVertexBufferWriterUnsafe.java
@@ -14,7 +14,7 @@ public class HFPModelVertexBufferWriterUnsafe extends VertexBufferWriterUnsafe i
     }
 
     @Override
-    public void writeQuad(float x, float y, float z, int color, float u, float v, int light) {
+    public void writeQuad(float x, float y, float z, int color, float u, float v, int light, int shaderBlockId) {
         this.writeQuadInternal(
                 ModelVertexUtil.denormalizeVertexPositionFloatAsShort(x),
                 ModelVertexUtil.denormalizeVertexPositionFloatAsShort(y),

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/format/sfp/SFPModelVertexBufferWriterNio.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/format/sfp/SFPModelVertexBufferWriterNio.java
@@ -13,7 +13,7 @@ public class SFPModelVertexBufferWriterNio extends VertexBufferWriterNio impleme
     }
 
     @Override
-    public void writeQuad(float x, float y, float z, int color, float u, float v, int light) {
+    public void writeQuad(float x, float y, float z, int color, float u, float v, int light, int shaderBlockId) {
         int i = this.writeOffset;
 
         ByteBuffer buffer = this.byteBuffer;

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/format/sfp/SFPModelVertexBufferWriterUnsafe.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/format/sfp/SFPModelVertexBufferWriterUnsafe.java
@@ -13,7 +13,7 @@ public class SFPModelVertexBufferWriterUnsafe extends VertexBufferWriterUnsafe i
     }
 
     @Override
-    public void writeQuad(float x, float y, float z, int color, float u, float v, int light) {
+    public void writeQuad(float x, float y, float z, int color, float u, float v, int light, int shaderBlockId) {
         long i = this.writePointer;
 
         memPutFloat(i, x);

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/pipeline/BlockRenderer.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/pipeline/BlockRenderer.java
@@ -150,6 +150,7 @@ public class BlockRenderer {
 
         final ModelQuadOrientation order = (useSodiumLight || this.useSeparateAo) ? ModelQuadOrientation.orient(light.br) : ModelQuadOrientation.NORMAL;
 
+        int shaderBlockId = quad.getShaderBlockId();
         for (int dstIndex = 0; dstIndex < 4; dstIndex++) {
             final int srcIndex = order.getVertexIndex(dstIndex);
 
@@ -173,7 +174,7 @@ public class BlockRenderer {
             final int lm = (useSeparateAo) ? ModelQuadUtil.mergeBakedLight(quad.getLight(srcIndex), light.lm[srcIndex]) :
                 (useSodiumLight) ? light.lm[srcIndex] : quad.getLight(srcIndex);
 
-            sink.writeQuad(x, y, z, color, u, v, lm);
+            sink.writeQuad(x, y, z, color, u, v, lm, shaderBlockId);
         }
 
         final TextureAtlasSprite sprite = quad.rubidium$getSprite();

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/pipeline/FluidRenderer.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/pipeline/FluidRenderer.java
@@ -405,7 +405,7 @@ public class FluidRenderer {
 
             int light = this.quadLightData.lm[vertexIdx];
 
-            sink.writeQuad(x, y, z, color, u, v, light);
+            sink.writeQuad(x, y, z, color, u, v, light, -1);
 
             vertexIdx += lightOrder;
         }

--- a/src/main/java/net/coderbot/iris/sodium/vertex_format/terrain_xhfp/XHFPModelVertexBufferWriterNio.java
+++ b/src/main/java/net/coderbot/iris/sodium/vertex_format/terrain_xhfp/XHFPModelVertexBufferWriterNio.java
@@ -30,7 +30,7 @@ public class XHFPModelVertexBufferWriterNio extends VertexBufferWriterNio implem
 	}
 
 	@Override
-	public void writeQuad(float x, float y, float z, int color, float u, float v, int light) {
+	public void writeQuad(float x, float y, float z, int color, float u, float v, int light, int shaderBlockId) {
 		uSum += u;
 		vSum += v;
 
@@ -42,7 +42,7 @@ public class XHFPModelVertexBufferWriterNio extends VertexBufferWriterNio implem
 				ModelVertexUtil.denormalizeVertexTextureFloatAsShort(u),
 				ModelVertexUtil.denormalizeVertexTextureFloatAsShort(v),
 				light,
-				contextHolder.blockId,
+				shaderBlockId != -1 ? (short)shaderBlockId : contextHolder.blockId,
 				contextHolder.renderType,
 				ExtendedDataHelper.computeMidBlock(x, y, z, contextHolder.localPosX, contextHolder.localPosY, contextHolder.localPosZ)
 		);

--- a/src/main/java/net/coderbot/iris/sodium/vertex_format/terrain_xhfp/XHFPModelVertexBufferWriterUnsafe.java
+++ b/src/main/java/net/coderbot/iris/sodium/vertex_format/terrain_xhfp/XHFPModelVertexBufferWriterUnsafe.java
@@ -30,7 +30,7 @@ public class XHFPModelVertexBufferWriterUnsafe extends VertexBufferWriterUnsafe 
 	}
 
 	@Override
-	public void writeQuad(float x, float y, float z, int color, float u, float v, int light) {
+	public void writeQuad(float x, float y, float z, int color, float u, float v, int light, int shaderBlockId) {
 		uSum += u;
 		vSum += v;
 
@@ -42,7 +42,7 @@ public class XHFPModelVertexBufferWriterUnsafe extends VertexBufferWriterUnsafe 
 				ModelVertexUtil.denormalizeVertexTextureFloatAsShort(u),
 				ModelVertexUtil.denormalizeVertexTextureFloatAsShort(v),
 				light,
-				contextHolder.blockId,
+				shaderBlockId != -1 ? (short)shaderBlockId : contextHolder.blockId,
 				contextHolder.renderType,
 				ExtendedDataHelper.computeMidBlock(x, y, z, contextHolder.localPosX, contextHolder.localPosY, contextHolder.localPosZ)
 		);


### PR DESCRIPTION
My version of overriding blockids for shaders, to allow each quad to have their own effect.
Should be compatible with all shaders that us the optifine blockId logic to select materials. For example needed for LittleTiles, to have multiple different effects inside a block.

Also see
- The needed GTNH Lib change: https://github.com/GTNewHorizons/GTNHLib/pull/114
- The LittleTiles example that uses this: https://github.com/DarkShadow44/LittleTiles/commit/acac13a74178af2d3df23eeae58f9970fe9401e3

Alternative to https://github.com/GTNewHorizons/Angelica/pull/869, posted here for better visibility, testing and review.