### PR TITLE
Optimize NEI rendering

### DIFF
--- a/src/main/java/com/gtnewhorizons/angelica/glsm/Feature.java
+++ b/src/main/java/com/gtnewhorizons/angelica/glsm/Feature.java
@@ -7,9 +7,11 @@ import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.GL13;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -19,21 +21,25 @@ public class Feature {
         GL13.GL_MULTISAMPLE_BIT, GL11.GL_PIXEL_MODE_BIT, GL11.GL_POINT_BIT, GL11.GL_POLYGON_BIT, GL11.GL_POLYGON_STIPPLE_BIT, GL11.GL_SCISSOR_BIT,
         GL11.GL_STENCIL_BUFFER_BIT, GL11.GL_TEXTURE_BIT, GL11.GL_TRANSFORM_BIT, GL11.GL_VIEWPORT_BIT };
 
-    static final Int2ObjectMap<Set<IStateStack<?>>> maskToFeaturesMap = new Int2ObjectOpenHashMap<>();
+    static final Int2ObjectMap<List<IStateStack<?>>> maskToFeaturesMap = new Int2ObjectOpenHashMap<>();
 
-    static Set<IStateStack<?>> maskToFeatures(int mask) {
+    static List<IStateStack<?>> maskToFeatures(int mask) {
         if(maskToFeaturesMap.containsKey(mask)) {
             return maskToFeaturesMap.get(mask);
         }
 
         final Set<IStateStack<?>> features = new HashSet<>();
+
         for(int attrib : Feature.supportedAttribs) {
             if((mask & attrib) == attrib) {
                 features.addAll(getFeatures(attrib));
             }
         }
-        maskToFeaturesMap.put(mask, features);
-        return features;
+
+        final List<IStateStack<?>> asList = new ArrayList<>(features);
+
+        maskToFeaturesMap.put(mask, asList);
+        return asList;
     }
 
     private static final Map<Integer, Set<IStateStack<?>>> attribToFeatures = new HashMap<>();

--- a/src/main/java/com/gtnewhorizons/angelica/glsm/GLStateManager.java
+++ b/src/main/java/com/gtnewhorizons/angelica/glsm/GLStateManager.java
@@ -26,6 +26,7 @@ import com.gtnewhorizons.angelica.glsm.texture.TextureInfoCache;
 import com.gtnewhorizons.angelica.glsm.texture.TextureTracker;
 import com.gtnewhorizons.angelica.hudcaching.HUDCaching;
 import com.gtnewhorizons.angelica.loading.AngelicaTweaker;
+import cpw.mods.fml.relauncher.ReflectionHelper;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import it.unimi.dsi.fastutil.ints.IntArrayList;
@@ -35,6 +36,7 @@ import it.unimi.dsi.fastutil.objects.Object2ObjectArrayMap;
 import it.unimi.dsi.fastutil.objects.ObjectArraySet;
 import lombok.Getter;
 import lombok.Setter;
+import lombok.SneakyThrows;
 import net.coderbot.iris.Iris;
 import net.coderbot.iris.gbuffer_overrides.state.StateTracker;
 import net.coderbot.iris.gl.blending.AlphaTestStorage;
@@ -65,12 +67,16 @@ import org.lwjgl.opengl.GLContext;
 import org.lwjgl.opengl.KHRDebug;
 
 import java.lang.Math;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.reflect.Field;
 import java.nio.ByteBuffer;
 import java.nio.DoubleBuffer;
 import java.nio.FloatBuffer;
 import java.nio.IntBuffer;
 import java.nio.ShortBuffer;
 import java.util.AbstractMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.IntSupplier;
@@ -134,10 +140,20 @@ public class GLStateManager {
     @Getter protected static final MaterialStateStack frontMaterial = new MaterialStateStack(GL11.GL_FRONT);
     @Getter protected static final MaterialStateStack backMaterial = new MaterialStateStack(GL11.GL_BACK);
 
+    private static final MethodHandle MAT4_STACK_CURR_DEPTH;
+
     static {
         for (int i = 0; i < lightStates.length; i ++) {
             lightStates[i] = new BooleanStateStack(GL11.GL_LIGHT0 + i);
             lightDataStates[i] = new LightStateStack(GL11.GL_LIGHT0 + i);
+        }
+
+        try {
+            Field curr = ReflectionHelper.findField(Matrix4fStack.class, "curr");
+            curr.setAccessible(true);
+            MAT4_STACK_CURR_DEPTH = MethodHandles.lookup().unreflectGetter(curr);
+        } catch (IllegalAccessException e) {
+            throw new RuntimeException(e);
         }
     }
 
@@ -150,11 +166,18 @@ public class GLStateManager {
         while(!attribs.isEmpty()) {
             attribs.popInt();
         }
-        for(IStateStack<?> stack : Feature.maskToFeatures(GL11.GL_ALL_ATTRIB_BITS)) {
+
+        List<IStateStack<?>> stacks = Feature.maskToFeatures(GL11.GL_ALL_ATTRIB_BITS);
+        int size = stacks.size();
+
+        for(int i = 0; i < size; i++) {
+            IStateStack<?> stack = stacks.get(i);
+
             while(!stack.isEmpty()) {
                 stack.pop();
             }
         }
+
         modelViewMatrix.clear();
         projectionMatrix.clear();
     }
@@ -399,6 +422,11 @@ public class GLStateManager {
         }
     }
 
+    @SneakyThrows
+    public static int getMatrixStackDepth(Matrix4fStack stack) {
+        return (int) MAT4_STACK_CURR_DEPTH.invokeExact(stack);
+    }
+
     public static int glGetInteger(int pname) {
         if(shouldBypassCache()) {
             return GL11.glGetInteger(pname);
@@ -418,6 +446,8 @@ public class GLStateManager {
             case GL11.GL_COLOR_MATERIAL_FACE -> colorMaterialFace.getValue();
             case GL11.GL_COLOR_MATERIAL_PARAMETER -> colorMaterialParameter.getValue();
             case GL20.GL_CURRENT_PROGRAM -> activeProgram;
+            case GL11.GL_MODELVIEW_STACK_DEPTH -> getMatrixStackDepth(modelViewMatrix);
+            case GL11.GL_PROJECTION_STACK_DEPTH -> getMatrixStackDepth(projectionMatrix);
 
             default -> GL11.glGetInteger(pname);
         };
@@ -1212,13 +1242,21 @@ public class GLStateManager {
             glListNesting += 1;
             return;
         }
+
         glListId = list;
         glListMode = mode;
         GL11.glNewList(list, mode);
-        for(IStateStack<?> stack : Feature.maskToFeatures(GL11.GL_ALL_ATTRIB_BITS)) {
+
+        List<IStateStack<?>> stacks = Feature.maskToFeatures(GL11.GL_ALL_ATTRIB_BITS);
+        int size = stacks.size();
+
+        for(int i = 0; i < size; i++) {
+            IStateStack<?> stack = stacks.get(i);
+
             // Feature Stack, copy of current feature state
             glListStates.put(stack, (ISettableState<?>) ((ISettableState<?>)stack).copy());
         }
+
         if(glListMode == GL11.GL_COMPILE) {
             pushState(GL11.GL_ALL_ATTRIB_BITS);
         }
@@ -1274,15 +1312,23 @@ public class GLStateManager {
 
     public static void pushState(int mask) {
         attribs.push(mask);
-        for(IStateStack<?> stack : Feature.maskToFeatures(mask)) {
-            stack.push();
-        }
 
+        List<IStateStack<?>> stacks = Feature.maskToFeatures(mask);
+        int size = stacks.size();
+
+        for(int i = 0; i < size; i++) {
+            stacks.get(i).push();
+        }
     }
+
     public static void popState() {
         final int mask = attribs.popInt();
-        for(IStateStack<?> stack : Feature.maskToFeatures(mask)) {
-            stack.pop();
+
+        List<IStateStack<?>> stacks = Feature.maskToFeatures(mask);
+        int size = stacks.size();
+
+        for(int i = 0; i < size; i++) {
+            stacks.get(i).pop();
         }
     }
 


### PR DESCRIPTION
I'm not sure if it's universal, but NEI is notoriously slow on my computer. This PR contains some trivial optimizations to make it run quite a bit faster. Without them, my angelica dev env idles between 50 to 60 fps. With them, my dev env idles around 130 to 140 fps.

The first one is to redirect `glGetInteger(GL_MODELVIEW_STACK_DEPTH)` to use the java matrix stack instead of deferring to the native method (along with `GL_PROJECTION_STACK_DEPTH` since I was in there, but that isn't needed here). This change shouldn't have any effect since the matrix stack already mirrors the gl matrix stack.

Also, I removed an Iterator allocation in a hot path (the `pushState`/`popState` methods). I swapped out the `Set` to a `List` so that I could use an index instead of the iterator. This is a relatively minor improvement, but it was a fairly safe one so I did it anyways.

To take these profiles, I uncapped the frame rate and turned off vsync & the alternative frame limiter. I also shrunk the render distance to 2 chunks (the minimum). I opened NEI so that it was rendering, and let my game sit for around a minute. Note that the total time taken is around the same since they're both at 100% utilization due to the uncapped fps (the main thread, not cpu).

Without:
https://spark.lucko.me/TT1Clyfsa5
![image](https://github.com/user-attachments/assets/94cd3019-6b68-431a-8982-8fbc7bd2eeda)
![image](https://github.com/user-attachments/assets/6795f7b5-8247-4ed6-80a6-55c7289f60fa)


With:
https://spark.lucko.me/FGG1fIRT2u
![image](https://github.com/user-attachments/assets/78b7c93f-ce2b-46ab-9af8-e3d316ed6562)
![Screenshot From 2025-02-22 18-03-00](https://github.com/user-attachments/assets/9087e57b-d122-433a-bc5f-20c2d2b70f35)
