### PR TITLE
Update GTNHLib dependency version in README

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -15,7 +15,7 @@
 
 # Required Dependencies
 * [UniMixins](https://github.com/LegacyModdingMC/UniMixins/releases) >= 0.1.19
-* [GTNHLib](https://github.com/GTNewHorizons/GTNHLib/releases) >= 0.5.20
+* [GTNHLib](https://github.com/GTNewHorizons/GTNHLib/releases) >= 0.6.6
 * NOTE: Some mods are not required, but a specific version is required if present - see: `Permanent Incompatibilities` below.
 
 # Known (temporary) Incompatibilities


### PR DESCRIPTION
Version specified in the readme caused a crash on launch.