### PR TITLE
Fix stencil buffer does not exist

### DIFF
--- a/src/mixin/java/com/gtnewhorizons/angelica/mixins/early/shaders/MixinFramebuffer.java
+++ b/src/mixin/java/com/gtnewhorizons/angelica/mixins/early/shaders/MixinFramebuffer.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 import net.coderbot.iris.rendertarget.IRenderTargetExt;
 import net.minecraft.client.renderer.OpenGlHelper;
 import net.minecraft.client.shader.Framebuffer;
+import net.minecraftforge.client.MinecraftForgeClient;
 import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.GL14;
 import org.lwjgl.opengl.GL30;
@@ -81,8 +82,15 @@ public abstract class MixinFramebuffer implements IRenderTargetExt {
             GL11.glTexParameteri(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_WRAP_S, GL11.GL_CLAMP);
             GL11.glTexParameteri(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_WRAP_T, GL11.GL_CLAMP);
             GL11.glTexParameteri(GL11.GL_TEXTURE_2D, GL14.GL_TEXTURE_COMPARE_MODE, 0);
-            GLStateManager.glTexImage2D(GL11.GL_TEXTURE_2D, 0, GL11.GL_DEPTH_COMPONENT, width, height, 0, GL11.GL_DEPTH_COMPONENT, GL11.GL_FLOAT, (IntBuffer) null);
+            if (MinecraftForgeClient.getStencilBits() != 0) {
+                GLStateManager.glTexImage2D(GL11.GL_TEXTURE_2D, 0, GL30.GL_DEPTH24_STENCIL8, width, height, 0, GL30.GL_DEPTH_STENCIL, GL30.GL_UNSIGNED_INT_24_8, (IntBuffer) null);
+            } else {
+                GLStateManager.glTexImage2D(GL11.GL_TEXTURE_2D, 0, GL11.GL_DEPTH_COMPONENT, width, height, 0, GL11.GL_DEPTH_COMPONENT, GL11.GL_FLOAT, (IntBuffer) null);
+            }
             OpenGlHelper.func_153188_a/*glFramebufferTexture2D*/(GL30.GL_FRAMEBUFFER, GL30.GL_DEPTH_ATTACHMENT, GL11.GL_TEXTURE_2D, this.iris$depthTextureId, 0);
+            if (MinecraftForgeClient.getStencilBits() != 0) {
+                OpenGlHelper.func_153188_a/*glFramebufferTexture2D*/(GL30.GL_FRAMEBUFFER, GL30.GL_STENCIL_ATTACHMENT, GL11.GL_TEXTURE_2D, this.iris$depthTextureId, 0);
+            }
         }
     }
 


### PR DESCRIPTION
This PR fixes FBO is provided without stencil buffer when Angelica is loaded and [StencilBits parameter is enabled on Forge](https://github.com/GTNewHorizons/ModularUI2/blob/a190b0da807b917407e8210daeb13759af7e79d5/src/main/java/com/cleanroommc/modularui/ClientProxy.java#L57)

MixinFlameBuffer mixins frame buffer class, creates its own FBO with its own depth buffer.
However, it does not consider stencil buffer is also created in the targeted function if the configuration is enabled, so the Minecraft standard FBO will always be delivered without the stencil buffer.
(Gl11.glGetInteger(GL_STENCIL_BITS) is always zero)
I found some mods [uses stencil buffer to scissor the edge of scroll bars](https://github.com/GTNewHorizons/ModularUI2/blob/a190b0da807b917407e8210daeb13759af7e79d5/src/main/java/com/cleanroommc/modularui/drawable/Stencil.java#L95) on vanilla FBO, so I think this should be fixed

Bugged scroll bar from ModularUI:

https://github.com/user-attachments/assets/3d0ad82d-55da-4bbf-bf5c-a83e2b7c3c34

