### PR TITLE
fix: camera position inaccuracies at far coordrinates

### DIFF
--- a/src/main/java/net/coderbot/iris/uniforms/CameraUniforms.java
+++ b/src/main/java/net/coderbot/iris/uniforms/CameraUniforms.java
@@ -1,7 +1,6 @@
 package net.coderbot.iris.uniforms;
 
 import com.gtnewhorizons.angelica.rendering.RenderingState;
-import lombok.Getter;
 import net.coderbot.iris.gl.uniform.UniformHolder;
 import net.minecraft.client.Minecraft;
 import org.joml.Vector3d;
@@ -22,11 +21,15 @@ public class CameraUniforms {
 		final CameraPositionTracker tracker = new CameraPositionTracker(notifier);
 
 		uniforms
-			.uniform1f(ONCE, "near", () -> 0.05)
-			.uniform1f(PER_FRAME, "far", CameraUniforms::getRenderDistanceInBlocks)
-			.uniform3d(PER_FRAME, "cameraPosition", tracker::getCurrentCameraPosition)
-			.uniform1f(PER_FRAME, "eyeAltitude", tracker::getCurrentCameraPositionY)
-			.uniform3d(PER_FRAME, "previousCameraPosition", tracker::getPreviousCameraPosition);
+            .uniform1f(ONCE, "near", () -> 0.05f)
+            .uniform1f(PER_FRAME, "far", CameraUniforms::getRenderDistanceInBlocks)
+            .uniform3d(PER_FRAME, "cameraPosition", tracker::getCurrentCameraPosition)
+            .uniform3d(PER_FRAME, "previousCameraPosition", tracker::getPreviousCameraPosition)
+            .uniform1f(PER_FRAME, "eyeAltitude", tracker::getCurrentCameraPositionY)
+            // Optional but useful for motion blur or velocity-based shaders
+            .uniform1f(PER_FRAME, "difX", () -> (float) (tracker.getCurrentCameraPosition().x - tracker.getPreviousCameraPosition().x))
+            .uniform1f(PER_FRAME, "difY", () -> (float) (tracker.getCurrentCameraPosition().y - tracker.getPreviousCameraPosition().y))
+            .uniform1f(PER_FRAME, "difZ", () -> (float) (tracker.getCurrentCameraPosition().z - tracker.getPreviousCameraPosition().z));
 	}
 
 	private static int getRenderDistanceInBlocks() {
@@ -45,66 +48,85 @@ public class CameraUniforms {
 		 * a noticeable change in shader animations and similar. 1000024 is the number used by Optifine for walking (however this is too much, so we choose 30000),
 		 * with an extra 1024 check for if the user has teleported between camera positions.
 		 */
-		private static final double WALK_RANGE = 30000;
-		private static final double TP_RANGE = 1000;
+        private static final double WALK_RANGE = 30000; // Maximum range for walking
+        private static final double TP_RANGE = 1000; // Maximum range for teleportation
 
-		@Getter
-        private Vector3d previousCameraPosition = new Vector3d();
-		@Getter
-        private Vector3d currentCameraPosition = new Vector3d();
-		private final Vector3d shift = new Vector3d();
+        private final Vector3d previousCameraPosition = new Vector3d();
+        private final Vector3d currentCameraPosition = new Vector3d();
+        private final Vector3d shift = new Vector3d();
+
 
 		CameraPositionTracker(FrameUpdateNotifier notifier) {
 			notifier.addListener(this::update);
 		}
 
-		private void update() {
-			previousCameraPosition = currentCameraPosition;
-			currentCameraPosition = getUnshiftedCameraPosition().add(shift);
+        /**
+         * Called once per frame. Updates the camera position and adjusts for large world coordinates if needed.
+         */
+        private void update() {
+            previousCameraPosition.set(currentCameraPosition);
+            currentCameraPosition.set(getUnshiftedCameraPosition()).add(shift);
 
-			updateShift();
-		}
+            updateShift();
+        }
 
-		/**
-		 * Updates our shift values to try to keep |x| < 30000 and |z| < 30000, to maintain precision with cameraPosition.
-		 * Since our actual range is 60000x60000, this means that we won't excessively move back and forth when moving
-		 * around a chunk border.
-		 */
-		private void updateShift() {
-			final double dX = getShift(currentCameraPosition.x, previousCameraPosition.x);
-			final double dZ = getShift(currentCameraPosition.z, previousCameraPosition.z);
+        /**
+         * Updates the shift if the camera's position has moved too far.
+         */
+        private void updateShift() {
+            double dX = getShift(currentCameraPosition.x, previousCameraPosition.x);
+            double dZ = getShift(currentCameraPosition.z, previousCameraPosition.z);
 
-			if (dX != 0.0 || dZ != 0.0) {
-				applyShift(dX, dZ);
-			}
-		}
+            if (dX != 0.0 || dZ != 0.0) {
+                applyShift(dX, dZ);
+            }
+        }
 
-		private static double getShift(double value, double prevValue) {
-			if (Math.abs(value) > WALK_RANGE || Math.abs(value - prevValue) > TP_RANGE) {
-				// Only shift by increments of WALK_RANGE - this is required for some packs (like SEUS PTGI) to work properly
-				return -(value - (value % WALK_RANGE));
-			} else {
-				return 0.0;
-			}
-		}
+        /**
+         * Determines how much to shift axis.
+         * - If the camera moves beyond ±WALK_RANGE Teleportation > TP_RANGE, shift is applied.
+         */
+        private static double getShift(double value, double prevValue) {
+            if (Math.abs(value) > WALK_RANGE || Math.abs(value - prevValue) > TP_RANGE) {
+                return -(value - (value % WALK_RANGE)); // Shift back to avoid precision issues
+            } else {
+                return 0.0;
+            }
+        }
 
-		/**
-		 * Shifts all current and future positions by the given amount. This is done in such a way that the difference
-		 * between cameraPosition and previousCameraPosition remains the same, since they are completely arbitrary
-		 * to the shader for the most part.
-		 */
-		private void applyShift(double dX, double dZ) {
-			shift.x += dX;
-			currentCameraPosition.x += dX;
-			previousCameraPosition.x += dX;
+        /**
+         * Applies the calculated shift to the current and previous camera positions.
+         */
+        private void applyShift(double dX, double dZ) {
+            shift.x += dX;
+            shift.z += dZ;
 
-			shift.z += dZ;
-			currentCameraPosition.z += dZ;
-			previousCameraPosition.z += dZ;
-		}
+            currentCameraPosition.x += dX;
+            previousCameraPosition.x += dX;
 
+            currentCameraPosition.z += dZ;
+            previousCameraPosition.z += dZ;
+        }
+
+        /**
+         * Returns the current camera's Y position.
+         */
         public double getCurrentCameraPositionY() {
-			return currentCameraPosition.y;
-		}
-	}
+            return currentCameraPosition.y;
+        }
+
+        /**
+         * Returns a defensive copy of the previous camera position to prevent external modification.
+         */
+        public Vector3d getPreviousCameraPosition() {
+            return new Vector3d(previousCameraPosition);
+        }
+
+        /**
+         * Returns a defensive copy of the current camera position to prevent external modification.
+         */
+        public Vector3d getCurrentCameraPosition() {
+            return new Vector3d(currentCameraPosition);
+        }
+    }
 }


### PR DESCRIPTION
This was causing shaders to only work in current chunk and tile entities not rendering at far coordinates