### PR TITLE
Fix `COLOR_BUFFER_BIT` leak in ShaderPackScreen

### DIFF
--- a/src/main/java/net/coderbot/iris/gui/screen/ShaderPackScreen.java
+++ b/src/main/java/net/coderbot/iris/gui/screen/ShaderPackScreen.java
@@ -1,5 +1,6 @@
 package net.coderbot.iris.gui.screen;
 
+import com.gtnewhorizons.angelica.glsm.GLStateManager;
 import com.gtnewhorizons.angelica.loading.AngelicaTweaker;
 import net.coderbot.iris.Iris;
 import net.coderbot.iris.gui.GuiUtil;
@@ -21,6 +22,7 @@ import org.jetbrains.annotations.Nullable;
 import org.lwjgl.Sys;
 import org.lwjgl.input.Keyboard;
 import org.lwjgl.input.Mouse;
+import org.lwjgl.opengl.GL11;
 
 import java.io.IOException;
 import java.net.URI;
@@ -90,6 +92,8 @@ public class ShaderPackScreen extends GuiScreen implements HudHideable {
     }
     @Override
     public void drawScreen(int mouseX, int mouseY, float delta) {
+        GLStateManager.glPushAttrib(GL11.GL_COLOR_BUFFER_BIT);
+        
         if(dirty) {
             dirty = false;
             this.initGui();
@@ -167,6 +171,8 @@ public class ShaderPackScreen extends GuiScreen implements HudHideable {
         } else {
             this.fontRendererObj.drawStringWithShadow(irisTextComponent, 2, this.height - 10, 0xFFFFFF);
         }
+        
+        GLStateManager.glPopAttrib();
     }
 
     @Override


### PR DESCRIPTION
([Adapted from here](https://github.com/kotmatross28729/Shader-fixer/blob/main/src/main/java/com/kotmatross/shadersfixer/mixins/early/client/special/MixinShaderPackScreen.java))

Fixes a leak when opening the shader selection menu

Can be seen with NTM:Space, on "Laythe":

https://github.com/user-attachments/assets/8aba54b1-273a-4184-8c3f-f573a8314a75

This happens because of this blendFunc:

https://github.com/JameH2/Hbm-s-Nuclear-Tech-GIT/blob/230c52d628886156634b3a914bee81ad13f5d086/src/main/java/com/hbm/dim/laythe/SkyProviderLaytheSunset.java#L26

Here it is after the fix:

https://github.com/user-attachments/assets/46f6cad2-0396-4d81-af04-4286fd7c91f9

I'm not sure what is the source of the problem, and the most surprising thing is that in this method... there are several leaks? For example, `net.coderbot.iris.gui.element.IrisGuiSlot.drawScreen()` and `net.minecraft.client.gui.GuiScreen.drawScreen()` - both cause a leak. I also verified that this ONLY happens in ShaderPackScreen, opening other sodium menus/settings doesn't cause this.

This is most likely due to multiple assumed states (including `GL_ALPHA_TEST` / `GL_BLEND`)

I don't know if using GLStateManager was correct, but it seems to work