### PR TITLE
Don't throw exception when trying to forward block+meta to shader while in non-world rendering pass (inventory, preview)

### DIFF
--- a/src/main/java/net/coderbot/iris/Iris.java
+++ b/src/main/java/net/coderbot/iris/Iris.java
@@ -668,14 +668,14 @@ public class Iris {
 
         int blockId = getShaderMaterialOverrideId(block, meta);
 
-        CapturingTessellator tess = (CapturingTessellator) TessellatorManager.get();
-        tess.setShaderBlockId(blockId);
+        if (TessellatorManager.get() instanceof CapturingTessellator tess)
+            tess.setShaderBlockId(blockId);
     }
 
     public static void resetShaderMaterialOverride() {
         if (!AngelicaConfig.enableIris)
             return;
-        CapturingTessellator tess = (CapturingTessellator) TessellatorManager.get();
-        tess.setShaderBlockId(-1);
+        if (TessellatorManager.get() instanceof CapturingTessellator tess)
+            tess.setShaderBlockId(-1);
     }
 }


### PR DESCRIPTION
Use instanceof instead of direct cast to protect against scenarios where mods like ForgeMicroblocks use the same rendering code for world, inventory and preview, and where the two latter happens in passes that are not rendered using a CapturingTesselator.