### PR TITLE
Battlegear 2 for Backhand compat

### DIFF
--- a/src/main/java/com/gtnewhorizons/angelica/compat/battlegear2/Battlegear2Compat.java
+++ b/src/main/java/com/gtnewhorizons/angelica/compat/battlegear2/Battlegear2Compat.java
@@ -1,0 +1,15 @@
+package com.gtnewhorizons.angelica.compat.battlegear2;
+
+import mods.battlegear2.api.core.IInventoryPlayerBattle;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+
+/**
+ * This class exists to isolate classes that exist in Battlegear 2 but not
+ * in Battlegear 2 for Backhand in order to avoid class loading exceptions.
+ */
+public class Battlegear2Compat {
+    public static ItemStack getBattlegear2Offhand(EntityPlayer player) {
+        return ((IInventoryPlayerBattle) player.inventory).battlegear2$getCurrentOffhandWeapon();
+    }
+}

--- a/src/main/java/com/gtnewhorizons/angelica/dynamiclights/DynamicLights.java
+++ b/src/main/java/com/gtnewhorizons/angelica/dynamiclights/DynamicLights.java
@@ -6,12 +6,12 @@ import com.gtnewhorizon.gtnhlib.blockpos.IBlockPos;
 import com.gtnewhorizon.gtnhlib.util.CoordinatePacker;
 import com.gtnewhorizons.angelica.api.IDynamicLightProducer;
 import com.gtnewhorizons.angelica.compat.ModStatus;
+import com.gtnewhorizons.angelica.compat.battlegear2.Battlegear2Compat;
 import com.gtnewhorizons.angelica.config.AngelicaConfig;
 import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
 import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
 import me.jellysquid.mods.sodium.client.render.SodiumWorldRenderer;
 import mods.battlegear2.api.core.IBattlePlayer;
-import mods.battlegear2.api.core.IInventoryPlayerBattle;
 import net.irisshaders.iris.api.v0.IrisApi;
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
@@ -376,7 +376,7 @@ public class DynamicLights {
                 player instanceof IBattlePlayer battlePlayer &&
                 battlePlayer.battlegear2$isBattlemode()
             ) {
-                ItemStack offhand = ((IInventoryPlayerBattle) player.inventory).battlegear2$getCurrentOffhandWeapon();
+                ItemStack offhand = Battlegear2Compat.getBattlegear2Offhand(player);
                 if (offhand != null) {
                     luminance = Math.max(luminance, getLuminanceFromItemStack(offhand, inWater));
                 }


### PR DESCRIPTION
Battlegear 2 for Backhand has `IBattlePlayer` but not `IInventoryPlayerBattle` so that latter class needs to be placed somewhere where it won't be class loaded. This works because `battlegear2$isBattlemode` is always false for the Backhand edition of BG2.