### PR TITLE
Fix CME

### DIFF
--- a/src/main/java/com/prupe/mcpatcher/mal/resource/TexturePackAPI.java
+++ b/src/main/java/com/prupe/mcpatcher/mal/resource/TexturePackAPI.java
@@ -311,19 +311,15 @@ public class TexturePackAPI {
     public static void flushUnusedTextures() {
         TextureManager textureManager = Minecraft.getMinecraft().getTextureManager();
         if (textureManager != null) {
-            Set<ResourceLocation> texturesToUnload = new HashSet<>();
             @SuppressWarnings("unchecked")
             Set<Map.Entry<ResourceLocation, ITextureObject>> entrySet = textureManager.mapTextureObjects.entrySet();
-            for (Map.Entry<ResourceLocation, ITextureObject> entry : entrySet) {
+            for (Map.Entry<ResourceLocation, ITextureObject> entry : new HashSet<>(entrySet)) {
                 ResourceLocation resource = entry.getKey();
                 ITextureObject texture = entry.getValue();
                 if (texture instanceof SimpleTexture && !(texture instanceof ThreadDownloadImageData)
                     && !TexturePackAPI.hasResource(resource)) {
-                    texturesToUnload.add(resource);
+                    unloadTexture(resource);
                 }
-            }
-            for (ResourceLocation resource : texturesToUnload) {
-                unloadTexture(resource);
             }
         }
     }


### PR DESCRIPTION
Fixes a CME on startup that i keep occasionally getting

Stacktrace:
java.util.ConcurrentModificationException
    at java.util.HashMap$HashIterator.nextNode(HashMap.java:1597)
    at java.util.HashMap$EntryIterator.next(HashMap.java:1630)
    at java.util.HashMap$EntryIterator.next(HashMap.java:1628)
    at com.prupe.mcpatcher.mal.resource.TexturePackAPI.flushUnusedTextures(TexturePackAPI.java:317)
    at com.prupe.mcpatcher.mal.resource.TexturePackChangeHandler.beforeChange1(TexturePackChangeHandler.java:114)
    at net.minecraft.client.Minecraft.handler$zgp000$angelica$modifyStartGame2(Minecraft.java:5512)
    at net.minecraft.client.Minecraft.startGame(Minecraft.java:480)
    at net.minecraft.client.Minecraft.run(Minecraft.java:7099)
    at net.minecraft.client.main.Main.main(SourceFile:148)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
    at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:568)
    at net.minecraft.launchwrapper.Launch.rfb$realLaunch(Launch.java:250)
    at net.minecraft.launchwrapper.Launch.launch(Launch.java:35)
    at net.minecraft.launchwrapper.Launch.main(Launch.java:60)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
    at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:568)
    at com.gtnewhorizons.retrofuturabootstrap.Main.main(Main.java:207)
    at org.prismlauncher.launcher.impl.StandardLauncher.launch(StandardLauncher.java:105)
    at org.prismlauncher.EntryPoint.listen(EntryPoint.java:129)
    at org.prismlauncher.EntryPoint.main(EntryPoint.java:70)