### PR TITLE
Font rendering: configurable shadow & glyph fix

### DIFF
--- a/src/main/java/com/gtnewhorizons/angelica/client/font/BatchingFontRenderer.java
+++ b/src/main/java/com/gtnewhorizons/angelica/client/font/BatchingFontRenderer.java
@@ -4,6 +4,7 @@ import static com.gtnewhorizon.gtnhlib.bytebuf.MemoryUtilities.*;
 
 import com.gtnewhorizons.angelica.glsm.GLStateManager;
 import com.gtnewhorizons.angelica.mixins.interfaces.FontRendererAccessor;
+import com.gtnewhorizons.angelica.config.AngelicaConfig;
 import it.unimi.dsi.fastutil.chars.Char2ShortOpenHashMap;
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import jss.util.RandomXoshiro256StarStar;
@@ -472,7 +473,7 @@ public class BatchingFontRenderer {
                         continue;
                     }
                     // Draw unicode char
-                    shadowOffset = 0.5F;
+                    shadowOffset = AngelicaConfig.shadowOffsetFontUC;
                     final int uniPage = chr / 256;
                     texture = getUnicodePageLocation(uniPage);
                     final int startColumn = this.glyphWidth[chr] >>> 4;

--- a/src/main/java/com/gtnewhorizons/angelica/config/AngelicaConfig.java
+++ b/src/main/java/com/gtnewhorizons/angelica/config/AngelicaConfig.java
@@ -87,6 +87,11 @@ public class AngelicaConfig {
     @Config.RequiresMcRestart
     public static boolean enableFontRenderer;
 
+    @Config.Comment("OffSet fonts shadows draw")
+    @Config.DefaultFloat(0.5F)
+    @Config.RangeFloat(min = 0.5F, max = 1F)
+    public static float shadowOffsetFontUC;
+
     @Config.Comment("Enable Dynamic Lights")
     @Config.DefaultBoolean(true)
     @Config.RequiresMcRestart

--- a/src/mixin/java/com/gtnewhorizons/angelica/mixins/early/angelica/fontrenderer/MixinFontRenderer.java
+++ b/src/mixin/java/com/gtnewhorizons/angelica/mixins/early/angelica/fontrenderer/MixinFontRenderer.java
@@ -16,6 +16,8 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
+import org.spongepowered.asm.mixin.injection.Constant;
 
 import java.util.Random;
 
@@ -185,4 +187,8 @@ public abstract class MixinFontRenderer implements FontRendererAccessor {
     @Override
     public void angelica$bindTexture(ResourceLocation location) { this.bindTexture(location); }
 
+    @ModifyConstant(method = "getCharWidth", constant = @Constant(intValue = 7))
+    private int angelica$maxCharWidth(int original) {
+        return Integer.MAX_VALUE;
+    }
 }


### PR DESCRIPTION
- Made shadowOffset configurable via new setting shadowOffsetFontUC (range 0.5F–1.0F, default 0.5F)
- Applied configurable shadow offset in BatchingFontRenderer
- Fixed getCharWidth to not force glyph width to 15 when >7 This improves compatibility with Unicode fonts and allows proper shadow tuning for non-1px glyphs.