### PR TITLE
Fix Tileentities not casting shadows

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/ChunkRenderManager.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/ChunkRenderManager.java
@@ -352,12 +352,13 @@ public class ChunkRenderManager<T extends ChunkGraphicsState> implements ChunkSt
 
     private void addEntitiesToRenderLists(ChunkRenderContainer<T> render) {
         Collection<TileEntity> tileEntities = render.getData().getTileEntities();
-
-        if (!tileEntities.isEmpty()) {
+        if (!tileEntities.isEmpty())
             this.visibleTileEntities.addAll(tileEntities);
-        }
+        Collection<TileEntity> globalTileEntities = render.getData().getGlobalTileEntities();
+        if (!globalTileEntities.isEmpty())
+            this.visibleTileEntities.addAll(globalTileEntities);
     }
-
+    
     public ChunkRenderContainer<T> getRender(int x, int y, int z) {
         ChunkRenderColumn<T> column = this.columns.get(ChunkPos.toLong(x, z));
 


### PR DESCRIPTION
Title, fixes #877

This is quite strange, but it seems that on chunk boundaries, tileentities in `ChunkRenderData` are placed in `Set<TileEntity> globalTileEntities` rather than `List<TileEntity> tileEntities`, which is why they don't cast shadows

All this PR does is put `globalTileEntities` into `visibleTileEntities`(in `ChunkRenderManager`)

Before:


<img width="1920" height="1017" alt="NOT_INFINITE_EXTENT_AABB_BEFORE" src="https://github.com/user-attachments/assets/ac47369b-93f9-4657-9bfe-a1e78133e12b" />

After:

<img width="1920" height="1017" alt="NOT_INFINITE_EXTENT_AABB_AFTER" src="https://github.com/user-attachments/assets/2d651699-399a-4cc9-a3ec-d51833f81753" />


---

This also fixes the problem where tileentities with `getRenderBoundingBox() == TileEntity.INFINITE_EXTENT_AABB` (for obvious reason) don't cast shadows:

Before:

<img width="1920" height="1017" alt="INFINITE_EXTENT_AABB_BEFORE" src="https://github.com/user-attachments/assets/963a7b6a-23fd-4b5d-9f99-f56c318c7059" />

After:

<img width="1920" height="1017" alt="INFINITE_EXTENT_AABB_AFTER" src="https://github.com/user-attachments/assets/547d8f88-7db6-45ea-a94f-4f48cd93d718" />
