### PR TITLE
Disabled force unicode

### DIFF
--- a/src/mixin/java/com/gtnewhorizons/angelica/mixins/early/shaders/MixinLocale.java
+++ b/src/mixin/java/com/gtnewhorizons/angelica/mixins/early/shaders/MixinLocale.java
@@ -79,4 +79,9 @@ public class MixinLocale {
         new LinkedList<>(definitions).descendingIterator().forEachRemaining(languageCodes::add);
     }
 
+    @Inject(method = "isUnicode", at = @At("HEAD"), cancellable = true)
+    private void iris$isUnicode(CallbackInfoReturnable<Boolean> cir) {
+        cir.setReturnValue(false);
+    }
+
 }

--- a/src/mixin/java/com/gtnewhorizons/angelica/mixins/early/shaders/MixinLocale.java
+++ b/src/mixin/java/com/gtnewhorizons/angelica/mixins/early/shaders/MixinLocale.java
@@ -23,6 +23,8 @@ public class MixinLocale {
     // storage
     @Shadow Map<String, String> field_135032_a;
 
+    @Shadow private boolean field_135029_d;
+
     @Unique
     private static final List<String> languageCodes = new ArrayList<>();
 
@@ -79,9 +81,10 @@ public class MixinLocale {
         new LinkedList<>(definitions).descendingIterator().forEachRemaining(languageCodes::add);
     }
 
-    @Inject(method = "isUnicode", at = @At("HEAD"), cancellable = true)
-    private void iris$isUnicode(CallbackInfoReturnable<Boolean> cir) {
-        cir.setReturnValue(false);
+    @Inject(method = "checkUnicode", at = @At("HEAD"), cancellable = true)
+    private void iris$checkUnicode(CallbackInfo ci) {
+        this.field_135029_d = false;
+        ci.cancel();
     }
 
 }


### PR DESCRIPTION
issue: https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/21418#issuecomment-3339007548

An old [mod](https://github.com/GTNewHorizons/Thaumic_Exploration/pull/47) disabled Unicode when loading a modpack. We fixed it to match vanilla, but that caused issues for Chinese players. This PR made Unicode switching work for all languages.