### PR TITLE
Fix blurry unicode text by not filtering it when scale factor is odd

### DIFF
--- a/src/main/java/com/gtnewhorizons/angelica/client/font/BatchingFontRenderer.java
+++ b/src/main/java/com/gtnewhorizons/angelica/client/font/BatchingFontRenderer.java
@@ -284,21 +284,7 @@ public class BatchingFontRenderer {
             }
             batchIndices.limit(cmd.startVtx + cmd.idxCount);
             batchIndices.position(cmd.startVtx);
-
-            Minecraft mc = Minecraft.getMinecraft();
-            int scaleFactor = new ScaledResolution(mc, mc.displayWidth, mc.displayHeight).getScaleFactor();
-            boolean shouldApplyFilter = cmd.isUnicode && scaleFactor % 2 != 0;
-
-            if (shouldApplyFilter) {
-                GLStateManager.glTexParameteri(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_MIN_FILTER, GL11.GL_LINEAR);
-                GLStateManager.glTexParameteri(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_MAG_FILTER, GL11.GL_LINEAR);
-            }
             GL11.glDrawElements(GL11.GL_TRIANGLES, batchIndices);
-
-            if (shouldApplyFilter) {
-                GLStateManager.glTexParameteri(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_MIN_FILTER, GL11.GL_NEAREST);
-                GLStateManager.glTexParameteri(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_MAG_FILTER, GL11.GL_NEAREST);
-            }
         }
 
         GL11.glDisableClientState(GL11.GL_TEXTURE_COORD_ARRAY);


### PR DESCRIPTION
While using GL_LINEAR when the scale factor is odd can have some anti aliasing effect, this doesn't seem to work well because it also blurred the glyphs. Below is the rendering effect of the unicode glyph using `GL_NEAREST` and `GL_LINEAR` when the scale factor is 3.
<img width="924" height="323" alt="image" src="https://github.com/user-attachments/assets/30200fda-4a6c-4766-90f4-d51c1d05f540" />
<img width="786" height="284" alt="image" src="https://github.com/user-attachments/assets/a0d94fb1-4490-4a62-9a29-fccbadfdacc5" />
