### PR TITLE
Fix missing GL20 in cstPoolParser

### DIFF
--- a/src/main/java/com/gtnewhorizons/angelica/loading/shared/transformers/AngelicaRedirector.java
+++ b/src/main/java/com/gtnewhorizons/angelica/loading/shared/transformers/AngelicaRedirector.java
@@ -87,7 +87,7 @@ public final class AngelicaRedirector {
         "net/minecraft/block/material/"
     };
 
-    private static final ClassConstantPoolParser cstPoolParser = new ClassConstantPoolParser(GL11, GL13, GL14, OpenGlHelper, EXTBlendFunc, ARBMultiTexture, BlockPackage, Project);
+    private static final ClassConstantPoolParser cstPoolParser = new ClassConstantPoolParser(GL11, GL13, GL14, GL20, OpenGlHelper, EXTBlendFunc, ARBMultiTexture, BlockPackage, Project);
     private static final Map<String, Map<String, String>> methodRedirects = new HashMap<>();
     private static final Map<Integer, String> glCapRedirects = new HashMap<>();
 


### PR DESCRIPTION
Fixed some GL20 calls not being redirected to GLSM