### PR TITLE
Add null check to zoom reset

### DIFF
--- a/src/main/java/com/gtnewhorizons/angelica/zoom/Zoom.java
+++ b/src/main/java/com/gtnewhorizons/angelica/zoom/Zoom.java
@@ -39,8 +39,10 @@ public class Zoom {
     }
 
     private static void resetMouseFilters(Minecraft mc) {
-        ((IMouseFilterExt) mc.entityRenderer.mouseFilterXAxis).angelica$reset();
-        ((IMouseFilterExt) mc.entityRenderer.mouseFilterYAxis).angelica$reset();
+        if (mc.entityRenderer != null) {
+            ((IMouseFilterExt) mc.entityRenderer.mouseFilterXAxis).angelica$reset();
+            ((IMouseFilterExt) mc.entityRenderer.mouseFilterYAxis).angelica$reset();
+        }
     }
 
     public static void resetZoom() {


### PR DESCRIPTION
I found this in my logs when booting one of the dailies last week:

```
[15:29:51] [Client thread/ERROR]: An uncaught exception occured while displaying the init error screen, making normal report instead
java.lang.NullPointerException: Cannot read field "field_78527_v" because "mc.field_71460_t" is null
        at Launch//com.gtnewhorizons.angelica.zoom.Zoom.resetMouseFilters(Zoom.java:42) ~[Zoom.class:?]
        at Launch//com.gtnewhorizons.angelica.zoom.Zoom.resetZoom(Zoom.java:51) ~[Zoom.class:?]
        at Launch//com.gtnewhorizons.angelica.proxy.ClientProxy.onGuiOpen(ClientProxy.java:318) ~[ClientProxy.class:?]
        at cpw.mods.fml.common.eventhandler.ASMEventHandler_303_ClientProxy_onGuiOpen_GuiOpenEvent.invoke(.dynamic) ~[?:?]
        at Launch//cpw.mods.fml.common.eventhandler.ASMEventHandler.invoke(ASMEventHandler.java:54) ~[ASMEventHandler.class:?]
        at Launch//cpw.mods.fml.common.eventhandler.EventBus.post(EventBus.java:140) ~[EventBus.class:?]
```

follow-up for #1016 
