### PR TITLE
Fix missing depth buffer writing before GUI rendering

### DIFF
--- a/src/mixin/java/com/gtnewhorizons/angelica/mixins/early/shaders/MixinEntityRenderer.java
+++ b/src/mixin/java/com/gtnewhorizons/angelica/mixins/early/shaders/MixinEntityRenderer.java
@@ -1,6 +1,7 @@
 package com.gtnewhorizons.angelica.mixins.early.shaders;
 
 import com.gtnewhorizons.angelica.compat.mojang.Camera;
+import com.gtnewhorizons.angelica.glsm.GLStateManager;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import com.llamalad7.mixinextras.sugar.Share;
@@ -21,7 +22,6 @@ import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.client.resources.IResourceManagerReloadListener;
 import net.minecraft.client.settings.GameSettings;
 import net.minecraft.entity.EntityLivingBase;
-import org.lwjgl.opengl.GL11;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
@@ -55,6 +55,7 @@ public abstract class MixinEntityRenderer implements IResourceManagerReloadListe
         pipeline.get().finalizeLevelRendering();
         pipeline.set(null);
         Program.unbind();
+        GLStateManager.glDepthMask(true);
     }
 
     @WrapOperation(method = "renderHand", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/ItemRenderer;renderItemInFirstPerson(F)V"))
@@ -100,7 +101,7 @@ public abstract class MixinEntityRenderer implements IResourceManagerReloadListe
     private void iris$beginWeatherAndwriteRainAndSnowToDepthBuffer(float partialTicks, long startTime, CallbackInfo ci, @Share("pipeline") LocalRef<WorldRenderingPipeline> pipeline) {
         pipeline.get().setPhase(WorldRenderingPhase.RAIN_SNOW);
         if (pipeline.get().shouldWriteRainAndSnowToDepthBuffer()) {
-            GL11.glDepthMask(true);
+            GLStateManager.glDepthMask(true);
         }
     }
 


### PR DESCRIPTION
Title, fixes #708

`RenderWorldLastEvent` (`ForgeHooksClient.dispatchRenderLast()`) expects depth buffer writing to be enabled, but `FinalPassRenderer.renderFinalPass()` (`pipeline.get().finalizeLevelRendering()`) disables it, causing particles/entities/TEs to render on top of the GUI

Particles before/after:


https://github.com/user-attachments/assets/5ab470c1-0e86-4dd4-a226-750dbae939d3


https://github.com/user-attachments/assets/2d6f71fc-5752-481f-b814-08a30db593c9



TEs before/after:


https://github.com/user-attachments/assets/e9b02f5f-936e-4c25-a3ff-9b8fc17c977b


https://github.com/user-attachments/assets/f2d010d5-4421-4e45-9d74-664b51944956



(Note: hand is still affected by this, since it's a bit more complicated)