### PR TITLE
Fix BE frustum culling far from spawn with shaders (fixes #965)

### DIFF
--- a/src/mixin/java/com/gtnewhorizons/angelica/mixins/early/sodium/MixinRenderGlobal.java
+++ b/src/mixin/java/com/gtnewhorizons/angelica/mixins/early/sodium/MixinRenderGlobal.java
@@ -223,6 +223,7 @@ public class MixinRenderGlobal implements IRenderGlobalExt {
         boolean hasForcedFrustum = false;
         boolean spectator = isSpectatorMode();
         Camera camera = new Camera(mc.renderViewEntity, partialTicks);
+        frustum.setPosition(camera.getPos().x, camera.getPos().y, camera.getPos().z);
 
         try {
             this.renderer.updateChunks(camera, frustum, hasForcedFrustum, sodium$frame++, spectator);


### PR DESCRIPTION
**What:** Set `Frustrum#setPosition(...)` from the current camera in
`MixinRenderGlobal#clipRenderersByFrustum` before passing the frustum to the renderer.

**Why:** Without setting the frustum origin, block entities (e.g. chests, drawers,
some doors) are incorrectly culled far from spawn (e.g. ~20k/40k) when shaders are enabled.

**How:** Initialize frustum origin with camera position each frame.

**Result:** Chests and drawer icons render correctly at large coordinates.
Fixes #965.
