### PR TITLE
Disable hardcoded custom uniforms by default

### DIFF
--- a/src/main/java/com/gtnewhorizons/angelica/config/AngelicaConfig.java
+++ b/src/main/java/com/gtnewhorizons/angelica/config/AngelicaConfig.java
@@ -166,4 +166,8 @@ public class AngelicaConfig {
     @Config.Comment("Allows unicode languages to use an odd gui scale")
     @Config.DefaultBoolean(true)
     public static boolean removeUnicodeEvenScaling;
+
+    @Config.Comment("Register HardcodedCustomUniforms in Iris Shaders. May help with compatibility in certain shader packs")
+    @Config.DefaultBoolean(false)
+    public static boolean enableHardcodedCustomUniforms;
 }

--- a/src/main/java/net/coderbot/iris/uniforms/CommonUniforms.java
+++ b/src/main/java/net/coderbot/iris/uniforms/CommonUniforms.java
@@ -1,5 +1,6 @@
 package net.coderbot.iris.uniforms;
 
+import com.gtnewhorizons.angelica.config.AngelicaConfig;
 import com.gtnewhorizons.angelica.glsm.GLStateManager;
 import com.gtnewhorizons.angelica.glsm.states.BlendState;
 import com.gtnewhorizons.angelica.glsm.texture.TextureInfo;
@@ -53,7 +54,11 @@ public final class CommonUniforms {
         IrisExclusiveUniforms.addIrisExclusiveUniforms(uniforms);
         IdMapUniforms.addIdMapUniforms(updateNotifier, uniforms, idMap, directives.isOldHandLight());
         MatrixUniforms.addMatrixUniforms(uniforms, directives);
-        HardcodedCustomUniforms.addHardcodedCustomUniforms(uniforms, updateNotifier);
+
+        if (AngelicaConfig.enableHardcodedCustomUniforms) {
+            HardcodedCustomUniforms.addHardcodedCustomUniforms(uniforms, updateNotifier);
+        }
+
         CommonUniforms.generalCommonUniforms(uniforms, updateNotifier, directives);
     }
 


### PR DESCRIPTION
Disables registering the uniforms provided by HardcodedCustomUniforms by default. These were uniforms that were shoved in as "built-in" uniforms in early versions of Iris before there was support for custom uniforms.

Given that Angelica has full support for custom uniforms now, these are not needed. They were mistakenly left wired up during the implementation of our custom uniforms, and any custom uniforms that a pack defines which collide with these will fail, as a pack is not allowed to override built-in uniforms.

There is a config option to turn them back on, but generally they shouldn't be needed. The only case where maybe they help is if there is a custom uniform that for some reason doesn't compile on Angelica, but was provided by this, but that should be extremely few and far between, if at all.