### PR TITLE
Set maxShiftBy to fix some log warnings

### DIFF
--- a/src/main/resources/mixins.angelica.early.json
+++ b/src/main/resources/mixins.angelica.early.json
@@ -4,6 +4,9 @@
   "package": "com.gtnewhorizons.angelica.mixins.early",
   "refmap": "mixins.angelica.refmap.json",
   "target": "@env(DEFAULT)",
+  "injectors":{
+    "maxShiftBy": 2
+  },
   "compatibilityLevel": "JAVA_8"
 }
 


### PR DESCRIPTION
Just a default of 2 right now, to keep things sane. 

Not sure if there is a way to set this dynamically based on the max number of shifts in your mixin system, so I just hardcoded it in the one file that was sending warnings.