### PR TITLE
[BCF] Fix z-fighting on GT ores

### DIFF
--- a/src/main/java/com/gtnewhorizons/angelica/config/AngelicaConfig.java
+++ b/src/main/java/com/gtnewhorizons/angelica/config/AngelicaConfig.java
@@ -189,17 +189,17 @@ public class AngelicaConfig {
             "net.minecraft.block.BlockStairs"
     })
     public static String[] blockCrackFixBlacklist;
-
+    
     @Config.Comment({"Block classes that have render pass other than 0 but still need to be manipulated.",
                      "Add a block class here if you see flickering (z-fighting) with fixBlockCrack enabled"
     })
     @Config.DefaultStringList({
-            "gregtech.common.blocks.BlockOres",
+            "gregtech.common.blocks.GTBlockOre",
             "shukaro.artifice.block.world.BlockOre",
             "bartworks.system.material.BWMetaGeneratedOres",
             "gtPlusPlus.core.block.base.BlockBaseOre",
     })
-    public static String[] blockCrackFixRenderPassWhitelist;
+    public static String[] blockCrackFixRenderPassWhitelist_;
 
     @Config.Comment("Register HardcodedCustomUniforms in Iris Shaders. May help with compatibility in certain shader packs")
     @Config.DefaultBoolean(false)

--- a/src/mixin/java/com/gtnewhorizons/angelica/mixins/early/angelica/bugfixes/MixinRenderBlocks_CrackFix.java
+++ b/src/mixin/java/com/gtnewhorizons/angelica/mixins/early/angelica/bugfixes/MixinRenderBlocks_CrackFix.java
@@ -239,8 +239,8 @@ public class MixinRenderBlocks_CrackFix {
 	}
 	@Unique
 	private static Class<?>[] angelica$getCrackFixRenderPassWhitelist() {
-		if (angelica$currentCrackFixWhitelistArr != AngelicaConfig.blockCrackFixRenderPassWhitelist) {
-			angelica$currentCrackFixWhitelistArr = AngelicaConfig.blockCrackFixRenderPassWhitelist;
+		if (angelica$currentCrackFixWhitelistArr != AngelicaConfig.blockCrackFixRenderPassWhitelist_) {
+			angelica$currentCrackFixWhitelistArr = AngelicaConfig.blockCrackFixRenderPassWhitelist_;
 			angelica$currentCrackFixWhitelistClasses = Arrays.stream(angelica$currentCrackFixWhitelistArr).map((name) -> {
 				try {
 					return Class.forName(name);


### PR DESCRIPTION
* Changed `gregtech.common.blocks.BlockOres` to `gregtech.common.blocks.GTBlockOre` due to the former being removed in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4984
* Changed `blockCrackFixRenderPassWhitelist` to `blockCrackFixRenderPassWhitelist_` to overwrite existing configs
