### PR TITLE
[BCF] Fix z-fighting on GT ores 2: here we go again edition

### DIFF
--- a/src/main/java/com/gtnewhorizons/angelica/config/AngelicaConfig.java
+++ b/src/main/java/com/gtnewhorizons/angelica/config/AngelicaConfig.java
@@ -194,12 +194,13 @@ public class AngelicaConfig {
                      "Add a block class here if you see flickering (z-fighting) with fixBlockCrack enabled"
     })
     @Config.DefaultStringList({
+            "gregtech.common.blocks.BlockOres",
             "gregtech.common.blocks.GTBlockOre",
             "shukaro.artifice.block.world.BlockOre",
             "bartworks.system.material.BWMetaGeneratedOres",
             "gtPlusPlus.core.block.base.BlockBaseOre",
     })
-    public static String[] blockCrackFixRenderPassWhitelist_;
+    public static String[] blockCrackFixRenderPassWhitelist__;
 
     @Config.Comment("Register HardcodedCustomUniforms in Iris Shaders. May help with compatibility in certain shader packs")
     @Config.DefaultBoolean(false)

--- a/src/mixin/java/com/gtnewhorizons/angelica/mixins/early/angelica/bugfixes/MixinRenderBlocks_CrackFix.java
+++ b/src/mixin/java/com/gtnewhorizons/angelica/mixins/early/angelica/bugfixes/MixinRenderBlocks_CrackFix.java
@@ -239,8 +239,8 @@ public class MixinRenderBlocks_CrackFix {
 	}
 	@Unique
 	private static Class<?>[] angelica$getCrackFixRenderPassWhitelist() {
-		if (angelica$currentCrackFixWhitelistArr != AngelicaConfig.blockCrackFixRenderPassWhitelist_) {
-			angelica$currentCrackFixWhitelistArr = AngelicaConfig.blockCrackFixRenderPassWhitelist_;
+		if (angelica$currentCrackFixWhitelistArr != AngelicaConfig.blockCrackFixRenderPassWhitelist__) {
+			angelica$currentCrackFixWhitelistArr = AngelicaConfig.blockCrackFixRenderPassWhitelist__;
 			angelica$currentCrackFixWhitelistClasses = Arrays.stream(angelica$currentCrackFixWhitelistArr).map((name) -> {
 				try {
 					return Class.forName(name);


### PR DESCRIPTION
Fixes #1158


Release uses the old version of GT, before `BlockOres` was replaced by `GTBlockOre`
Nightlies use GT after this change

So for now we are using both classes