### PR TITLE
Fix broken text rendering after certain characters

### DIFF
--- a/src/main/java/com/gtnewhorizons/angelica/client/font/FontProviderUnicode.java
+++ b/src/main/java/com/gtnewhorizons/angelica/client/font/FontProviderUnicode.java
@@ -37,7 +37,7 @@ public final class FontProviderUnicode implements FontProvider {
 
     @Override
     public float getUStart(char chr) {
-        final float startColumnF = (float)((this.glyphWidth[chr] & 255) >>> 4);
+        final float startColumnF = (float)((this.glyphWidth[chr] >>> 4) & 15);
         return ((float) (chr % 16 * 16) + startColumnF + 0.21f) / 256.0f;
     }
 


### PR DESCRIPTION
The PR fixes a bug where text after some chars disappeared due to some improper byte-to-int casts.
Such problem was uploaded to Mojang as [MC-13046](https://bugs.mojang.com/browse/MC/issues/MC-13046) and was fixed in MC 1.9, but Angelica's font renderer still uses the corrupted vanilla logic, which caused the same behavior.
This PR fixed that by some AND calculations, just as what Mojang have done in 1.9.