### PR TITLE
Always delete texture parameter cache

### DIFF
--- a/src/main/java/com/gtnewhorizons/angelica/glsm/texture/TextureInfoCache.java
+++ b/src/main/java/com/gtnewhorizons/angelica/glsm/texture/TextureInfoCache.java
@@ -48,7 +48,7 @@ public class TextureInfoCache {
 	}
 
 	public void onDeleteTexture(int id) {
-		if(id >= 0 && GLStateManager.isCachingEnabled()) cache.remove(id);
+		if(id >= 0) cache.remove(id);
 	}
 
 }


### PR DESCRIPTION
Remove isCachingEnabled() check since it only applies to the Splash thread, not any other thread.

This is the same exact behavior of `TextureTracker` & `PBRTextureManager`

Don't have the time to test, but should fix https://github.com/GTNewHorizons/Angelica/issues/538