### PR TITLE
Fix block meta parsing by removing space in split

### DIFF
--- a/src/main/java/net/coderbot/iris/shaderpack/materialmap/BlockEntry.java
+++ b/src/main/java/net/coderbot/iris/shaderpack/materialmap/BlockEntry.java
@@ -80,7 +80,7 @@ public class BlockEntry {
 
 		for (int index = statesStart; index < splitStates.length; index++) {
 			// Parse out one or more metadata ids
-			final String[] metaParts = splitStates[index].split(", ");
+			final String[] metaParts = splitStates[index].split(",");
 
             for (String metaPart : metaParts) {
                 try {


### PR DESCRIPTION
Super simple fix! 

Entries were already being split with whitespace (ie ``brick_stairs stone_slab:4 stone_slab:12``), having an entry like ``farmland:1, 2, 3, 4, 5, 6`` would then be parsed as ``farmland:1,`` ``2,`` ``3,`` etc. 

The current code would never see a comma with a space after, this commit fixes that so you just need a comma.