### PR TITLE
Update entity.properties formatting

### DIFF
--- a/src/mixin/java/com/gtnewhorizons/angelica/mixins/early/sodium/MixinRenderGlobal.java
+++ b/src/mixin/java/com/gtnewhorizons/angelica/mixins/early/sodium/MixinRenderGlobal.java
@@ -325,7 +325,7 @@ public class MixinRenderGlobal implements IRenderGlobalExt {
 
     @WrapOperation(method="renderEntities", at=@At(value="INVOKE", target="Lnet/minecraft/client/renderer/entity/RenderManager;renderEntitySimple(Lnet/minecraft/entity/Entity;F)Z"))
     private boolean angelica$renderEntitySimple(RenderManager instance, Entity entity, float partialTicks, Operation<Boolean> original) {
-        int entityId = -1;
+        int entityId = entity.getEntityId();
 
         Object2IntFunction<NamespacedId> entityIdMap = BlockRenderingSettings.INSTANCE.getEntityIds();
         if (entityIdMap != null) {


### PR DESCRIPTION
This should allow shaderpacks to use entity.properties with 1.7.10 naming convention. Tested with Vanilla and Biomes'O Plenty + Euphoria Patches and it seems to work.