### PR TITLE
Adds ability to match block metas

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/compile/ChunkBuildBuffers.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/compile/ChunkBuildBuffers.java
@@ -1,7 +1,8 @@
 package me.jellysquid.mods.sodium.client.render.chunk.compile;
 
 import com.gtnewhorizon.gtnhlib.client.renderer.cel.model.quad.properties.ModelQuadFacing;
-import it.unimi.dsi.fastutil.objects.Object2IntMap;
+import it.unimi.dsi.fastutil.ints.Int2IntMap;
+import it.unimi.dsi.fastutil.objects.Reference2ObjectMap;
 import net.coderbot.iris.Iris;
 import java.nio.ByteBuffer;
 import java.util.Map;
@@ -60,10 +61,10 @@ public class ChunkBuildBuffers implements ChunkBuildBuffersExt {
         }
 
         if(Iris.enabled) {
-            final Object2IntMap<Block> blockMatches = BlockRenderingSettings.INSTANCE.getBlockMatches();
+            final Reference2ObjectMap<Block, Int2IntMap> blockMetaMatches = BlockRenderingSettings.INSTANCE.getBlockMetaMatches();
 
-            if (blockMatches != null) {
-                this.iris$contextHolder = new BlockContextHolder(blockMatches);
+            if (blockMetaMatches != null) {
+                this.iris$contextHolder = new BlockContextHolder(blockMetaMatches);
             } else {
                 this.iris$contextHolder = new BlockContextHolder();
             }
@@ -160,9 +161,9 @@ public class ChunkBuildBuffers implements ChunkBuildBuffersExt {
         this.iris$contextHolder.setLocalPos(localPosX, localPosY, localPosZ);
     }
 
-    public void iris$setMaterialId(Block block, short renderType) {
+    public void iris$setMaterialId(Block block, int meta, short renderType) {
         if(!Iris.enabled) return;
-        this.iris$contextHolder.set(block, renderType);
+        this.iris$contextHolder.set(block, meta, renderType);
     }
 
     public void iris$resetBlockContext() {

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/tasks/ChunkRenderRebuildTask.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/tasks/ChunkRenderRebuildTask.java
@@ -227,14 +227,14 @@ public class ChunkRenderRebuildTask<T extends ChunkGraphicsState> extends ChunkR
                             if (ModStatus.isFluidLoggedLoaded) {
                                 if (fluid != null && canRenderInPass(fluid.getBlock(), pass)) {
                                     ChunkRenderManager.setWorldRenderPass(pass);
-                                    if(Iris.enabled)  buffers.iris$setMaterialId(fluid.getBlock(), ExtendedDataHelper.FLUID_RENDER_TYPE);
+                                    if(Iris.enabled)  buffers.iris$setMaterialId(fluid.getBlock(), 0, ExtendedDataHelper.FLUID_RENDER_TYPE);
 
                                     cache.getBlockRenderer().renderFluidLogged(cache.getWorldSlice(), fluid, renderBlocks, pos, buffers.get(pass), seed);
                                 }
                             }
                             if (canRenderInPass(block, pass) && !shouldUseSodiumFluidRendering(block)) {
                                 ChunkRenderManager.setWorldRenderPass(pass);
-                                if(Iris.enabled) buffers.iris$setMaterialId(block, ExtendedDataHelper.BLOCK_RENDER_TYPE);
+                                if(Iris.enabled) buffers.iris$setMaterialId(block, meta, ExtendedDataHelper.BLOCK_RENDER_TYPE);
 
                                 if (cache.getBlockRenderer().renderModel(cache.getWorldSlice(), renderBlocks, block, meta, pos, buffers.get(pass), true, seed)) {
                                     bounds.addBlock(relX, relY, relZ);
@@ -252,7 +252,7 @@ public class ChunkRenderRebuildTask<T extends ChunkGraphicsState> extends ChunkR
                         for (BlockRenderPass pass : BlockRenderPass.VALUES) {
                             if (canRenderInPass(block, pass)) {
                                 ChunkRenderManager.setWorldRenderPass(pass);
-                                if(Iris.enabled)  buffers.iris$setMaterialId(block, ExtendedDataHelper.FLUID_RENDER_TYPE);
+                                if(Iris.enabled)  buffers.iris$setMaterialId(block, 0, ExtendedDataHelper.FLUID_RENDER_TYPE);
 
                                 if (cache.getFluidRenderer().render(slice, cache.getWorldSlice(), block, pos, buffers.get(pass))) {
                                     bounds.addBlock(relX, relY, relZ);
@@ -363,7 +363,7 @@ public class ChunkRenderRebuildTask<T extends ChunkGraphicsState> extends ChunkR
                 if (canRenderInPass(block, pass) && !shouldUseSodiumFluidRendering(block)) {
                     ChunkRenderManager.setWorldRenderPass(pass);
                     final long seed = MathUtil.hashPos(pos.x, pos.y, pos.z);
-                    if(Iris.enabled) buffers.iris$setMaterialId(block, ExtendedDataHelper.BLOCK_RENDER_TYPE);
+                    if(Iris.enabled) buffers.iris$setMaterialId(block, meta, ExtendedDataHelper.BLOCK_RENDER_TYPE);
 
                     if (cache.getBlockRenderer().renderModel(slice.getWorld(), rb, block, meta, pos, buffers.get(pass), true, seed)) {
                         bounds.addBlock(relX, relY, relZ);

--- a/src/main/java/net/coderbot/iris/Iris.java
+++ b/src/main/java/net/coderbot/iris/Iris.java
@@ -848,14 +848,14 @@ public class Iris {
 
     private static int getShaderMaterialOverrideId(Block block, int meta) {
         if (contextHolder == null) {
-            final Object2IntMap<Block> blockMatches = BlockRenderingSettings.INSTANCE.getBlockMatches();
-            if (blockMatches == null) {
+            final it.unimi.dsi.fastutil.objects.Reference2ObjectMap<Block, it.unimi.dsi.fastutil.ints.Int2IntMap> blockMetaMatches = BlockRenderingSettings.INSTANCE.getBlockMetaMatches();
+            if (blockMetaMatches == null) {
                 return -1;
             }
-            contextHolder = new BlockContextHolder(blockMatches);
+            contextHolder = new BlockContextHolder(blockMetaMatches);
 
         }
-        contextHolder.set(block, (short) block.getRenderType());
+        contextHolder.set(block, meta, (short) block.getRenderType());
         return contextHolder.blockId;
     }
 

--- a/src/main/java/net/coderbot/iris/block_rendering/BlockRenderingSettings.java
+++ b/src/main/java/net/coderbot/iris/block_rendering/BlockRenderingSettings.java
@@ -1,8 +1,9 @@
 package net.coderbot.iris.block_rendering;
 
 import com.gtnewhorizons.angelica.compat.toremove.RenderLayer;
+import it.unimi.dsi.fastutil.ints.Int2IntMap;
 import it.unimi.dsi.fastutil.objects.Object2IntFunction;
-import it.unimi.dsi.fastutil.objects.Object2IntMap;
+import it.unimi.dsi.fastutil.objects.Reference2ObjectMap;
 import lombok.Getter;
 import net.coderbot.iris.shaderpack.materialmap.NamespacedId;
 import net.minecraft.block.Block;
@@ -15,7 +16,7 @@ public class BlockRenderingSettings {
 
 	@Getter
     private boolean reloadRequired;
-	private Object2IntMap<Block> blockMatches;
+	private Reference2ObjectMap<Block, Int2IntMap> blockMetaMatches;
 	private Map<Block, RenderLayer> blockTypeIds;
 	private Object2IntFunction<NamespacedId> entityIds;
 	private float ambientOcclusionLevel;
@@ -25,7 +26,7 @@ public class BlockRenderingSettings {
 
 	public BlockRenderingSettings() {
 		reloadRequired = false;
-		blockMatches = null;
+		blockMetaMatches = null;
 		blockTypeIds = null;
 		ambientOcclusionLevel = 1.0F;
 		disableDirectionalShading = false;
@@ -38,8 +39,8 @@ public class BlockRenderingSettings {
 	}
 
     @Nullable
-	public Object2IntMap<Block> getBlockMatches() {
-		return blockMatches;
+	public Reference2ObjectMap<Block, Int2IntMap> getBlockMetaMatches() {
+		return blockMetaMatches;
 	}
 
 	@Nullable
@@ -52,13 +53,9 @@ public class BlockRenderingSettings {
 		return entityIds;
 	}
 
-	public void setBlockMatches(Object2IntMap<Block> blockIds) {
-		if (this.blockMatches != null && this.blockMatches.equals(blockIds)) {
-			return;
-		}
-
+	public void setBlockMetaMatches(Reference2ObjectMap<Block, Int2IntMap> blockMetaIds) {
 		this.reloadRequired = true;
-		this.blockMatches = blockIds;
+		this.blockMetaMatches = blockMetaIds;
 	}
 
 	public void setBlockTypeIds(Map<Block, RenderLayer> blockTypeIds) {

--- a/src/main/java/net/coderbot/iris/pipeline/DeferredWorldRenderingPipeline.java
+++ b/src/main/java/net/coderbot/iris/pipeline/DeferredWorldRenderingPipeline.java
@@ -228,8 +228,7 @@ public class DeferredWorldRenderingPipeline implements WorldRenderingPipeline, R
             holder -> CommonUniforms.addNonDynamicUniforms(holder, programs.getPack().getIdMap(), programs.getPackDirectives(), this.updateNotifier)
         );
 
-        // TODO: BlockStateIdMap
-		BlockRenderingSettings.INSTANCE.setBlockMatches(BlockMaterialMapping.createBlockStateIdMap(programs.getPack().getIdMap().getBlockProperties()));
+		BlockRenderingSettings.INSTANCE.setBlockMetaMatches(BlockMaterialMapping.createBlockMetaIdMap(programs.getPack().getIdMap().getBlockProperties()));
 		BlockRenderingSettings.INSTANCE.setBlockTypeIds(BlockMaterialMapping.createBlockTypeMap(programs.getPack().getIdMap().getBlockRenderTypeMap()));
 
 		BlockRenderingSettings.INSTANCE.setEntityIds(programs.getPack().getIdMap().getEntityIdMap());

--- a/src/main/java/net/coderbot/iris/sodium/block_context/BlockContextHolder.java
+++ b/src/main/java/net/coderbot/iris/sodium/block_context/BlockContextHolder.java
@@ -1,11 +1,16 @@
 package net.coderbot.iris.sodium.block_context;
 
-import it.unimi.dsi.fastutil.objects.Object2IntMap;
-import it.unimi.dsi.fastutil.objects.Object2IntMaps;
+import it.unimi.dsi.fastutil.ints.Int2IntMap;
+import it.unimi.dsi.fastutil.objects.Reference2ObjectMap;
+import it.unimi.dsi.fastutil.objects.Reference2ObjectMaps;
 import net.minecraft.block.Block;
 
+/**
+ * Holds block context for shader material ID lookups.
+ * Based on Iris's approach but adapted for 1.7.10 metadata system.
+ */
 public class BlockContextHolder {
-	private final Object2IntMap<Block> blockMatches;
+	private final Reference2ObjectMap<Block, Int2IntMap> blockMetaMatches;
 
 	public int localPosX;
 	public int localPosY;
@@ -15,13 +20,13 @@ public class BlockContextHolder {
 	public short renderType;
 
 	public BlockContextHolder() {
-		this.blockMatches = Object2IntMaps.emptyMap();
+		this.blockMetaMatches = Reference2ObjectMaps.emptyMap();
 		this.blockId = -1;
 		this.renderType = -1;
 	}
 
-	public BlockContextHolder(Object2IntMap<Block> idMap) {
-		this.blockMatches = idMap;
+	public BlockContextHolder(Reference2ObjectMap<Block, Int2IntMap> idMap) {
+		this.blockMetaMatches = idMap;
 		this.blockId = -1;
 		this.renderType = -1;
 	}
@@ -32,8 +37,11 @@ public class BlockContextHolder {
 		this.localPosZ = localPosZ;
 	}
 
-	public void set(Block block, short renderType) {
-		this.blockId = (short) this.blockMatches.getOrDefault(block, -1);
+	public void set(Block block, int meta, short renderType) {
+		Int2IntMap metaMap = this.blockMetaMatches.get(block);
+		int id = metaMap != null ? metaMap.get(meta) : -1;
+
+		this.blockId = (short) id;
 		this.renderType = renderType;
 	}
 

--- a/src/main/java/net/coderbot/iris/sodium/block_context/ChunkBuildBuffersExt.java
+++ b/src/main/java/net/coderbot/iris/sodium/block_context/ChunkBuildBuffersExt.java
@@ -5,7 +5,7 @@ import net.minecraft.block.Block;
 public interface ChunkBuildBuffersExt {
 	void iris$setLocalPos(int localPosX, int localPosY, int localPosZ);
 
-	void iris$setMaterialId(Block block, short renderType);
+	void iris$setMaterialId(Block block, int meta, short renderType);
 
 	void iris$resetBlockContext();
 }


### PR DESCRIPTION
I took a peek at how modern Iris does it's blockstate matching and pretty much adapted it to 1.7.10's meta system. Did some profiling (not exactly sure what I was doing tbh) and saw there was around 4-5% less opengl calls vs the current commit 2c808fae43b2f11b200ef3ec98ef00b408922fb6.

I don't see any bad side effects or bad regressions as of now.

Let me know if I need to change anything.