### PR TITLE
Use Font.getName() instead of Font.getFontName()

### DIFF
--- a/src/main/java/com/gtnewhorizons/angelica/client/font/FontProviderCustom.java
+++ b/src/main/java/com/gtnewhorizons/angelica/client/font/FontProviderCustom.java
@@ -51,7 +51,7 @@ public final class FontProviderCustom implements FontProvider {
         }
         int fontPos = -1;
         for (int i = 0; i < availableFonts.length; i++) {
-            if (Objects.equals(myFontName, availableFonts[i].getFontName())) {
+            if (Objects.equals(myFontName, availableFonts[i].getName())) {
                 fontPos = i;
                 break;
             }

--- a/src/main/java/com/gtnewhorizons/angelica/client/font/FontStrategist.java
+++ b/src/main/java/com/gtnewhorizons/angelica/client/font/FontStrategist.java
@@ -37,7 +37,7 @@ public class FontStrategist {
             HashMultiset<String> duplicates = HashMultiset.create(); // for debugging
 
             for (Font font : availableFontsDirty) {
-                String fontName = font.getFontName();
+                String fontName = font.getName();
                 if (fontSet.containsKey(fontName)) {
                     duplicates.add(fontName);
                 } else {
@@ -57,7 +57,7 @@ public class FontStrategist {
                 sb.append(". Some fonts may be missing from the font selection menu.");
                 LOGGER.warn(sb.toString());
             }
-            availableFonts = fontSet.values().stream().sorted(Comparator.comparing(Font::getFontName)).toArray(Font[]::new);
+            availableFonts = fontSet.values().stream().sorted(Comparator.comparing(Font::getName)).toArray(Font[]::new);
 
             LOGGER.info("Got {} fonts from GraphicsEnvironment ({} after deduplication)", availableFontsDirty.length, availableFonts.length);
         }
@@ -103,10 +103,10 @@ public class FontStrategist {
         FontProviderCustom.getPrimary().setFont(null);
         FontProviderCustom.getFallback().setFont(null);
         for (int i = 0; i < availableFonts.length; i++) {
-            if (Objects.equals(FontConfig.customFontNamePrimary, availableFonts[i].getFontName())) {
+            if (Objects.equals(FontConfig.customFontNamePrimary, availableFonts[i].getName())) {
                 FontProviderCustom.getPrimary().reloadFont(i);
             }
-            if (Objects.equals(FontConfig.customFontNameFallback, availableFonts[i].getFontName())) {
+            if (Objects.equals(FontConfig.customFontNameFallback, availableFonts[i].getName())) {
                 FontProviderCustom.getFallback().reloadFont(i);
             }
         }

--- a/src/main/java/com/gtnewhorizons/angelica/client/gui/FontConfigScreen.java
+++ b/src/main/java/com/gtnewhorizons/angelica/client/gui/FontConfigScreen.java
@@ -68,10 +68,10 @@ public class FontConfigScreen extends GuiScreen {
         this.currentFallbackFontName = FontConfig.customFontNameFallback;
         this.displayedFonts = new ArrayList<>(Arrays.asList(availableFonts));
         for (int i = 0; i < availableFonts.length; i++) {
-            if (Objects.equals(this.currentPrimaryFontName, availableFonts[i].getFontName())) {
+            if (Objects.equals(this.currentPrimaryFontName, availableFonts[i].getName())) {
                 selectedPrimaryFontListPos = i;
             }
-            if (Objects.equals(this.currentFallbackFontName, availableFonts[i].getFontName())) {
+            if (Objects.equals(this.currentFallbackFontName, availableFonts[i].getName())) {
                 selectedFallbackFontListPos = i;
             }
         }
@@ -267,11 +267,11 @@ public class FontConfigScreen extends GuiScreen {
         int pos;
         pos = selectedPrimaryFontListPos;
         if (pos >= 0 && pos < displayedFonts.size()) {
-            FontConfig.customFontNamePrimary = displayedFonts.get(pos).getFontName();
+            FontConfig.customFontNamePrimary = displayedFonts.get(pos).getName();
         }
         pos = selectedFallbackFontListPos;
         if (pos >= 0 && pos < displayedFonts.size()) {
-            FontConfig.customFontNameFallback = displayedFonts.get(pos).getFontName();
+            FontConfig.customFontNameFallback = displayedFonts.get(pos).getName();
         }
 
         FontStrategist.reloadCustomFontProviders();
@@ -466,16 +466,16 @@ public class FontConfigScreen extends GuiScreen {
         if (search == null || search.isEmpty()) {
             results = new ArrayList<>(Arrays.asList(availableFonts));
         } else {
-            results = Arrays.stream(availableFonts).filter((font -> font.getFontName().toLowerCase().contains(search))).collect(Collectors.toCollection(ArrayList::new));
+            results = Arrays.stream(availableFonts).filter((font -> font.getName().toLowerCase().contains(search))).collect(Collectors.toCollection(ArrayList::new));
         }
 
         selectedPrimaryFontListPos = -1;
         selectedFallbackFontListPos = -1;
         for (int i = 0; i < results.size(); i++) {
-            if (Objects.equals(currentPrimaryFontName, results.get(i).getFontName())) {
+            if (Objects.equals(currentPrimaryFontName, results.get(i).getName())) {
                 selectedPrimaryFontListPos = i;
             }
-            if (Objects.equals(currentFallbackFontName, results.get(i).getFontName())) {
+            if (Objects.equals(currentFallbackFontName, results.get(i).getName())) {
                 selectedFallbackFontListPos = i;
             }
         }
@@ -509,10 +509,10 @@ public class FontConfigScreen extends GuiScreen {
         protected void onElemClicked(int index, boolean rightClick) {
             if (!rightClick) {
                 selectedPrimaryFontListPos = index;
-                currentPrimaryFontName = displayedFonts.get(index).getFontName();
+                currentPrimaryFontName = displayedFonts.get(index).getName();
             } else {
                 selectedFallbackFontListPos = index;
-                currentFallbackFontName = displayedFonts.get(index).getFontName();
+                currentFallbackFontName = displayedFonts.get(index).getName();
             }
             applyChanges(false);
         }
@@ -555,7 +555,7 @@ public class FontConfigScreen extends GuiScreen {
             if (index == selectedFallbackFontListPos) {
                 color &= 0x55ffff;
             }
-            drawCenteredString(fontRendererObj, displayedFonts.get(index).getFontName(), this.width / 2, y + 1, color);
+            drawCenteredString(fontRendererObj, displayedFonts.get(index).getName(), this.width / 2, y + 1, color);
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/GTNewHorizons/Angelica/issues/1219
Perhaps the [font list deduplication code](https://github.com/GTNewHorizons/Angelica/blob/ad7a0d42a868f9a8aff77cf6edbb3873a8ee3a60/src/main/java/com/gtnewhorizons/angelica/client/font/FontStrategist.java#L34-L59) is now unnecessary but I'll keep it just to be safe