### PR TITLE
Chunk Thread Saftey

### DIFF
--- a/src/main/java/com/gtnewhorizons/angelica/mixins/interfaces/IChunkTileEntityMapHolder.java
+++ b/src/main/java/com/gtnewhorizons/angelica/mixins/interfaces/IChunkTileEntityMapHolder.java
@@ -1,0 +1,7 @@
+package com.gtnewhorizons.angelica.mixins.interfaces;
+
+import com.gtnewhorizons.angelica.utils.ConcurrentTileEntityMap;
+
+public interface IChunkTileEntityMapHolder {
+    ConcurrentTileEntityMap angelica$getConcurrentTEMap();
+}

--- a/src/main/java/com/gtnewhorizons/angelica/rendering/RenderThreadContext.java
+++ b/src/main/java/com/gtnewhorizons/angelica/rendering/RenderThreadContext.java
@@ -1,0 +1,27 @@
+package com.gtnewhorizons.angelica.rendering;
+
+import com.gtnewhorizons.angelica.rendering.celeritas.world.WorldSlice;
+import net.minecraft.tileentity.TileEntity;
+
+public class RenderThreadContext {
+
+    private static final ThreadLocal<WorldSlice> currentWorldSlice = new ThreadLocal<>();
+
+    public static void set(WorldSlice slice) {
+        currentWorldSlice.set(slice);
+    }
+
+    public static void clear() {
+        currentWorldSlice.remove();
+    }
+
+    public static TileEntity getSnapshotTE(int x, int y, int z) {
+        final WorldSlice slice = currentWorldSlice.get();
+        if (slice == null) return null;
+        return slice.getTileEntity(x, y, z);
+    }
+
+    public static boolean hasWorldSlice() {
+        return currentWorldSlice.get() != null;
+    }
+}

--- a/src/main/java/com/gtnewhorizons/angelica/rendering/celeritas/threading/ThreadedAngelicaChunkBuilderMeshingTask.java
+++ b/src/main/java/com/gtnewhorizons/angelica/rendering/celeritas/threading/ThreadedAngelicaChunkBuilderMeshingTask.java
@@ -2,6 +2,7 @@ package com.gtnewhorizons.angelica.rendering.celeritas.threading;
 
 import com.gtnewhorizon.gtnhlib.client.renderer.TessellatorManager;
 import com.gtnewhorizons.angelica.rendering.AngelicaBlockSafetyRegistry;
+import com.gtnewhorizons.angelica.rendering.RenderThreadContext;
 import com.gtnewhorizons.angelica.rendering.celeritas.AngelicaChunkBuilderMeshingTask;
 import com.gtnewhorizons.angelica.rendering.celeritas.SmoothBiomeColorCache;
 import com.gtnewhorizons.angelica.rendering.celeritas.WorldClientExtension;
@@ -103,12 +104,16 @@ public class ThreadedAngelicaChunkBuilderMeshingTask extends AngelicaChunkBuilde
         enteredLocalMode = !TessellatorManager.isOnMainThread();
         if (enteredLocalMode) {
             TessellatorManager.enterLocalMode();
+            if (blockAccess instanceof WorldSlice worldSlice) {
+                RenderThreadContext.set(worldSlice);
+            }
         }
     }
 
     @Override
     protected void onExitExecute() {
         if (enteredLocalMode) {
+            RenderThreadContext.clear();
             RenderPassHelper.resetWorldRenderPass();
             TessellatorManager.exitLocalMode();
         }

--- a/src/main/java/com/gtnewhorizons/angelica/utils/ConcurrentTileEntityMap.java
+++ b/src/main/java/com/gtnewhorizons/angelica/utils/ConcurrentTileEntityMap.java
@@ -1,0 +1,203 @@
+package com.gtnewhorizons.angelica.utils;
+
+import com.gtnewhorizons.angelica.rendering.RenderThreadContext;
+import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.world.ChunkPosition;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+/**
+ * Thread-safe wrapper around Object2ObjectOpenHashMap for chunkTileEntityMap.
+ */
+public class ConcurrentTileEntityMap implements Map<ChunkPosition, TileEntity> {
+    private final Object2ObjectOpenHashMap<ChunkPosition, TileEntity> delegate = new Object2ObjectOpenHashMap<>();
+    private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
+    private final ConcurrentLinkedQueue<ChunkPosition> invalidationQueue = new ConcurrentLinkedQueue<>();
+
+    public void queueInvalidation(ChunkPosition pos) {
+        invalidationQueue.add(pos);
+    }
+
+    private void processInvalidationQueue() {
+        ChunkPosition pos;
+        while ((pos = invalidationQueue.poll()) != null) {
+            final TileEntity te = delegate.get(pos);
+            if (te != null && te.isInvalid()) {
+                delegate.remove(pos);
+            }
+        }
+    }
+
+    public void withReadLock(Runnable action) {
+        lock.readLock().lock();
+        try {
+            action.run();
+        } finally {
+            lock.readLock().unlock();
+        }
+    }
+
+    public void withWriteLock(Runnable action) {
+        lock.writeLock().lock();
+        try {
+            action.run();
+        } finally {
+            lock.writeLock().unlock();
+        }
+    }
+
+    public Object2ObjectOpenHashMap<ChunkPosition, TileEntity> getDelegate() {
+        return delegate;
+    }
+
+    public TileEntity putDirect(ChunkPosition key, TileEntity value) {
+        return delegate.put(key, value);
+    }
+
+    private static boolean isRenderWorkerThread() {
+        return RenderThreadContext.hasWorldSlice();
+    }
+
+
+    @Override
+    public TileEntity get(Object key) {
+        if (!isRenderWorkerThread()) return delegate.get(key);
+
+        lock.readLock().lock();
+        try {
+            final TileEntity te = delegate.get(key);
+            if (te != null && te.isInvalid()) {
+                if (key instanceof ChunkPosition pos) {
+                    invalidationQueue.add(pos);
+                }
+                return null;
+            }
+            return te;
+        } finally {
+            lock.readLock().unlock();
+        }
+    }
+
+    @Override
+    public TileEntity put(ChunkPosition key, TileEntity value) {
+        lock.writeLock().lock();
+        try {
+            processInvalidationQueue();
+            return delegate.put(key, value);
+        } finally {
+            lock.writeLock().unlock();
+        }
+    }
+
+    @Override
+    public TileEntity remove(Object key) {
+        if (isRenderWorkerThread()) {
+            if (key instanceof ChunkPosition pos) {
+                invalidationQueue.add(pos);
+            }
+            return null;
+        }
+        lock.writeLock().lock();
+        try {
+            processInvalidationQueue();
+            return delegate.remove(key);
+        } finally {
+            lock.writeLock().unlock();
+        }
+    }
+
+    @Override
+    public void putAll(Map<? extends ChunkPosition, ? extends TileEntity> m) {
+        lock.writeLock().lock();
+        try {
+            processInvalidationQueue();
+            delegate.putAll(m);
+        } finally {
+            lock.writeLock().unlock();
+        }
+    }
+
+    @Override
+    public void clear() {
+        lock.writeLock().lock();
+        try {
+            invalidationQueue.clear();
+            delegate.clear();
+        } finally {
+            lock.writeLock().unlock();
+        }
+    }
+
+    @Override
+    public int size() {
+        if (!isRenderWorkerThread()) return delegate.size();
+        lock.readLock().lock();
+        try {
+            return delegate.size();
+        } finally {
+            lock.readLock().unlock();
+        }
+    }
+
+    @Override
+    public boolean isEmpty() {
+        if (!isRenderWorkerThread()) return delegate.isEmpty();
+        lock.readLock().lock();
+        try {
+            return delegate.isEmpty();
+        } finally {
+            lock.readLock().unlock();
+        }
+    }
+
+    @Override
+    public boolean containsKey(Object key) {
+        if (!isRenderWorkerThread()) return delegate.containsKey(key);
+        lock.readLock().lock();
+        try {
+            return delegate.containsKey(key);
+        } finally {
+            lock.readLock().unlock();
+        }
+    }
+
+    @Override
+    public boolean containsValue(Object value) {
+        if (!isRenderWorkerThread()) return delegate.containsValue(value);
+        lock.readLock().lock();
+        try {
+            return delegate.containsValue(value);
+        } finally {
+            lock.readLock().unlock();
+        }
+    }
+
+    @Override
+    public Set<ChunkPosition> keySet() {
+        if (isRenderWorkerThread()) {
+            throw new IllegalStateException("keySet() called from render worker. Use withReadLock() for iteration.");
+        }
+        return delegate.keySet();
+    }
+
+    @Override
+    public Collection<TileEntity> values() {
+        if (isRenderWorkerThread()) {
+            throw new IllegalStateException("values() called from render worker. Use withReadLock() for iteration.");
+        }
+        return delegate.values();
+    }
+
+    @Override
+    public Set<Entry<ChunkPosition, TileEntity>> entrySet() {
+        if (isRenderWorkerThread()) {
+            throw new IllegalStateException("entrySet() called from render worker. Use withReadLock() for iteration.");
+        }
+        return delegate.entrySet();
+    }
+}

--- a/src/mixin/java/com/gtnewhorizons/angelica/mixins/early/celeritas/terrain/MixinChunk.java
+++ b/src/mixin/java/com/gtnewhorizons/angelica/mixins/early/celeritas/terrain/MixinChunk.java
@@ -2,6 +2,9 @@ package com.gtnewhorizons.angelica.mixins.early.celeritas.terrain;
 
 import java.util.Map;
 
+import com.gtnewhorizons.angelica.mixins.interfaces.IChunkTileEntityMapHolder;
+import com.gtnewhorizons.angelica.rendering.RenderThreadContext;
+import com.gtnewhorizons.angelica.utils.ConcurrentTileEntityMap;
 import net.minecraft.block.Block;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.ChunkPosition;
@@ -14,14 +17,13 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
-
 @Mixin(Chunk.class)
-public abstract class MixinChunk {
+public abstract class MixinChunk implements IChunkTileEntityMapHolder {
 
-    @Shadow public Map<ChunkPosition, TileEntity> chunkTileEntityMap = new Object2ObjectOpenHashMap<>();
+    @Shadow public Map<ChunkPosition, TileEntity> chunkTileEntityMap = new ConcurrentTileEntityMap();
     @Shadow public World worldObj;
     @Shadow private ExtendedBlockStorage[] storageArrays;
     @Final @Shadow public int xPosition;
@@ -29,41 +31,89 @@ public abstract class MixinChunk {
 
     @Shadow public abstract void addTileEntity(TileEntity te);
 
+    @Override
+    public ConcurrentTileEntityMap angelica$getConcurrentTEMap() {
+        return (ConcurrentTileEntityMap) this.chunkTileEntityMap;
+    }
+
+    @Redirect(method = "getTileEntityUnsafe", at = @At(value = "INVOKE", target = "Ljava/util/Map;get(Ljava/lang/Object;)Ljava/lang/Object;"), remap = false)
+    private Object angelica$redirectGetTEUnsafe(Map<ChunkPosition, TileEntity> map, Object key) {
+        if (RenderThreadContext.hasWorldSlice()) {
+            final ChunkPosition pos = (ChunkPosition) key;
+            final TileEntity te = RenderThreadContext.getSnapshotTE((this.xPosition << 4) + pos.chunkPosX, pos.chunkPosY, (this.zPosition << 4) + pos.chunkPosZ);
+            if (te != null) return te;
+        }
+        return map.get(key);
+    }
+
+    @Redirect(method = "func_150806_e", at = @At(value = "INVOKE", target = "Ljava/util/Map;get(Ljava/lang/Object;)Ljava/lang/Object;"))
+    private Object angelica$redirectGetTEFunc(Map<ChunkPosition, TileEntity> map, Object key) {
+        if (RenderThreadContext.hasWorldSlice()) {
+            final ChunkPosition pos = (ChunkPosition) key;
+            final TileEntity te = RenderThreadContext.getSnapshotTE((this.xPosition << 4) + pos.chunkPosX, pos.chunkPosY, (this.zPosition << 4) + pos.chunkPosZ);
+            if (te != null) return te;
+        }
+        return map.get(key);
+    }
+
+    @Redirect(method = "func_150806_e", at = @At(value = "INVOKE", target = "Ljava/util/Map;remove(Ljava/lang/Object;)Ljava/lang/Object;"))
+    private Object angelica$deferRemoveFunc150806e(Map<ChunkPosition, TileEntity> map, Object key) {
+        return angelica$deferRemoveImpl(map, key);
+    }
+
+    @Redirect(method = "getTileEntityUnsafe", at = @At(value = "INVOKE", target = "Ljava/util/Map;remove(Ljava/lang/Object;)Ljava/lang/Object;"), remap = false)
+    private Object angelica$deferRemoveGetTEUnsafe(Map<ChunkPosition, TileEntity> map, Object key) {
+        return angelica$deferRemoveImpl(map, key);
+    }
+
+    @Redirect(method = "removeInvalidTileEntity", at = @At(value = "INVOKE", target = "Ljava/util/Map;remove(Ljava/lang/Object;)Ljava/lang/Object;"), remap = false)
+    private Object angelica$deferRemoveInvalidTE(Map<ChunkPosition, TileEntity> map, Object key) {
+        return angelica$deferRemoveImpl(map, key);
+    }
+
+    private Object angelica$deferRemoveImpl(Map<ChunkPosition, TileEntity> map, Object key) {
+        if (!RenderThreadContext.hasWorldSlice()) return map.remove(key);
+        ((ConcurrentTileEntityMap) map).queueInvalidation((ChunkPosition) key);
+        return null;
+    }
+
     @Inject(method = "fillChunk", at = @At("RETURN"))
     private void angelica$createTileEntities(byte[] data, int primaryBitMask, int addBitMask, boolean groundUp, CallbackInfo ci) {
-        final boolean hasExistingTEs = !this.chunkTileEntityMap.isEmpty();
+        ((ConcurrentTileEntityMap) this.chunkTileEntityMap).withWriteLock(() -> {
+            final boolean hasExistingTEs = !this.chunkTileEntityMap.isEmpty();
 
-        for (int sectionY = 0; sectionY < this.storageArrays.length; sectionY++) {
-            if ((primaryBitMask & (1 << sectionY)) == 0) continue;
+            for (int sectionY = 0; sectionY < this.storageArrays.length; sectionY++) {
+                if ((primaryBitMask & (1 << sectionY)) == 0) continue;
 
-            final ExtendedBlockStorage section = this.storageArrays[sectionY];
-            if (section == null) continue;
+                final ExtendedBlockStorage section = this.storageArrays[sectionY];
+                if (section == null) continue;
 
-            final int baseY = sectionY << 4;
-            for (int y = 0; y < 16; y++) {
-                final int worldY = baseY + y;
-                for (int z = 0; z < 16; z++) {
-                    for (int x = 0; x < 16; x++) {
-                        final Block block = section.getBlockByExtId(x, y, z);
-                        if (block == null) continue;
-                        final int meta = section.getExtBlockMetadata(x, y, z);
-                        if (block.hasTileEntity(meta)) {
-                            if (hasExistingTEs) {
-                                final ChunkPosition pos = new ChunkPosition(x, worldY, z);
-                                final TileEntity existing = this.chunkTileEntityMap.get(pos);
-                                if (existing != null && !existing.isInvalid()) continue;
-                            }
-                            final TileEntity te = block.createTileEntity(this.worldObj, meta);
-                            if (te != null) {
-                                te.xCoord = (this.xPosition << 4) + x;
-                                te.yCoord = worldY;
-                                te.zCoord = (this.zPosition << 4) + z;
-                                this.addTileEntity(te);
+                final int baseY = sectionY << 4;
+                for (int y = 0; y < 16; y++) {
+                    final int worldY = baseY + y;
+                    for (int z = 0; z < 16; z++) {
+                        for (int x = 0; x < 16; x++) {
+                            final Block block = section.getBlockByExtId(x, y, z);
+                            if (block == null) continue;
+                            final int meta = section.getExtBlockMetadata(x, y, z);
+                            if (block.hasTileEntity(meta)) {
+                                if (hasExistingTEs) {
+                                    final ChunkPosition pos = new ChunkPosition(x, worldY, z);
+                                    final TileEntity existing = this.chunkTileEntityMap.get(pos);
+                                    if (existing != null && !existing.isInvalid()) continue;
+                                }
+                                final TileEntity te = block.createTileEntity(this.worldObj, meta);
+                                if (te != null) {
+                                    te.xCoord = (this.xPosition << 4) + x;
+                                    te.yCoord = worldY;
+                                    te.zCoord = (this.zPosition << 4) + z;
+                                    this.addTileEntity(te);
+                                }
                             }
                         }
                     }
                 }
             }
-        }
+        });
     }
 }


### PR DESCRIPTION
* Try to stop RenderingThreads from accessing the chunkTileEntityMap directly
* Defer invalid TE invalidations for the main (client) thread
* Gate most other operations behind a ReentrantReadWriteLock