### PR TITLE
Add PFAA Geologica cobble/bricks to the BlockCrackFix Whitelist

### DIFF
--- a/src/main/java/com/gtnewhorizons/angelica/config/AngelicaConfig.java
+++ b/src/main/java/com/gtnewhorizons/angelica/config/AngelicaConfig.java
@@ -210,6 +210,8 @@ public class AngelicaConfig {
             "shukaro.artifice.block.world.BlockOre",
             "bartworks.system.material.BWMetaGeneratedOres",
             "gtPlusPlus.core.block.base.BlockBaseOre",
+            "org.pfaa.geologica.block.BrokenGeoBlock",
+            "org.pfaa.geologica.block.BrickGeoBlock",
     })
     public static String[] blockCrackFixRenderPassWhitelist__;
 


### PR DESCRIPTION
Closes #524

Workaround for flickering issues with PFAA:Geologica cobble/brick blocks, similar to #1161, uses code from #1023

