### PR TITLE
Fix dependencies

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -108,8 +108,7 @@ dependencies {
 
     compileOnly("curse.maven:minefactory-reloaded-66672:2277486")
 
-    compileOnly("com.github.GTNewHorizons:NotEnoughIds:2.1.10:dev") // Mixin Version
-    compileOnly("com.github.GTNewHorizons:NotEnoughIds-Legacy:1.4.7:dev") // ASM Version
+    compileOnly("com.github.GTNewHorizons:NotEnoughIds:2.1.10:dev")
 
     compileOnly(rfg.deobf("maven.modrinth:ntmspace:X5593_H261"))
 
@@ -126,7 +125,7 @@ dependencies {
     transformedMod("net.industrial-craft:industrialcraft-2:2.2.828-experimental:dev")
 
     // Better Crashes
-    compileOnly("com.github.GTNewHorizons:BetterCrashes:1.4.0-GTNH:dev")
+    compileOnly("com.github.GTNewHorizons:BetterCrashes:1.4.1-GTNH:dev")
 
     afterEvaluate {
         dependencies {

--- a/src/main/java/com/gtnewhorizons/angelica/compat/ExtendedBlockStorageExt.java
+++ b/src/main/java/com/gtnewhorizons/angelica/compat/ExtendedBlockStorageExt.java
@@ -6,7 +6,6 @@ import com.gtnewhorizons.neid.mixins.interfaces.IExtendedBlockStorageMixin;
 import net.minecraft.world.chunk.Chunk;
 import net.minecraft.world.chunk.NibbleArray;
 import net.minecraft.world.chunk.storage.ExtendedBlockStorage;
-import ru.fewizz.idextender.Hooks;
 
 public class ExtendedBlockStorageExt extends ExtendedBlockStorage {
     public boolean hasSky;
@@ -38,12 +37,6 @@ public class ExtendedBlockStorageExt extends ExtendedBlockStorage {
                     final short[] block16BMetaArray = ((IExtendedBlockStorageMixin)(Object)this).getBlock16BMetaArray();
                     System.arraycopy(((IExtendedBlockStorageMixin)(Object)storage).getBlock16BMetaArray(), 0, block16BMetaArray, 0, block16BMetaArray.length);
                 }
-            }
-            else if (ModStatus.isOldNEIDLoaded){
-                final short[] blockLSBArray = Hooks.get(this);
-                System.arraycopy(Hooks.get(storage), 0, blockLSBArray, 0, blockLSBArray.length);
-                // getBlockMSBArray is nuked in asm version
-                arrayLen = blockLSBArray.length;
             }
             else {
                 final byte[] blockLSBArray = this.getBlockLSBArray();

--- a/src/main/java/com/gtnewhorizons/angelica/compat/ModStatus.java
+++ b/src/main/java/com/gtnewhorizons/angelica/compat/ModStatus.java
@@ -12,15 +12,8 @@ public class ModStatus {
     public static final Logger LOGGER = LogManager.getLogger("ModCompat");
 
     public static BackhandReflectionCompat backhandCompat;
-    /**
-     * Mixin Version
-     */
-    public static boolean isNEIDLoaded;
-    /**
-     * ASM Version
-     */
-    public static boolean isOldNEIDLoaded;
     public static boolean isBetterCrashesLoaded;
+    public static boolean isNEIDLoaded;
     public static boolean isNEIDMetadataExtended;
     public static boolean isLotrLoaded;
     public static boolean isChunkAPILoaded;
@@ -42,7 +35,6 @@ public class ModStatus {
 
         isBetterCrashesLoaded = Loader.isModLoaded("bettercrashes");
         isNEIDLoaded = Loader.isModLoaded("neid");
-        isOldNEIDLoaded = Loader.isModLoaded("notenoughIDs");
         isLotrLoaded = Loader.isModLoaded("lotr");
         isChunkAPILoaded = Loader.isModLoaded("chunkapi");
         isEIDBiomeLoaded = Loader.isModLoaded("endlessids_biome");


### PR DESCRIPTION
Remove support for NotEnoughIds-Legacy and update BetterCrashes dependency version, as the old files have been removed from the GTNH source.