### PR TITLE
Split MixinRenderManager into two for DAPI compat

### DIFF
--- a/src/main/java/com/gtnewhorizons/angelica/mixins/Mixins.java
+++ b/src/main/java/com/gtnewhorizons/angelica/mixins/Mixins.java
@@ -229,12 +229,29 @@ public enum Mixins implements IMixins {
             , "shaders.MixinRenderGlobal"
             , "shaders.MixinRenderHorse"
             , "shaders.MixinRenderItem"
-            , "shaders.MixinRenderManager"
             , "shaders.MixinRenderNameTag"
             , "shaders.MixinRenderPlayerArmor"
             , "shaders.MixinTileEntityBeaconRenderer"
             , "shaders.MixinRenderEndPortal"
             , "shaders.MixinTileEntityRendererDispatcher"
+        )
+    ),
+
+    IRIS_SHADERS_RENDER_MANAGER(new MixinBuilder()
+        .setPhase(Phase.EARLY)
+        .setApplyIf(() -> AngelicaConfig.enableIris)
+        .addExcludedMod(TargetedMod.DRAGON_API)
+        .addClientMixins(
+            "shaders.MixinRenderManager"
+        )
+    ),
+
+    IRIS_SHADERS_RENDER_MANAGER_DAPI(new MixinBuilder()
+        .setPhase(Phase.EARLY)
+        .setApplyIf(() -> AngelicaConfig.enableIris)
+        .addRequiredMod(TargetedMod.DRAGON_API)
+        .addClientMixins(
+            "shaders.MixinRenderManagerDAPI"
         )
     ),
 

--- a/src/mixin/java/com/gtnewhorizons/angelica/mixins/early/shaders/MixinRenderManagerDAPI.java
+++ b/src/mixin/java/com/gtnewhorizons/angelica/mixins/early/shaders/MixinRenderManagerDAPI.java
@@ -1,0 +1,31 @@
+package com.gtnewhorizons.angelica.mixins.early.shaders;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import net.coderbot.iris.uniforms.CapturedRenderingState;
+import net.coderbot.iris.uniforms.EntityIdHelper;
+import net.coderbot.iris.uniforms.ItemIdManager;
+import net.minecraft.client.renderer.entity.Render;
+import net.minecraft.client.renderer.entity.RenderManager;
+import net.minecraft.entity.Entity;
+import org.spongepowered.asm.mixin.Dynamic;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+@Mixin(RenderManager.class)
+public class MixinRenderManagerDAPI {
+
+    @Dynamic
+    @WrapOperation(
+        method = "func_147939_a(Lnet/minecraft/entity/Entity;DDDFFZ)Z",
+        at = @At(remap = false, value = "INVOKE", target = "LReika/DragonAPI/Instantiable/Event/Client/EntityRenderEvent;fire(Lnet/minecraft/client/renderer/entity/Render;Lnet/minecraft/entity/Entity;DDDFF)V"),
+        require = 1 // Require this if DAPI is present, which should be the case when this mixin is applied.
+    )
+    private void iris$wrapDoRenderDragonAPI(Render render, Entity entity, double x, double y, double z, float entityYaw, float partialTicks, Operation<Void> original) {
+        int entityId = EntityIdHelper.getEntityId(entity);
+        CapturedRenderingState.INSTANCE.setCurrentEntity(entityId);
+        ItemIdManager.resetItemId();
+        original.call(render, entity, x, y, z, entityYaw, partialTicks);
+        CapturedRenderingState.INSTANCE.setCurrentEntity(-1);
+    }
+}


### PR DESCRIPTION
This fixes the shader mixin not being applied when DAPIs ASM was loaded, and a crash if mixin debug was active.

There is another thing related to this that lead to crashes with mixin debug, that is now handled by chromatifixes: https://github.com/MalTeeez/ChromatiFixes/commit/48a7546e5e5543388cbf3f46d50015f12374bfe8#diff-6042f9332795e0b31b07b818ab12adcc7980c9cf47ef22a9cdccf56e668c71af