### PR TITLE
Add a second profiles button to Angelica

### DIFF
--- a/src/main/java/net/coderbot/iris/gui/element/widget/ProfileElementWidget.java
+++ b/src/main/java/net/coderbot/iris/gui/element/widget/ProfileElementWidget.java
@@ -8,6 +8,7 @@ import net.coderbot.iris.shaderpack.option.OptionSet;
 import net.coderbot.iris.shaderpack.option.Profile;
 import net.coderbot.iris.shaderpack.option.ProfileSet;
 import net.coderbot.iris.shaderpack.option.menu.OptionMenuProfileElement;
+import net.coderbot.iris.shaderpack.option.menu.ProfileElementTracker;
 import net.coderbot.iris.shaderpack.option.values.OptionValues;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.resources.I18n;
@@ -30,6 +31,7 @@ public class ProfileElementWidget extends BaseOptionElementWidget<OptionMenuProf
 	public void init(ShaderPackScreen screen, NavigationController navigation) {
 		super.init(screen, navigation);
 		this.setLabel(PROFILE_LABEL);
+        boolean secondProfileSet = ProfileElementTracker.isSecondProfileSet(this.element);
 
 		final ProfileSet profiles = this.element.profiles;
         final OptionSet options = this.element.options;
@@ -41,7 +43,8 @@ public class ProfileElementWidget extends BaseOptionElementWidget<OptionMenuProf
 		this.previous = result.previous;
         final Optional<String> profileName = result.current.map(p -> p.name);
 
-		this.profileLabel = profileName.map(name -> GuiUtil.translateOrDefault(name, "profile." + name)).orElse(PROFILE_CUSTOM);
+        String translationKey = "profile" + (secondProfileSet ? "2." : ".") + profileName.orElse("custom");
+        this.profileLabel = profileName.map(name -> GuiUtil.translateOrDefault(name, translationKey)).orElse(PROFILE_CUSTOM);
 	}
 
 	@Override
@@ -63,7 +66,7 @@ public class ProfileElementWidget extends BaseOptionElementWidget<OptionMenuProf
 
 	@Override
 	public String getCommentKey() {
-		return "profile.comment";
+        return ProfileElementTracker.isSecondProfileSet(this.element) ? "profile2.comment" : "profile.comment";
 	}
 
 	@Override

--- a/src/main/java/net/coderbot/iris/shaderpack/ShaderProperties.java
+++ b/src/main/java/net/coderbot/iris/shaderpack/ShaderProperties.java
@@ -97,6 +97,7 @@ public class ShaderProperties {
 	@Getter private OptionalBoolean prepareBeforeShadow = OptionalBoolean.DEFAULT;
 	@Getter private List<String> sliderOptions = new ArrayList<>();
 	@Getter private final Map<String, List<String>> profiles = new LinkedHashMap<>();
+    @Getter private final Map<String, List<String>> profiles2 = new LinkedHashMap<>();
 	private List<String> mainScreenOptions = null;
 	@Getter private final Map<String, List<String>> subScreenOptions = new HashMap<>();
 	private Integer mainScreenColumnCount = null;
@@ -517,6 +518,7 @@ public class ShaderProperties {
 			// the last definition being used, should be tested if behavior matches OptiFine
 			handleWhitespacedListDirective(key, value, "sliders", sliders -> sliderOptions = sliders);
 			handlePrefixedWhitespacedListDirective("profile.", key, value, profiles::put);
+            handlePrefixedWhitespacedListDirective("profile2.", key, value, profiles2::put);
 
 			if (handleIntDirective(key, value, "screen.columns", columns -> mainScreenColumnCount = columns)) {
 				return;

--- a/src/main/java/net/coderbot/iris/shaderpack/option/menu/OptionMenuContainer.java
+++ b/src/main/java/net/coderbot/iris/shaderpack/option/menu/OptionMenuContainer.java
@@ -1,6 +1,7 @@
 package net.coderbot.iris.shaderpack.option.menu;
 
 import com.google.common.collect.Lists;
+import lombok.Getter;
 import net.coderbot.iris.Iris;
 import net.coderbot.iris.shaderpack.ShaderProperties;
 import net.coderbot.iris.shaderpack.option.ProfileSet;
@@ -21,10 +22,12 @@ public class OptionMenuContainer {
 	private final List<String> usedOptions = new ArrayList<>();
 	private final List<String> unusedOptions = new ArrayList<>(); // To be used when screens contain a "*" element
 	private final Map<List<OptionMenuElement>, Integer> unusedOptionDumpQueue = new HashMap<>(); // Used by screens with "*" element
-	private final ProfileSet profiles;
+	@Getter private final ProfileSet profiles;
+    @Getter private final ProfileSet profiles2;
 
 	public OptionMenuContainer(ShaderProperties shaderProperties, ShaderPackOptions shaderPackOptions, ProfileSet profiles) {
 		this.profiles = profiles;
+        this.profiles2 = ProfileSet.fromTree(shaderProperties.getProfiles2(), shaderPackOptions.getOptionSet());
 
 		// note: if the Shader Pack does not provide a list of options for the main screen, then dump all options on to
 		// the main screen by default.
@@ -66,10 +69,6 @@ public class OptionMenuContainer {
 
 			entry.getKey().addAll(entry.getValue(), elementsToInsert);
 		}
-	}
-
-	public ProfileSet getProfiles() {
-		return profiles;
 	}
 
 	// Screens will call this when they contain a "*" element, so that the list of

--- a/src/main/java/net/coderbot/iris/shaderpack/option/menu/OptionMenuElement.java
+++ b/src/main/java/net/coderbot/iris/shaderpack/option/menu/OptionMenuElement.java
@@ -12,6 +12,7 @@ public abstract class OptionMenuElement {
 
 	private static final String ELEMENT_EMPTY = "<empty>";
 	private static final String ELEMENT_PROFILE = "<profile>";
+    private static final String ELEMENT_PROFILE2 = "<profile2>";
 
 	public static OptionMenuElement create(String elementString, OptionMenuContainer container, ShaderProperties shaderProperties, ShaderPackOptions shaderPackOptions) throws IllegalArgumentException {
 		// Empty element
@@ -24,6 +25,13 @@ public abstract class OptionMenuElement {
 			// null indicates that the element should be forgotten (not treated as empty)
 			return container.getProfiles().size() > 0 ? new OptionMenuProfileElement(container.getProfiles(), shaderPackOptions.getOptionSet(), shaderPackOptions.getOptionValues()) : null;
 		}
+        // Second profile element
+        if (ELEMENT_PROFILE2.equals(elementString)) {
+            // null indicates that the element should be forgotten (not treated as empty)
+            return container.getProfiles2().size() > 0
+                ? ProfileElementTracker.markSecondProfileSet(new OptionMenuProfileElement(container.getProfiles2(), shaderPackOptions.getOptionSet(), shaderPackOptions.getOptionValues()))
+                : null;
+        }
 		// Link to sub screen element
 		if (elementString.startsWith("[") && elementString.endsWith("]")) {
 			return new OptionMenuLinkElement(elementString.substring(1, elementString.length() - 1));

--- a/src/main/java/net/coderbot/iris/shaderpack/option/menu/ProfileElementTracker.java
+++ b/src/main/java/net/coderbot/iris/shaderpack/option/menu/ProfileElementTracker.java
@@ -1,0 +1,22 @@
+package net.coderbot.iris.shaderpack.option.menu;
+
+import java.util.Collections;
+import java.util.Set;
+import java.util.WeakHashMap;
+
+public final class ProfileElementTracker {
+    private static final Set<Object> SECOND_PROFILE_ELEMENTS =
+        Collections.newSetFromMap(new WeakHashMap<>());
+
+    private ProfileElementTracker() {
+    }
+
+    public static <T> T markSecondProfileSet(T element) {
+        SECOND_PROFILE_ELEMENTS.add(element);
+        return element;
+    }
+
+    public static boolean isSecondProfileSet(Object element) {
+        return SECOND_PROFILE_ELEMENTS.contains(element);
+    }
+}


### PR DESCRIPTION
This adds a second profiles button, which I now use in Euphoria Patches. In modern versions, I mixin into Iris/Oculus to add it, but here, why not add it in directly!
It does not interfere with anything and the old one works exactly the same. Here we now just have 2 profile buttons working side by side and Euphoria Patches already makes use of it :)