### PR TITLE
Fix blend leak in BatchingFontRenderer

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -119,7 +119,7 @@ dependencies {
 
     compileOnly("com.github.GTNewHorizons:NotEnoughIds:2.1.10:dev")
 
-    compileOnly(rfg.deobf("maven.modrinth:ntmspace:X5593_H261"))
+    compileOnly(rfg.deobf("maven.modrinth:ntmspace:X5634_H261"))
 
     compileOnly(rfg.deobf("curse.maven:campfirebackport-387444:4611675"))
     compileOnly(rfg.deobf("curse.maven:xaeros-minimap-263420:5060684"))

--- a/src/main/java/com/gtnewhorizons/angelica/client/font/BatchingFontRenderer.java
+++ b/src/main/java/com/gtnewhorizons/angelica/client/font/BatchingFontRenderer.java
@@ -334,6 +334,7 @@ public class BatchingFontRenderer {
         batchCommands.sort(FontDrawCmd.DRAW_ORDER_COMPARATOR);
 
         final boolean isTextureEnabledBefore = GLStateManager.glIsEnabled(GL11.GL_TEXTURE_2D);
+        final boolean isBlendEnabledBefore = GLStateManager.glIsEnabled(GL11.GL_BLEND);
         final int boundTextureBefore = GLStateManager.glGetInteger(GL11.GL_TEXTURE_BINDING_2D);
         boolean textureChanged = false;
 
@@ -416,6 +417,9 @@ public class BatchingFontRenderer {
 
         if (isTextureEnabledBefore) {
         	GLStateManager.glEnable(GL11.GL_TEXTURE_2D);
+        }
+        if (!isBlendEnabledBefore) {
+            GLStateManager.disableBlend();
         }
         if (textureChanged) {
         	GLStateManager.glBindTexture(GL11.GL_TEXTURE_2D, boundTextureBefore);


### PR DESCRIPTION
Fixes #1504 

BatchingFontRenderer enabled blending without checking whether it was enabled or not before

Provided world from #1504 had an RBMK console (renders text) and FENSU (changes the blend mode to `GL11.GL_SRC_ALPHA, GL11.GL_ONE`), so next TEs were rendered with blending, which they shouldn't have (thanks to RenderDoc)


<img width="1920" height="1017" alt="2026-03-26_00 57 01" src="https://github.com/user-attachments/assets/80f55711-8822-4b86-b23f-4e087d817731" />

<img width="1920" height="1017" alt="2026-03-26_01 00 45" src="https://github.com/user-attachments/assets/ca5c51d6-5056-45de-8e76-a85af4790984" />
