### PR TITLE
 fix: crash when client-side vertex attrib pointers are used in core profile

### DIFF
--- a/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/GLStateManager.java
+++ b/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/GLStateManager.java
@@ -419,6 +419,8 @@ public class GLStateManager {
     @Getter protected static int boundVBO;
     @Getter protected static int boundEBO;
     @Getter protected static int boundVAO;
+    private static int clientArraysVBO = 0;
+    private static int clientArraysVBOCapacity = 0;
     private static int boundPixelUnpackBuffer;
     private static int boundPixelPackBuffer;
     private static final Int2IntOpenHashMap vaoEboMap = new Int2IntOpenHashMap();
@@ -2260,6 +2262,39 @@ public class GLStateManager {
 
     public static void glDrawElementsInstanced(int mode, int count, int type, long indices, int primcount) { RENDER_BACKEND.drawElementsInstanced(mode, count, type, indices, primcount); }
 
+    private static void uploadClientArraysToVBO() {
+        final int[] vboOffsets = new int[VertexAttribState.MAX_ATTRIBS];
+        int totalBytes = 0;
+        for (int i = 0; i < VertexAttribState.MAX_ATTRIBS; i++) {
+            vboOffsets[i] = -1;
+            final VertexAttribState.Attrib a = VertexAttribState.get(i);
+            if (!a.enabled || a.clientPointer == null) continue;
+            vboOffsets[i] = totalBytes;
+            totalBytes += a.clientPointer.remaining();
+        }
+        if (totalBytes == 0) return;
+
+        if (clientArraysVBO == 0) {
+            clientArraysVBO = RENDER_BACKEND.genBuffers();
+        }
+        glBindBuffer(GL15.GL_ARRAY_BUFFER, clientArraysVBO);
+        if (totalBytes > clientArraysVBOCapacity) {
+            int newCap = Math.max(4096, clientArraysVBOCapacity);
+            while (newCap < totalBytes) newCap *= 2;
+            RENDER_BACKEND.bufferData(GL15.GL_ARRAY_BUFFER, newCap, GL15.GL_STREAM_DRAW);
+            clientArraysVBOCapacity = newCap;
+        }
+
+        for (int i = 0; i < VertexAttribState.MAX_ATTRIBS; i++) {
+            if (vboOffsets[i] < 0) continue;
+            final VertexAttribState.Attrib a = VertexAttribState.get(i);
+            RENDER_BACKEND.bufferSubData(GL15.GL_ARRAY_BUFFER, vboOffsets[i], a.clientPointer.duplicate());
+            RENDER_BACKEND.vertexAttribPointer(i, a.size, a.type, a.normalized, a.stride, (long) vboOffsets[i]);
+        }
+
+        glBindBuffer(GL15.GL_ARRAY_BUFFER, 0);
+    }
+
     public static void glDrawArrays(int mode, int first, int count) {
         CommandRecorder savedRecorder = null;
         final RecordMode recordMode = DisplayListManager.getRecordMode();
@@ -2278,6 +2313,10 @@ public class GLStateManager {
         }
         prepareWideLineEmulation(mode);
         ShaderManager.getInstance().preDraw();
+
+        if (ShaderManager.getInstance().isEnabled() && VertexAttribState.hasAnyClientSideEnabledAttrib()) {
+            uploadClientArraysToVBO();
+        }
         if (mode == GL11.GL_QUADS) {
             QuadConverter.drawQuadsAsTriangles(first, count);
         } else {

--- a/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/states/VertexAttribState.java
+++ b/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/states/VertexAttribState.java
@@ -92,6 +92,18 @@ public class VertexAttribState {
         return false;
     }
 
+    /**
+     * Returns true if any currently enabled vertex attribute was registered without a VBO
+     * (i.e. as a client-side pointer). In core profile, such attribs are treated as null
+     * offsets into a non-existent buffer, causing a native crash at draw time.
+     */
+    public static boolean hasAnyClientSideEnabledAttrib() {
+        for (int i = 0; i < MAX_ATTRIBS; i++) {
+            if (current[i].enabled && current[i].vboId == 0 && current[i].clientPointer != null) return true;
+        }
+        return false;
+    }
+
     public static class Attrib {
         public boolean enabled;
         public int size;


### PR DESCRIPTION
In core OpenGL profile, glVertexAttribPointer with no VBO bound treats the pointer as a null offset into a non-existent buffer, causing a native crash at draw time.

Add uploadClientArraysToVBO() which detects client-side attrib pointers before glDrawArrays and transparently uploads them into a lazily-allocated  stream VBO before issuing the draw call. The VBO capacity doubles as needed to avoid repeated allocations.

This specifically fixes the crash triggered when [NGTTessellator#draw](https://github.com/Kai-Z-JP/KaizPatchX/blob/98ae889bf678cefe41e85f6fc687dcb9742050c1/src/main/java/jp/ngt/ngtlib/renderer/NGTTessellator.java#L109) from KaizPatchX/RTM uses client-side vertex attribute arrays under Angelica/core-profile rendering.

```
#
# A fatal error has been detected by the Java Runtime Environment:
#
#  EXCEPTION_ACCESS_VIOLATION (0xc0000005) at pc=0x000001198039fe02, pid=16044, tid=0x000000000000cd40
#
# JRE version: Java(TM) SE Runtime Environment (8.0_451) (build 1.8.0_451-b10)
# Java VM: Java HotSpot(TM) 64-Bit Server VM (25.451-b10 mixed mode windows-amd64 compressed oops)
# Problematic frame:
# C  0x000001198039fe02
#
# Failed to write core dump. Minidumps are not enabled by default on client versions of Windows
#
# If you would like to submit a bug report, please visit:
#   http://bugreport.java.com/bugreport/crash.jsp
# The crash happened outside the Java Virtual Machine in native code.
# See problematic frame for where to report the bug.
#

---------------  T H R E A D  ---------------

Current thread (0x00000119ce901800):  JavaThread "Client thread" [_thread_in_native, id=52544, stack(0x00000010e7100000,0x00000010e7200000)]

siginfo: ExceptionCode=0xc0000005, reading address 0x0000000000000000

Registers:
RAX=0x0000011992254510, RBX=0x0000011980080000, RCX=0x0000000000000000, RDX=0x000000000000006c
RSP=0x00000010e71fce20, RBP=0x000000000000006c, RSI=0x0000000000000000, RDI=0x0000000000000000
R8 =0x0000000000000000, R9 =0x000000000000006c, R10=0x00000000094d4510, R11=0x00007ff8bcc0e925
R12=0x0000000000000000, R13=0x0000011992254510, R14=0x0000011a738e0fd0, R15=0x0000000000000004
RIP=0x000001198039fe02, EFLAGS=0x0000000000010246

Top of Stack: (sp=0x00000010e71fce20)
0x00000010e71fce20:   0000000000000002 0000011980080000
0x00000010e71fce30:   0000000000000000 00000119800cc230
0x00000010e71fce40:   000000000000006c 00007ff8bc2e6eb5
0x00000010e71fce50:   000000000000006c 00000119800cc230
0x00000010e71fce60:   00000000000006c0 0000000000000000
0x00000010e71fce70:   0000011a738ea18c 0000000000000004
0x00000010e71fce80:   0000001000000000 ffff80182a023b08
0x00000010e71fce90:   0000011a7c554128 3bfadb02bbe99d81
0x00000010e71fcea0:   0000000000000000 0000000000000004
0x00000010e71fceb0:   0000000000000000 0000011a738e0fd0
0x00000010e71fcec0:   000000000000006c 00007ff8bc2e2d33
0x00000010e71fced0:   0000000000000000 0000011a6c532964
0x00000010e71fcee0:   0000011980080000 0000000000000000
0x00000010e71fcef0:   0000000000000004 00c0000000000000
0x00000010e71fcf00:   0000000000000001 0000000000000004
0x00000010e71fcf10:   000000000000006c 00007ff8bbe8f171 

Instructions: (pc=0x000001198039fe02)
0x000001198039fde2:   8b d1 48 be 68 8e 0d 80 19 01 00 00 48 8b 36 48
0x000001198039fdf2:   8b b6 08 03 00 00 48 8b f9 48 c1 e7 04 48 03 f7
0x000001198039fe02:   8b 3e 8b 6e 04 89 38 89 68 04 8b 7e 08 8b 6e 0c
0x000001198039fe12:   89 78 08 89 68 0c 48 83 c0 10 ff c1 ff ca 75 c2 


Register to memory mapping:

RAX=0x0000011992254510 is an unknown value
RBX=0x0000011980080000 is an unknown value
RCX=0x0000000000000000 is an unknown value
RDX=0x000000000000006c is an unknown value
RSP=0x00000010e71fce20 is pointing into the stack for thread: 0x00000119ce901800
RBP=0x000000000000006c is an unknown value
RSI=0x0000000000000000 is an unknown value
RDI=0x0000000000000000 is an unknown value
R8 =0x0000000000000000 is an unknown value
R9 =0x000000000000006c is an unknown value
R10=0x00000000094d4510 is an unknown value
R11=0x00007ff8bcc0e925 is an unknown value
R12=0x0000000000000000 is an unknown value
R13=0x0000011992254510 is an unknown value
R14=0x0000011a738e0fd0 is an unknown value
R15=0x0000000000000004 is an unknown value


Stack: [0x00000010e7100000,0x00000010e7200000],  sp=0x00000010e71fce20,  free space=1011k
Native frames: (J=compiled Java code, j=interpreted, Vv=VM code, C=native code)
C  0x000001198039fe02

Java frames: (J=compiled Java code, j=interpreted, Vv=VM code)
J 19124  org.lwjgl.opengl.GL11.nglDrawArrays(IIIJ)V (0 bytes) @ 0x00000119d3f9680e [0x00000119d3f967c0+0x4e]
J 26079 C2 com.gtnewhorizons.angelica.glsm.GLStateManager.glDrawArrays(III)V (104 bytes) @ 0x00000119d329fc0c [0x00000119d329f820+0x3ec]
j  jp.ngt.ngtlib.renderer.NGTTessellator.draw()I+144
```