### PR TITLE
Return `phaseChangeNotifier`

### DIFF
--- a/src/main/java/net/coderbot/iris/gl/state/StateUpdateNotifiers.java
+++ b/src/main/java/net/coderbot/iris/gl/state/StateUpdateNotifiers.java
@@ -6,4 +6,5 @@ package net.coderbot.iris.gl.state;
 public class StateUpdateNotifiers {
 	public static ValueUpdateNotifier normalTextureChangeNotifier;
 	public static ValueUpdateNotifier specularTextureChangeNotifier;
+	public static ValueUpdateNotifier phaseChangeNotifier;
 }

--- a/src/main/java/net/coderbot/iris/layer/GbufferPrograms.java
+++ b/src/main/java/net/coderbot/iris/layer/GbufferPrograms.java
@@ -4,6 +4,7 @@ import net.coderbot.iris.Iris;
 import net.coderbot.iris.gbuffer_overrides.matching.SpecialCondition;
 import com.gtnewhorizons.angelica.glsm.GLStateManager;
 import net.coderbot.iris.gl.shader.ProgramCreator;
+import net.coderbot.iris.gl.state.StateUpdateNotifiers;
 import net.coderbot.iris.pipeline.WorldRenderingPhase;
 import net.coderbot.iris.pipeline.WorldRenderingPipeline;
 
@@ -11,7 +12,12 @@ public class GbufferPrograms {
 	private static boolean entities;
 	private static boolean blockEntities;
 	private static boolean outline;
-
+	private static Runnable phaseChangeListener;
+	
+	static {
+		StateUpdateNotifiers.phaseChangeNotifier = listener -> phaseChangeListener = listener;
+	}
+	
 	private static void checkReentrancy() {
 		if (entities || blockEntities || outline) {
 			throw new IllegalStateException("GbufferPrograms in weird state, tried to call begin function when entities = "
@@ -106,7 +112,13 @@ public class GbufferPrograms {
 	public static void teardownSpecialRenderCondition() {
 		Iris.getPipelineManager().getPipeline().ifPresent(p -> p.setSpecialCondition(null));
 	}
-
+	
+	public static void runPhaseChangeNotifier() {
+		if (phaseChangeListener != null) {
+			phaseChangeListener.run();
+		}
+	}
+	
 	public static void init() {
 		// Empty initializer to run static
 	}

--- a/src/main/java/net/coderbot/iris/pipeline/DeferredWorldRenderingPipeline.java
+++ b/src/main/java/net/coderbot/iris/pipeline/DeferredWorldRenderingPipeline.java
@@ -41,6 +41,7 @@ import net.coderbot.iris.gl.state.FogMode;
 import net.coderbot.iris.gl.texture.DepthBufferFormat;
 import net.coderbot.iris.gl.texture.TextureType;
 import net.coderbot.iris.helpers.Tri;
+import net.coderbot.iris.layer.GbufferPrograms;
 import net.coderbot.iris.pipeline.transform.PatchShaderType;
 import net.coderbot.iris.pipeline.transform.TransformPatcher;
 import net.coderbot.iris.postprocess.BufferFlipper;
@@ -774,10 +775,10 @@ public class DeferredWorldRenderingPipeline implements WorldRenderingPipeline, R
 		if (!isRenderingWorld || isRenderingFullScreenPass || isPostChain || !isMainBound) {
 			return;
 		}
-
+		
 		final RenderCondition condition = getCondition(getPhase());
 		final Pass matched = table.match(condition, inputs);
-
+		
 		beginPass(matched);
 	}
 
@@ -1656,12 +1657,14 @@ public class DeferredWorldRenderingPipeline implements WorldRenderingPipeline, R
 	public void setOverridePhase(WorldRenderingPhase phase) {
 		this.overridePhase = phase;
 		matchPass();
+		GbufferPrograms.runPhaseChangeNotifier();
 	}
 
 	@Override
 	public void setPhase(WorldRenderingPhase phase) {
 		this.phase = phase;
 		matchPass();
+		GbufferPrograms.runPhaseChangeNotifier();
 	}
 
 	@Override

--- a/src/main/java/net/coderbot/iris/uniforms/CommonUniforms.java
+++ b/src/main/java/net/coderbot/iris/uniforms/CommonUniforms.java
@@ -9,6 +9,7 @@ import com.gtnewhorizons.angelica.client.rendering.TextureTracker;
 import com.gtnewhorizons.angelica.mixins.interfaces.EntityRendererAccessor;
 import net.coderbot.iris.compat.dh.DHCompat;
 import net.coderbot.iris.gl.state.FogMode;
+import net.coderbot.iris.gl.state.StateUpdateNotifiers;
 import net.coderbot.iris.gl.state.ValueUpdateNotifier;
 import net.coderbot.iris.gl.uniform.DynamicUniformHolder;
 import net.coderbot.iris.gl.uniform.UniformHolder;
@@ -100,7 +101,7 @@ public final class CommonUniforms {
             return ZERO_VECTOR_4i;
 		}, ValueUpdateNotifier.NONE);
 
-		uniforms.uniform1i("renderStage", () -> GbufferPrograms.getCurrentPhase().ordinal(), ValueUpdateNotifier.NONE);
+		uniforms.uniform1i("renderStage", () -> GbufferPrograms.getCurrentPhase().ordinal(), StateUpdateNotifiers.phaseChangeNotifier);
 
         uniforms.uniform4f("entityColor", CapturedRenderingState.INSTANCE::getCurrentEntityColor, CapturedRenderingState.INSTANCE.getEntityColorNotifier());
 


### PR DESCRIPTION
I noticed that `phaseChangeNotifier` / `runPhaseChangeNotifier` were (for some reason) removed from `StateUpdateNotifiers` / `GbufferPrograms` in 2.0.0
This causes renderStage uniform to stay stuck on the first phase when multiple phases (like `SUNSET`/`SUN`) share same RenderCondition (`SKY`)

For example:

```glsl
	if (renderStage == MC_RENDER_STAGE_SUNSET) color.rgb = vec3(0.0, 1.0, 0.0);
	else if (renderStage == MC_RENDER_STAGE_SUN) color.rgb = vec3(0.0, 0.0, 1.0);
	else if (renderStage == MC_RENDER_STAGE_MOON) color.rgb = vec3(1.0, 0.0, 0.0);
```

Should color sunset green, sun blue, and moon red

However:

<img width="640" height="339" alt="IMG" src="https://github.com/user-attachments/assets/08622950-b864-4875-b013-e26090d8dac2" />


Sunset isn't colored, sun is green, and stars are red (cascade of incorrect renderStage)


Upon returning `phaseChangeNotifier`:

<img width="640" height="339" alt="IMG1" src="https://github.com/user-attachments/assets/d13320e9-615a-497e-999c-4836722bff8a" />

<img width="640" height="339" alt="IMG2" src="https://github.com/user-attachments/assets/cbe91540-686f-4560-aa34-732a50665683" />

as expected

---


<details>

<summary>In practice, this means that:</summary>

(part of complementary's code)
```glsl
bool isSun = renderStage == MC_RENDER_STAGE_SUN;
```

This variable will always be false, resulting in artifacts like this:

<img width="640" height="339" alt="IMG10" src="https://github.com/user-attachments/assets/5076e782-2265-4169-808e-7d0218ced413" />


When it should look like this:


<img width="640" height="339" alt="IMG6" src="https://github.com/user-attachments/assets/c591bbb5-3d1d-4968-9a46-d00f07ffd04b" />


</details>

