### PR TITLE
Fix item reset hopefully for the last time

### DIFF
--- a/src/main/java/com/gtnewhorizons/angelica/rendering/DeferredEntityOverlay.java
+++ b/src/main/java/com/gtnewhorizons/angelica/rendering/DeferredEntityOverlay.java
@@ -5,7 +5,6 @@ import lombok.Getter;
 import net.coderbot.iris.layer.GbufferPrograms;
 import net.coderbot.iris.uniforms.CapturedRenderingState;
 import net.coderbot.iris.uniforms.EntityIdHelper;
-import net.coderbot.iris.uniforms.ItemIdManager;
 import net.minecraft.client.renderer.OpenGlHelper;
 import net.minecraft.client.renderer.entity.RendererLivingEntity;
 import net.minecraft.entity.EntityLivingBase;
@@ -125,7 +124,6 @@ public class DeferredEntityOverlay {
         try {
             for (DeferredEntry entry : deferred) {
                 CapturedRenderingState.INSTANCE.setCurrentEntity(EntityIdHelper.getEntityId(entry.entity));
-                ItemIdManager.resetItemId();
                 renderOverlay(entry);
             }
         } finally {

--- a/src/main/java/net/coderbot/iris/uniforms/CapturedRenderingState.java
+++ b/src/main/java/net/coderbot/iris/uniforms/CapturedRenderingState.java
@@ -1,6 +1,7 @@
 package net.coderbot.iris.uniforms;
 
 import lombok.Getter;
+import lombok.Setter;
 import net.coderbot.iris.gl.state.ValueUpdateNotifier;
 
 import org.joml.Vector4f;
@@ -8,7 +9,8 @@ import org.joml.Vector4f;
 public class CapturedRenderingState {
 	public static final CapturedRenderingState INSTANCE = new CapturedRenderingState();
 
-	@Getter
+	@Setter
+    @Getter
     private float tickDelta;
 	@Getter
     private int currentRenderedBlockEntity;
@@ -29,10 +31,6 @@ public class CapturedRenderingState {
 	private CapturedRenderingState() {
 	}
 
-	public void setTickDelta(float tickDelta) {
-		this.tickDelta = tickDelta;
-	}
-
     public void setCurrentBlockEntity(int entity) {
 		this.currentRenderedBlockEntity = entity;
 
@@ -47,6 +45,7 @@ public class CapturedRenderingState {
 		if (this.entityIdListener != null) {
 			this.entityIdListener.run();
 		}
+        setCurrentRenderedItem(0);
 	}
 
     public void setCurrentEntityColor(float r, float g, float b, float a) {

--- a/src/mixin/java/com/gtnewhorizons/angelica/mixins/early/shaders/MixinRenderItem.java
+++ b/src/mixin/java/com/gtnewhorizons/angelica/mixins/early/shaders/MixinRenderItem.java
@@ -31,17 +31,6 @@ public class MixinRenderItem {
     }
 
     /**
-     * Reset the item ID after rendering dropped items.
-     */
-    @Inject(
-        method = "doRender(Lnet/minecraft/entity/item/EntityItem;DDDFF)V",
-        at = @At("RETURN")
-    )
-    private void iris$resetItemIdAfterRender(EntityItem entity, double x, double y, double z, float entityYaw, float partialTicks, CallbackInfo ci) {
-        ItemIdManager.resetItemId();
-    }
-
-    /**
      * Activate GLINT shader before rendering enchantment glint on dropped items.
      */
     @Inject(

--- a/src/mixin/java/com/gtnewhorizons/angelica/mixins/early/shaders/MixinRenderManager.java
+++ b/src/mixin/java/com/gtnewhorizons/angelica/mixins/early/shaders/MixinRenderManager.java
@@ -4,7 +4,6 @@ import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import net.coderbot.iris.uniforms.CapturedRenderingState;
 import net.coderbot.iris.uniforms.EntityIdHelper;
-import net.coderbot.iris.uniforms.ItemIdManager;
 import net.minecraft.client.renderer.entity.Render;
 import net.minecraft.client.renderer.entity.RenderManager;
 import net.minecraft.entity.Entity;
@@ -26,7 +25,6 @@ public class MixinRenderManager {
     private void iris$wrapDoRender(Render render, Entity entity, double x, double y, double z, float entityYaw, float partialTicks, Operation<Void> original) {
         int entityId = EntityIdHelper.getEntityId(entity);
         CapturedRenderingState.INSTANCE.setCurrentEntity(entityId);
-        ItemIdManager.resetItemId();
         original.call(render, entity, x, y, z, entityYaw, partialTicks);
         CapturedRenderingState.INSTANCE.setCurrentEntity(-1);
     }

--- a/src/mixin/java/com/gtnewhorizons/angelica/mixins/early/shaders/MixinRenderManagerDAPI.java
+++ b/src/mixin/java/com/gtnewhorizons/angelica/mixins/early/shaders/MixinRenderManagerDAPI.java
@@ -4,7 +4,6 @@ import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import net.coderbot.iris.uniforms.CapturedRenderingState;
 import net.coderbot.iris.uniforms.EntityIdHelper;
-import net.coderbot.iris.uniforms.ItemIdManager;
 import net.minecraft.client.renderer.entity.Render;
 import net.minecraft.client.renderer.entity.RenderManager;
 import net.minecraft.entity.Entity;
@@ -24,7 +23,6 @@ public class MixinRenderManagerDAPI {
     private void iris$wrapDoRenderDragonAPI(Render render, Entity entity, double x, double y, double z, float entityYaw, float partialTicks, Operation<Void> original) {
         int entityId = EntityIdHelper.getEntityId(entity);
         CapturedRenderingState.INSTANCE.setCurrentEntity(entityId);
-        ItemIdManager.resetItemId();
         original.call(render, entity, x, y, z, entityYaw, partialTicks);
         CapturedRenderingState.INSTANCE.setCurrentEntity(-1);
     }

--- a/src/mixin/java/com/gtnewhorizons/angelica/mixins/early/shaders/MixinRendererLivingEntity.java
+++ b/src/mixin/java/com/gtnewhorizons/angelica/mixins/early/shaders/MixinRendererLivingEntity.java
@@ -22,13 +22,13 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 @Mixin(RendererLivingEntity.class)
 public class MixinRendererLivingEntity {
     /**
-     * Reset currentRenderedItemId at the start of rendering each living entity.
+     * Reset ID before damage overlay renders, otherwise you get random shiny zombies
      */
     @Inject(
         method = "doRender(Lnet/minecraft/entity/EntityLivingBase;DDDFF)V",
-        at = @At("HEAD")
+        at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/entity/RendererLivingEntity;renderEquippedItems(Lnet/minecraft/entity/EntityLivingBase;F)V", shift = At.Shift.AFTER)
     )
-    private void iris$resetItemIdAtStart(EntityLivingBase entity, double x, double y, double z, float entityYaw, float partialTicks, CallbackInfo ci) {
+    private void iris$resetItemIdAfterEquipped(EntityLivingBase entity, double x, double y, double z, float entityYaw, float partialTicks, CallbackInfo ci) {
         ItemIdManager.resetItemId();
     }
 
@@ -79,7 +79,6 @@ public class MixinRendererLivingEntity {
         remap = false
     )
     private void iris$glintStart(CallbackInfo ci) {
-        ItemIdManager.resetItemId();
         GbufferPrograms.setupSpecialRenderCondition(SpecialCondition.GLINT);
     }
 


### PR DESCRIPTION
I added the item ID reset to setCurrentEntity to try and prevent future issues where people (like me) forget to reset it manually. Also apparently the damage overlay has been broke this whole time so that's cool.