### PR TITLE
Pass mc_Entity like upstream does

### DIFF
--- a/src/main/java/com/gtnewhorizons/angelica/rendering/celeritas/iris/IrisExtendedChunkVertexEncoder.java
+++ b/src/main/java/com/gtnewhorizons/angelica/rendering/celeritas/iris/IrisExtendedChunkVertexEncoder.java
@@ -79,13 +79,13 @@ public class IrisExtendedChunkVertexEncoder implements ContextAwareChunkVertexEn
 
         baseEncoder.write(ptr, material, vertex, sectionIndex);
 
-        // Per-vertex: renderType, midBlock, lightValue
-        memPutShort(ptr + MC_ENTITY_OFFSET + 2, ctx.renderType);
+        // Per-vertex: mc_Entity (packed blockId + renderType), midBlock, lightValue
+        memPutInt(ptr + MC_ENTITY_OFFSET, ((ctx.blockId + 1) << 1) | (ctx.renderType & 1));
         final int midBlock = ExtendedDataHelper.computeMidBlock(vertex.x, vertex.y, vertex.z, ctx.localPosX, ctx.localPosY, ctx.localPosZ);
         memPutInt(ptr + MID_BLOCK_OFFSET, midBlock);
         memPutByte(ptr + MID_BLOCK_OFFSET + 3, ctx.lightValue);
 
-        // Per-quad: midTexCoord, blockId, normal, tangent
+        // Per-quad: midTexCoord, normal, tangent
         if (vertexCount == 4) {
             vertexCount = 0;
 
@@ -97,11 +97,6 @@ public class IrisExtendedChunkVertexEncoder implements ContextAwareChunkVertexEn
             memPutInt(ptr + MID_TEX_OFFSET - STRIDE, midUV);
             memPutInt(ptr + MID_TEX_OFFSET - STRIDE * 2, midUV);
             memPutInt(ptr + MID_TEX_OFFSET - STRIDE * 3, midUV);
-
-            memPutShort(ptr + MC_ENTITY_OFFSET, ctx.blockId);
-            memPutShort(ptr + MC_ENTITY_OFFSET - STRIDE, ctx.blockId);
-            memPutShort(ptr + MC_ENTITY_OFFSET - STRIDE * 2, ctx.blockId);
-            memPutShort(ptr + MC_ENTITY_OFFSET - STRIDE * 3, ctx.blockId);
 
             quad.setup(ptr, STRIDE);
             NormalHelper.computeFaceNormal(normal, quad);

--- a/src/main/java/com/gtnewhorizons/angelica/rendering/celeritas/iris/IrisExtendedChunkVertexType.java
+++ b/src/main/java/com/gtnewhorizons/angelica/rendering/celeritas/iris/IrisExtendedChunkVertexType.java
@@ -13,7 +13,7 @@ import org.embeddedt.embeddium.impl.render.chunk.vertex.format.ChunkVertexType;
  *   mc_midTexCoord  ushort[2]  - quad center UV (average of 4 vertices)
  *   at_tangent      byte[4]    - tangent vector, normalized
  *   iris_Normal     byte[3]+1  - face normal, normalized
- *   mc_Entity       short[2]   - (blockId, renderType)
+ *   mc_Entity       uint       - packed as ((blockId + 1) << 1) | (renderType & 1)
  *   at_midBlock     byte[4]    - (xyz offset from block center, lightValue)
  */
 public class IrisExtendedChunkVertexType implements ChunkVertexType {
@@ -25,7 +25,7 @@ public class IrisExtendedChunkVertexType implements ChunkVertexType {
         .addElement("mc_midTexCoord", GlVertexFormat.NEXT_ALIGNED_POINTER, GlVertexAttributeFormat.UNSIGNED_SHORT, 2, false, false)
         .addElement("at_tangent", GlVertexFormat.NEXT_ALIGNED_POINTER, GlVertexAttributeFormat.BYTE, 4, true, false)
         .addElement("iris_Normal", GlVertexFormat.NEXT_ALIGNED_POINTER, GlVertexAttributeFormat.BYTE, 3, true, false)
-        .addElement("mc_Entity", GlVertexFormat.NEXT_ALIGNED_POINTER, GlVertexAttributeFormat.SHORT, 2, false, false)
+        .addElement("mc_Entity", GlVertexFormat.NEXT_ALIGNED_POINTER, GlVertexAttributeFormat.UNSIGNED_INT, 1, false, true)
         .addElement("at_midBlock", GlVertexFormat.NEXT_ALIGNED_POINTER, GlVertexAttributeFormat.BYTE, 4, false, false)
         .build();
 

--- a/src/main/java/net/coderbot/iris/pipeline/transform/ShaderTransformer.java
+++ b/src/main/java/net/coderbot/iris/pipeline/transform/ShaderTransformer.java
@@ -428,6 +428,7 @@ public class ShaderTransformer {
                 // Handle mc_midTexCoord for Celeritas
                 patchMultiTexCoord3(transformer, parameters);
                 replaceMidTexCoord(transformer, IrisExtendedChunkVertexType.MID_TEX_SCALE);
+                replaceMCEntity(transformer, parameters);
                 applyIntelHd4000Workaround(transformer);
                 break;
             case COMPOSITE:
@@ -492,6 +493,55 @@ public class ShaderTransformer {
 
         transformer.injectVariable("in vec2 mc_midTexCoord;"); //TODO why is this inserted oddly?
 
+    }
+
+    /**
+     * Replaces shader-declared mc_Entity (vec2/ivec2/float/int/etc.) with upstream-compatible unpacking
+     * from a single uint attribute. The uint is packed as ((blockId + 1) << 1) | (renderType & 1).
+     */
+    public static void replaceMCEntity(Transformer transformer, Parameters parameters) {
+        if (parameters.type != ShaderType.VERTEX) return;
+
+        final int type = transformer.findType("mc_Entity");
+        if (type != 0) {
+            transformer.removeVariable("mc_Entity");
+        }
+        transformer.replaceExpression("mc_Entity", "iris_Entity");
+        switch (type) {
+            case 0:
+            case GLSLLexer.BOOL:
+                return;
+            case GLSLLexer.FLOAT:
+                transformer.injectFunction("float iris_Entity = float(int(mc_Entity >> 1u) - 1);");
+                break;
+            case GLSLLexer.VEC2:
+                transformer.injectFunction("vec2 iris_Entity = vec2(int(mc_Entity >> 1u) - 1, mc_Entity & 1u);");
+                break;
+            case GLSLLexer.VEC3:
+                transformer.injectFunction("vec3 iris_Entity = vec3(int(mc_Entity >> 1u) - 1, mc_Entity & 1u, 0.0);");
+                break;
+            case GLSLLexer.VEC4:
+                transformer.injectFunction("vec4 iris_Entity = vec4(int(mc_Entity >> 1u) - 1, mc_Entity & 1u, 0.0, 1.0);");
+                break;
+            case GLSLLexer.UINT:
+                transformer.injectFunction("uint iris_Entity = uint(int(mc_Entity >> 1u) - 1);");
+                break;
+            case GLSLLexer.INT:
+                transformer.injectFunction("int iris_Entity = int(mc_Entity >> 1u) - 1;");
+                break;
+            case GLSLLexer.IVEC2:
+                transformer.injectFunction("ivec2 iris_Entity = ivec2(int(mc_Entity >> 1u) - 1, mc_Entity & 1u);");
+                break;
+            case GLSLLexer.IVEC3:
+                transformer.injectFunction("ivec3 iris_Entity = ivec3(int(mc_Entity >> 1u) - 1, mc_Entity & 1u, 0);");
+                break;
+            case GLSLLexer.IVEC4:
+                transformer.injectFunction("ivec4 iris_Entity = ivec4(int(mc_Entity >> 1u) - 1, mc_Entity & 1u, 0, 1);");
+                break;
+            default:
+                throw new IllegalStateException("Got an invalid format mc_Entity (type token " + type + ").");
+        }
+        transformer.injectVariable("in uint mc_Entity;");
     }
 
     public static void addIfNotExists(Transformer transformer, String name, String code) {

--- a/src/main/java/net/coderbot/iris/vertices/ExtendedDataHelper.java
+++ b/src/main/java/net/coderbot/iris/vertices/ExtendedDataHelper.java
@@ -1,8 +1,8 @@
 package net.coderbot.iris.vertices;
 
 public final class ExtendedDataHelper {
-	// TODO: Resolve render types for normal blocks?
-	public static final short BLOCK_RENDER_TYPE = -1;
+	// Packed mc_Entity only preserves one terrain/fluid bit, so normal blocks must encode as 0.
+	public static final short BLOCK_RENDER_TYPE = 0;
 	/** All fluids have a ShadersMod render type of 1, to match behavior of Minecraft 1.7 and earlier. */
 	public static final short FLUID_RENDER_TYPE = 1;
 


### PR DESCRIPTION
For photon shaders.
Also needs patch to load block.properties, since it only has them for 1.13+. See https://github.com/GTNewHorizons/Angelica/pull/1626

This makes the water work on setting "LOW".