### PR TITLE
Port shadow translucent (aka shadow_water) from upstream

### DIFF
--- a/src/main/java/net/coderbot/iris/celeritas/CeleritasTerrainPipeline.java
+++ b/src/main/java/net/coderbot/iris/celeritas/CeleritasTerrainPipeline.java
@@ -72,9 +72,11 @@ public class CeleritasTerrainPipeline {
             Optional<ProgramSource> terrainSource,
             Optional<ProgramSource> translucentSource,
             Optional<ProgramSource> shadowSource,
+            Optional<ProgramSource> shadowTranslucentSource,
             CompletableFuture<Map<PatchShaderType, String>> terrainFuture,
             CompletableFuture<Map<PatchShaderType, String>> translucentFuture,
             CompletableFuture<Map<PatchShaderType, String>> shadowFuture,
+            CompletableFuture<Map<PatchShaderType, String>> shadowTranslucentFuture,
             RenderTargets renderTargets,
             ImmutableSet<Integer> flippedAfterPrepare,
             ImmutableSet<Integer> flippedAfterTranslucent,
@@ -92,6 +94,7 @@ public class CeleritasTerrainPipeline {
         gbufferProgramSource.put(IrisTerrainPass.GBUFFER_CUTOUT, terrainSource);
         gbufferProgramSource.put(IrisTerrainPass.GBUFFER_TRANSLUCENT, translucentSource.isPresent() ? translucentSource : terrainSource);
         gbufferProgramSource.put(IrisTerrainPass.SHADOW, shadowSource);
+        gbufferProgramSource.put(IrisTerrainPass.SHADOW_TRANSLUCENT, shadowTranslucentSource.isPresent() ? shadowTranslucentSource : shadowSource);
 
         // Initialize PassInfo, framebuffers, blend modes, and alpha in single pass
         for (IrisTerrainPass pass : IrisTerrainPass.VALUES) {
@@ -101,11 +104,12 @@ public class CeleritasTerrainPipeline {
             // Set up framebuffer, blend mode, and buffer blend overrides
             final ProgramId programId = switch (pass) {
                 case GBUFFER_TRANSLUCENT -> ProgramId.Water;
+                case SHADOW_TRANSLUCENT -> ProgramId.ShadowWater;
                 case SHADOW, SHADOW_CUTOUT -> ProgramId.Shadow;
                 default -> ProgramId.Terrain;
             };
 
-            if (pass == IrisTerrainPass.SHADOW || pass == IrisTerrainPass.SHADOW_CUTOUT) {
+            if (pass.isShadow()) {
                 passInfo.framebuffer = shadowFramebuffer;
                 passInfo.blendModeOverride = programId.getBlendModeOverride();
                 passInfo.bufferBlendOverrides = Collections.emptyList();
@@ -145,6 +149,7 @@ public class CeleritasTerrainPipeline {
         processShaderFuture(terrainFuture, terrainSource, passInfoMap.get(IrisTerrainPass.GBUFFER_SOLID), passInfoMap.get(IrisTerrainPass.GBUFFER_CUTOUT));
         processShaderFuture(translucentFuture, translucentSource, passInfoMap.get(IrisTerrainPass.GBUFFER_TRANSLUCENT));
         processShaderFuture(shadowFuture, shadowSource, passInfoMap.get(IrisTerrainPass.SHADOW), passInfoMap.get(IrisTerrainPass.SHADOW_CUTOUT));
+        processShaderFuture(shadowTranslucentFuture, shadowTranslucentSource.isPresent() ? shadowTranslucentSource : shadowSource, passInfoMap.get(IrisTerrainPass.SHADOW_TRANSLUCENT));
     }
 
     private void processShaderFuture(@Nullable CompletableFuture<Map<PatchShaderType, String>> future, Optional<ProgramSource> source, PassInfo... targets) {

--- a/src/main/java/net/coderbot/iris/celeritas/IrisCeleritasChunkProgramOverrides.java
+++ b/src/main/java/net/coderbot/iris/celeritas/IrisCeleritasChunkProgramOverrides.java
@@ -136,8 +136,10 @@ public class IrisCeleritasChunkProgramOverrides {
             if (celeritasPipeline != null && !celeritasPipeline.hasShadowPass()) {
                 throw new IllegalStateException("Shadow program requested, but shader pack has no shadow pass");
             }
-            return programs.get(pass.supportsFragmentDiscard() ?
-                IrisTerrainPass.SHADOW_CUTOUT : IrisTerrainPass.SHADOW);
+            if (pass.isReverseOrder()) {
+                return programs.get(IrisTerrainPass.SHADOW_TRANSLUCENT);
+            }
+            return programs.get(pass.supportsFragmentDiscard() ? IrisTerrainPass.SHADOW_CUTOUT : IrisTerrainPass.SHADOW);
         } else {
             if (pass.supportsFragmentDiscard()) {
                 return programs.get(IrisTerrainPass.GBUFFER_CUTOUT);

--- a/src/main/java/net/coderbot/iris/celeritas/IrisCeleritasChunkShaderInterface.java
+++ b/src/main/java/net/coderbot/iris/celeritas/IrisCeleritasChunkShaderInterface.java
@@ -187,7 +187,11 @@ public class IrisCeleritasChunkShaderInterface implements ChunkShaderInterface {
         final boolean isShadow = ShadowRenderingState.areShadowsCurrentlyBeingRendered();
         final IrisTerrainPass irisPass;
         if (isShadow) {
-            irisPass = pass.supportsFragmentDiscard() ? IrisTerrainPass.SHADOW_CUTOUT : IrisTerrainPass.SHADOW;
+            if (pass.isReverseOrder()) {
+                irisPass = IrisTerrainPass.SHADOW_TRANSLUCENT;
+            } else {
+                irisPass = pass.supportsFragmentDiscard() ? IrisTerrainPass.SHADOW_CUTOUT : IrisTerrainPass.SHADOW;
+            }
         } else if (pass.isReverseOrder()) {
             irisPass = IrisTerrainPass.GBUFFER_TRANSLUCENT;
         } else if (pass.supportsFragmentDiscard()) {

--- a/src/main/java/net/coderbot/iris/celeritas/IrisTerrainPass.java
+++ b/src/main/java/net/coderbot/iris/celeritas/IrisTerrainPass.java
@@ -6,6 +6,7 @@ import org.embeddedt.embeddium.impl.render.chunk.terrain.TerrainRenderPass;
 public enum IrisTerrainPass {
     SHADOW("shadow"),
     SHADOW_CUTOUT("shadow"),
+    SHADOW_TRANSLUCENT("shadow_water"),
     GBUFFER_SOLID("gbuffers_terrain"),
     GBUFFER_CUTOUT("gbuffers_terrain_cutout"),
     GBUFFER_TRANSLUCENT("gbuffers_water");
@@ -23,19 +24,22 @@ public enum IrisTerrainPass {
     }
 
     public boolean isShadow() {
-        return this == SHADOW || this == SHADOW_CUTOUT;
+        return this == SHADOW || this == SHADOW_CUTOUT || this == SHADOW_TRANSLUCENT;
     }
 
     public TerrainRenderPass toTerrainPass(RenderPassConfiguration<?> config) {
         return switch (this) {
             case SHADOW, GBUFFER_SOLID -> config.defaultSolidMaterial().pass;
             case SHADOW_CUTOUT, GBUFFER_CUTOUT -> config.defaultCutoutMippedMaterial().pass;
-            case GBUFFER_TRANSLUCENT -> config.defaultTranslucentMaterial().pass;
+            case SHADOW_TRANSLUCENT, GBUFFER_TRANSLUCENT -> config.defaultTranslucentMaterial().pass;
         };
     }
 
     public static IrisTerrainPass fromTerrainPass(TerrainRenderPass pass, boolean isShadow) {
         if (isShadow) {
+            if (pass.isReverseOrder()) {
+                return SHADOW_TRANSLUCENT;
+            }
             return pass.supportsFragmentDiscard() ? SHADOW_CUTOUT : SHADOW;
         } else if (pass.supportsFragmentDiscard()) {
             return GBUFFER_CUTOUT;

--- a/src/main/java/net/coderbot/iris/gbuffer_overrides/matching/RenderCondition.java
+++ b/src/main/java/net/coderbot/iris/gbuffer_overrides/matching/RenderCondition.java
@@ -18,6 +18,7 @@ public enum RenderCondition {
 	HAND_TRANSLUCENT,
 	RAIN_SNOW,
 	WORLD_BORDER,
+	SHADOW_TRANSLUCENT,
 	// NB: Must be last due to implementation details of DeferredWorldRenderingPipeline
 	SHADOW
 }

--- a/src/main/java/net/coderbot/iris/pipeline/DeferredWorldRenderingPipeline.java
+++ b/src/main/java/net/coderbot/iris/pipeline/DeferredWorldRenderingPipeline.java
@@ -220,11 +220,13 @@ public class DeferredWorldRenderingPipeline implements WorldRenderingPipeline, R
 		final Optional<ProgramSource> terrainSource = first(programs.getGbuffersTerrain(), programs.getGbuffersTexturedLit(), programs.getGbuffersTextured(), programs.getGbuffersBasic());
 		final Optional<ProgramSource> translucentSource = first(programs.getGbuffersWater(), terrainSource);
 		final Optional<ProgramSource> shadowSource = programs.getShadow();
+		final Optional<ProgramSource> shadowTranslucentSource = first(programs.getShadowWater(), shadowSource);
 
 		// Celeritas terrain transform futures
 		final CompletableFuture<Map<PatchShaderType, String>> celeritasTerrainFuture = terrainSource.map(DeferredWorldRenderingPipeline::submitCeleritasTerrainTransform).orElse(null);
 		final CompletableFuture<Map<PatchShaderType, String>> celeritasTranslucentFuture = translucentSource.map(DeferredWorldRenderingPipeline::submitCeleritasTerrainTransform).orElse(null);
 		final CompletableFuture<Map<PatchShaderType, String>> celeritasShadowFuture = shadowSource.map(DeferredWorldRenderingPipeline::submitCeleritasTerrainTransform).orElse(null);
+		final CompletableFuture<Map<PatchShaderType, String>> celeritasShadowTranslucentFuture = shadowTranslucentSource.map(DeferredWorldRenderingPipeline::submitCeleritasTerrainTransform).orElse(null);
 
 		this.cloudSetting = programs.getPackDirectives().getCloudSetting();
 		this.shouldRenderUnderwaterOverlay = programs.getPackDirectives().underwaterOverlay();
@@ -388,6 +390,7 @@ public class DeferredWorldRenderingPipeline implements WorldRenderingPipeline, R
 				null, null, ProgramId.Weather,
 				// world border uses textured_lit even though it has no lightmap :/
 				null, ProgramId.TexturedLit, ProgramId.TexturedLit,
+				ProgramId.ShadowWater, ProgramId.ShadowWater, ProgramId.ShadowWater,
 				ProgramId.Shadow, ProgramId.Shadow, ProgramId.Shadow
 		};
 
@@ -431,7 +434,7 @@ public class DeferredWorldRenderingPipeline implements WorldRenderingPipeline, R
 			return cachedPasses.computeIfAbsent(Pair.of(id, availability), p -> {
 				final ProgramSource source = resolver.resolveNullable(p.getLeft());
 
-				if (condition == RenderCondition.SHADOW) {
+				if (condition == RenderCondition.SHADOW || condition == RenderCondition.SHADOW_TRANSLUCENT) {
 					if (!shadowDirectives.isShadowEnabled().orElse(shadowRenderTargets != null)) {
 						// shadow is not used
 						return null;
@@ -448,7 +451,8 @@ public class DeferredWorldRenderingPipeline implements WorldRenderingPipeline, R
 				}
 
 				try {
-					return createPass(source, availability, condition == RenderCondition.SHADOW, finalId);
+					return createPass(source, availability,
+						condition == RenderCondition.SHADOW || condition == RenderCondition.SHADOW_TRANSLUCENT, finalId);
 				} catch (Exception e) {
 					throw new RuntimeException("Failed to create pass for " + source.getName() + " for rendering condition "
 						+ condition + " specialized to input availability " + availability, e);
@@ -475,7 +479,9 @@ public class DeferredWorldRenderingPipeline implements WorldRenderingPipeline, R
 				this.shadowRenderer = new ShadowRenderer(programs.getShadow().orElse(null),
 					programs.getPackDirectives(), shadowRenderTargets, shadowCompositeRenderer);
 				Program shadowProgram = table.match(RenderCondition.SHADOW, new InputAvailability(true, true)).getProgram();
-				shadowRenderer.setUsesImages(shadowProgram != null && shadowProgram.getActiveImages() > 0);
+				Program shadowWaterProgram = table.match(RenderCondition.SHADOW_TRANSLUCENT, new InputAvailability(true, true)).getProgram();
+				shadowRenderer.setUsesImages((shadowProgram != null && shadowProgram.getActiveImages() > 0)
+					|| (shadowWaterProgram != null && shadowWaterProgram.getActiveImages() > 0));
 			} else {
 				shadowRenderer = null;
 			}
@@ -592,7 +598,8 @@ public class DeferredWorldRenderingPipeline implements WorldRenderingPipeline, R
 			terrainSource,
 			translucentSource,
 			shadowSource,
-			celeritasTerrainFuture, celeritasTranslucentFuture, celeritasShadowFuture,
+			shadowTranslucentSource,
+			celeritasTerrainFuture, celeritasTranslucentFuture, celeritasShadowFuture, celeritasShadowTranslucentFuture,
 			renderTargets, flippedAfterPrepare, flippedAfterTranslucent,
 			celeritasShadowFb);
 
@@ -699,7 +706,10 @@ public class DeferredWorldRenderingPipeline implements WorldRenderingPipeline, R
 
 	private RenderCondition getCondition(WorldRenderingPhase phase) {
 		if (isRenderingShadow) {
-			return RenderCondition.SHADOW;
+			return switch (phase) {
+				case TERRAIN_TRANSLUCENT, TRIPWIRE -> RenderCondition.SHADOW_TRANSLUCENT;
+				default -> RenderCondition.SHADOW;
+			};
 		}
 
 		if (special != null) {

--- a/src/main/java/net/coderbot/iris/shaderpack/ProgramSet.java
+++ b/src/main/java/net/coderbot/iris/shaderpack/ProgramSet.java
@@ -16,6 +16,7 @@ public class ProgramSet {
 	private final PackDirectives packDirectives;
 
 	private final ProgramSource shadow;
+	private final ProgramSource shadowWater;
 	private final ComputeSource[] shadowCompute;
 
 	private final ProgramSource[] shadowcomp;
@@ -79,6 +80,8 @@ public class ProgramSet {
 		// - https://github.com/IrisShaders/Iris/issues/483
 		// - https://github.com/IrisShaders/Iris/issues/987
 		this.shadow = readProgramSource(directory, sourceProvider, "shadow", this, shaderProperties,
+				BlendModeOverride.OFF);
+		this.shadowWater = readProgramSource(directory, sourceProvider, "shadow_water", this, shaderProperties,
 				BlendModeOverride.OFF);
 		this.shadowCompute = readComputeArray(directory, sourceProvider, "shadow");
 
@@ -218,6 +221,7 @@ public class ProgramSet {
 		List<ComputeSource> computes = new ArrayList<>();
 
 		programs.add(shadow);
+		programs.add(shadowWater);
 		programs.addAll(Arrays.asList(shadowcomp));
 		programs.addAll(Arrays.asList(begin));
 		programs.addAll(Arrays.asList(prepare));
@@ -300,6 +304,10 @@ public class ProgramSet {
 
 	public Optional<ProgramSource> getShadow() {
 		return shadow.requireValid();
+	}
+
+	public Optional<ProgramSource> getShadowWater() {
+		return shadowWater.requireValid();
 	}
 
 	public ProgramSource[] getShadowComposite() {
@@ -413,6 +421,7 @@ public class ProgramSet {
 	public Optional<ProgramSource> get(ProgramId programId) {
 		return switch (programId) {
 			case Shadow -> getShadow();
+			case ShadowWater -> first(getShadowWater(), getShadow());
 			case Basic -> getGbuffersBasic();
 			case Line -> gbuffersLine.requireValid();
 			case Textured -> getGbuffersTextured();

--- a/src/main/java/net/coderbot/iris/shaderpack/loading/ProgramId.java
+++ b/src/main/java/net/coderbot/iris/shaderpack/loading/ProgramId.java
@@ -14,6 +14,7 @@ public enum ProgramId {
 	Shadow(ProgramGroup.Shadow, ""),
 	ShadowSolid(ProgramGroup.Shadow, "solid", Shadow),
 	ShadowCutout(ProgramGroup.Shadow, "cutout", Shadow),
+	ShadowWater(ProgramGroup.Shadow, "water", Shadow, BlendModeOverride.OFF),
 
 	Basic(ProgramGroup.Gbuffers, "basic"),
 	Line(ProgramGroup.Gbuffers, "line", Basic),


### PR DESCRIPTION
For photon shaders. After https://github.com/GTNewHorizons/Angelica/pull/1627 and https://github.com/GTNewHorizons/Angelica/pull/1626 water on "High" is still broken. This PR aims to fix that.
Ported over with the use of AI. I'm not 100% sure about all of it, but it works for photon shaders.