### PR TITLE
[Memory-opti:fix leak] Fix cached item in RenderItemFrame leaking both world client and server

### DIFF
--- a/src/mixin/java/com/gtnewhorizons/angelica/mixins/early/notfine/optimization/MixinRenderItemFrame.java
+++ b/src/mixin/java/com/gtnewhorizons/angelica/mixins/early/notfine/optimization/MixinRenderItemFrame.java
@@ -1,34 +1,48 @@
 package com.gtnewhorizons.angelica.mixins.early.notfine.optimization;
 
-import net.minecraft.client.renderer.entity.Render;
+import com.llamalad7.mixinextras.sugar.Local;
 import net.minecraft.client.renderer.tileentity.RenderItemFrame;
 import net.minecraft.entity.item.EntityItem;
 import net.minecraft.item.ItemStack;
 import net.minecraft.world.World;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-@Mixin(value = RenderItemFrame.class)
-public abstract class MixinRenderItemFrame extends Render {
+@Mixin(RenderItemFrame.class)
+public class MixinRenderItemFrame {
 
-    private EntityItem cachedEntityItem;
+    @Unique
+    private EntityItem notfine$cachedEntityItem;
 
     @Redirect(
         method = "func_82402_b(Lnet/minecraft/entity/item/EntityItemFrame;)V",
         at = @At(
             value = "NEW",
             target = "(Lnet/minecraft/world/World;DDDLnet/minecraft/item/ItemStack;)Lnet/minecraft/entity/item/EntityItem;",
-            ordinal = 0
-        )
-    )
-    public EntityItem cacheEntityItem(World world, double x, double y, double z, ItemStack itemstack) {
-        if(cachedEntityItem == null) {
-            cachedEntityItem = new EntityItem(world, 0.0D, 0.0D, 0.0D, itemstack);
+            ordinal = 0))
+    private EntityItem cacheEntityItem(World world, double x, double y, double z, ItemStack itemstack) {
+        if (notfine$cachedEntityItem == null) {
+            notfine$cachedEntityItem = new EntityItem(world, x, y, z, itemstack);
         } else {
-            cachedEntityItem.setEntityItemStack(itemstack);
+            notfine$cachedEntityItem.setWorld(world);
+            notfine$cachedEntityItem.setEntityItemStack(itemstack);
         }
-        return cachedEntityItem;
+        return notfine$cachedEntityItem;
     }
 
+    @Inject(
+        method = "func_82402_b(Lnet/minecraft/entity/item/EntityItemFrame;)V",
+        at = @At(
+            value = "INVOKE",
+            target = "Lorg/lwjgl/opengl/GL11;glPopMatrix()V",
+            remap = false,
+            shift = At.Shift.AFTER))
+    private void clearWorldRef(CallbackInfo ci, @Local(name = "entityitem") EntityItem entityitem) {
+        entityitem.setWorld(null);
+        entityitem.setEntityItemStack(null);
+    }
 }


### PR DESCRIPTION
<img width="625" height="206" alt="image" src="https://github.com/user-attachments/assets/9842d1ac-5971-4bbd-bf45-686ed2e4831e" />
<img width="818" height="385" alt="image" src="https://github.com/user-attachments/assets/8029172a-22d8-4f54-8299-673f3bce8b5b" />

