### PR TITLE
Don't advance buffer positions for Material shininess in GLSM

### DIFF
--- a/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/states/MaterialState.java
+++ b/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/states/MaterialState.java
@@ -103,9 +103,12 @@ public class MaterialState implements ISettableState<MaterialState> {
         }
     }
 
-    public void setShininess(FloatBuffer newBuffer) { setShininess(newBuffer.get()); }
+    // On the buffer versions of shininess, we need to call `get(0)` explicitly specifying the index
+    // otherwise calling `get()` advances the buffer position, and some mods may re-use the same buffer
+    // in subsequent calls, resulting in a BufferUnderflowException.
+    public void setShininess(FloatBuffer newBuffer) { setShininess(newBuffer.get(0)); }
 
-    public void setShininess(IntBuffer newBuffer) { setShininess((float) newBuffer.get());}
+    public void setShininess(IntBuffer newBuffer) { setShininess((float) newBuffer.get(0)); }
 
     public void setShininess(int val) { setShininess((float) val);}
 


### PR DESCRIPTION
Fixes an issue where Angelica would advance the position of buffers passed into glMaterial for `GL_SHININESS`, if a mod then sends back in the same buffer, it will cause a BufferUnderflowException because without GLSM the buffer position doesn't get advanced when calling `glMaterial`.

Fixes #1638