### PR TITLE
always request 0.9.0+ GTNHLib version when a player has an outdated version

### DIFF
--- a/src/main/java/com/gtnewhorizons/angelica/loading/AngelicaClientTweaker.java
+++ b/src/main/java/com/gtnewhorizons/angelica/loading/AngelicaClientTweaker.java
@@ -106,9 +106,6 @@ public final class AngelicaClientTweaker implements IFMLLoadingPlugin, IEarlyMix
                 "/it/unimi/dsi/fastutil/ints/Int2ObjectMap.class",
                 "Missing dependency: Angelica requires GTNHLib! Download: https://modrinth.com/mod/gtnhlib"),
             new DependencyVerifier.Check(
-                "/com/gtnewhorizon/gtnhlib/client/renderer/PrimitiveExtractor.class",
-                "GTNHLib is outdated: Angelica requires GTNHLib 0.8.21 or newer! Download: https://modrinth.com/mod/gtnhlib"),
-            new DependencyVerifier.Check(
                 "/xyz/wagyourtail/jvmdg/exc/MissingStubError.class",
                 "GTNHLib is outdated: Angelica requires GTNHLib 0.9.0 or newer! Download: https://modrinth.com/mod/gtnhlib")
         ));

--- a/umbra/src/main/java/com/gtnewhorizons/umbra/loading/UmbraClientTweaker.java
+++ b/umbra/src/main/java/com/gtnewhorizons/umbra/loading/UmbraClientTweaker.java
@@ -70,8 +70,8 @@ public class UmbraClientTweaker implements IFMLLoadingPlugin, IEarlyMixinLoader 
     private static void verifyDependencies() {
         DependencyVerifier.verify(UmbraClientTweaker.class, List.of(
             new DependencyVerifier.Check(
-                "/com/gtnewhorizon/gtnhlib/client/renderer/PrimitiveExtractor.class",
-                "Missing dependency: Umbra requires GTNHLib 0.8.21+! Download: https://modrinth.com/mod/gtnhlib"),
+                "/it/unimi/dsi/fastutil/ints/Int2ObjectMap.class",
+                "Missing dependency: Umbra requires GTNHLib! Download: https://modrinth.com/mod/gtnhlib"),
             new DependencyVerifier.Check(
                 "/xyz/wagyourtail/jvmdg/exc/MissingStubError.class",
                 "GTNHLib is outdated: Umbra requires GTNHLib 0.9.0+! Download: https://modrinth.com/mod/gtnhlib")


### PR DESCRIPTION
Suggested by @kurrycat2004 here: https://github.com/GTNewHorizons/Angelica/pull/1642#discussion_r3035611888

also changed the missing dependency check in Umbra to only throw when the dep is really missing, which mirrors the Angelica behavior