### PR TITLE
fix(iris): implement full GL alpha test

### DIFF
--- a/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/GLStateManager.java
+++ b/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/GLStateManager.java
@@ -1636,6 +1636,9 @@ public class GLStateManager {
         }
         alphaTest.enable();
         fragmentGeneration++;
+        if (GLSMHooks.ALPHA_STATE_CHANGE.hasListeners()) {
+            GLSMHooks.ALPHA_STATE_CHANGE.post(GLSMHooks.alphaStateChangeEvent);
+        }
     }
 
     public static void disableAlphaTest() {
@@ -1653,6 +1656,9 @@ public class GLStateManager {
         }
         alphaTest.disable();
         fragmentGeneration++;
+        if (GLSMHooks.ALPHA_STATE_CHANGE.hasListeners()) {
+            GLSMHooks.ALPHA_STATE_CHANGE.post(GLSMHooks.alphaStateChangeEvent);
+        }
     }
 
     public static void glAlphaFunc(int function, float reference) {
@@ -1672,6 +1678,9 @@ public class GLStateManager {
             alphaState.setFunction(function);
             alphaState.setReference(reference);
             fragmentGeneration++;
+            if (GLSMHooks.ALPHA_STATE_CHANGE.hasListeners()) {
+                GLSMHooks.ALPHA_STATE_CHANGE.post(GLSMHooks.alphaStateChangeEvent);
+            }
         }
     }
 

--- a/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/hooks/GLSMHooks.java
+++ b/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/hooks/GLSMHooks.java
@@ -1,12 +1,6 @@
 package com.gtnewhorizons.angelica.glsm.hooks;
 
-import com.gtnewhorizons.angelica.glsm.hooks.events.BlendFuncChangeEvent;
-import com.gtnewhorizons.angelica.glsm.hooks.events.FogStateChangeEvent;
-import com.gtnewhorizons.angelica.glsm.hooks.events.LightmapCoordsEvent;
-import com.gtnewhorizons.angelica.glsm.hooks.events.ProgramChangeEvent;
-import com.gtnewhorizons.angelica.glsm.hooks.events.TextureBindEvent;
-import com.gtnewhorizons.angelica.glsm.hooks.events.TextureDeleteEvent;
-import com.gtnewhorizons.angelica.glsm.hooks.events.TextureUnitStateEvent;
+import com.gtnewhorizons.angelica.glsm.hooks.events.*;
 import net.minecraftforge.eventbus.api.bus.EventBus;
 
 public final class GLSMHooks {
@@ -23,6 +17,7 @@ public final class GLSMHooks {
     public static final EventBus<BlendFuncChangeEvent> BLEND_FUNC_CHANGE = EventBus.create(BlendFuncChangeEvent.class);
     public static final EventBus<FogStateChangeEvent> FOG_STATE_CHANGE = EventBus.create(FogStateChangeEvent.class);
     public static final EventBus<LightmapCoordsEvent> LIGHTMAP_COORDS = EventBus.create(LightmapCoordsEvent.class);
+    public static final EventBus<AlphaStateChangeEvent> ALPHA_STATE_CHANGE = EventBus.create(AlphaStateChangeEvent.class);
 
     // Reusable event instances
     public static final TextureBindEvent textureBindEvent = new TextureBindEvent();
@@ -32,6 +27,7 @@ public final class GLSMHooks {
     public static final BlendFuncChangeEvent blendFuncChangeEvent = new BlendFuncChangeEvent();
     public static final FogStateChangeEvent fogStateChangeEvent = new FogStateChangeEvent();
     public static final LightmapCoordsEvent lightmapCoordsEvent = new LightmapCoordsEvent();
+    public static final AlphaStateChangeEvent alphaStateChangeEvent = new AlphaStateChangeEvent();
 
     private GLSMHooks() {}
 }

--- a/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/hooks/events/AlphaStateChangeEvent.java
+++ b/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/hooks/events/AlphaStateChangeEvent.java
@@ -1,0 +1,9 @@
+package com.gtnewhorizons.angelica.glsm.hooks.events;
+
+import net.minecraftforge.eventbus.api.event.MutableEvent;
+
+/**
+ * AlphaTest changed - Listeners should query GLSM alpha state directly if they care what changed.
+ */
+public final class AlphaStateChangeEvent extends MutableEvent {
+}

--- a/src/main/java/com/gtnewhorizons/angelica/iris/IrisGLSMBridge.java
+++ b/src/main/java/com/gtnewhorizons/angelica/iris/IrisGLSMBridge.java
@@ -19,21 +19,25 @@ import net.coderbot.iris.texture.pbr.PBRTextureManager;
 import net.coderbot.iris.vertices.ImmediateState;
 
 public class IrisGLSMBridge {
-    
+
+    private static Runnable alphaFuncListener = null;
+    private static Runnable alphaTestListener = null;
     private static Runnable blendFuncListener = null;
     private static Runnable fogModeListener = null;
     private static Runnable fogStartListener = null;
     private static Runnable fogEndListener = null;
     private static Runnable fogDensityListener = null;
-    
+
     static {
+        StateUpdateNotifiers.alphaFuncNotifier = listener -> alphaFuncListener = listener;
+        StateUpdateNotifiers.alphaTestNotifier = listener -> alphaTestListener = listener;
         StateUpdateNotifiers.blendFuncNotifier = listener -> blendFuncListener = listener;
         StateUpdateNotifiers.fogModeNotifier = listener -> fogModeListener = listener;
         StateUpdateNotifiers.fogStartNotifier = listener -> fogStartListener = listener;
         StateUpdateNotifiers.fogEndNotifier = listener -> fogEndListener = listener;
         StateUpdateNotifiers.fogDensityNotifier = listener -> fogDensityListener = listener;
     }
-    
+
     public static void register() {
         IrisSamplers.initRenderer();
         GLSMHooks.blendHandler = new DeferredBlendHandler() {
@@ -91,13 +95,20 @@ public class IrisGLSMBridge {
                 DepthColorStorage.deferColorMask(r, g, b, a);
             }
         };
-        
+
+        GLSMHooks.ALPHA_STATE_CHANGE.addListener(event -> {
+            if (Iris.enabled) {
+                if (alphaFuncListener != null) alphaFuncListener.run();
+                if (alphaTestListener != null) alphaTestListener.run();
+            }
+        });
+
         GLSMHooks.BLEND_FUNC_CHANGE.addListener(event -> {
             if (Iris.enabled) {
                 if (blendFuncListener != null) blendFuncListener.run();
             }
         });
-        
+
         GLSMHooks.FOG_STATE_CHANGE.addListener(event -> {
             if (Iris.enabled) {
                 if (fogModeListener != null) fogModeListener.run();
@@ -106,7 +117,7 @@ public class IrisGLSMBridge {
                 if (fogDensityListener != null) fogDensityListener.run();
             }
         });
-        
+
         GLSMHooks.TEXTURE_BIND.addListener(event -> {
             if (Iris.enabled) {
                 TextureTracker.INSTANCE.onBindTexture();

--- a/src/main/java/net/coderbot/iris/gl/state/StateUpdateNotifiers.java
+++ b/src/main/java/net/coderbot/iris/gl/state/StateUpdateNotifiers.java
@@ -8,6 +8,8 @@ public class StateUpdateNotifiers {
 	public static ValueUpdateNotifier fogStartNotifier;
 	public static ValueUpdateNotifier fogEndNotifier;
 	public static ValueUpdateNotifier fogDensityNotifier;
+    public static ValueUpdateNotifier alphaFuncNotifier;
+    public static ValueUpdateNotifier alphaTestNotifier;
 	public static ValueUpdateNotifier blendFuncNotifier;
 	public static ValueUpdateNotifier bindTextureNotifier;
 	public static ValueUpdateNotifier normalTextureChangeNotifier;

--- a/src/main/java/net/coderbot/iris/pipeline/transform/CommonTransformer.java
+++ b/src/main/java/net/coderbot/iris/pipeline/transform/CommonTransformer.java
@@ -46,7 +46,22 @@ public class CommonTransformer {
 				// runtime discard using the GLSM-tracked alpha reference value.
 				if (found.contains(0) && parameters.patch != Patch.COMPOSITE && parameters.patch != Patch.COMPUTE) {
 					root.injectVariable("uniform float iris_currentAlphaTest;");
-					root.appendMain("if (iris_FragData0.a <= iris_currentAlphaTest) discard;");
+                    root.injectVariable("uniform int iris_currentAlphaFunc;");
+                    root.injectFunction(
+                        "bool iris_alphaTestPass(float a) {" +
+                            " if (iris_currentAlphaFunc == 7) return true;" +   // ALWAYS / disabled
+                            " if (iris_currentAlphaFunc == 0) return false;" +  // NEVER
+                            " float qa = round(a * 255.0);" +
+                            " float qr = round(iris_currentAlphaTest * 255.0);" +
+                            " if (iris_currentAlphaFunc == 1) return qa < qr;" +    // LESS
+                            " if (iris_currentAlphaFunc == 2) return qa == qr;" +   // EQUAL
+                            " if (iris_currentAlphaFunc == 3) return qa <= qr;" +   // LEQUAL
+                            " if (iris_currentAlphaFunc == 4) return qa > qr;" +    // GREATER
+                            " if (iris_currentAlphaFunc == 5) return qa != qr;" +   // NOTEQUAL
+                            " return qa >= qr;" +                                // GEQUAL (6)
+                            "}"
+                    );
+                    root.appendMain("if (!iris_alphaTestPass(iris_FragData0.a)) discard;");
 				}
 			}
 		}

--- a/src/main/java/net/coderbot/iris/uniforms/IrisInternalUniforms.java
+++ b/src/main/java/net/coderbot/iris/uniforms/IrisInternalUniforms.java
@@ -2,6 +2,7 @@ package net.coderbot.iris.uniforms;
 
 import com.gtnewhorizons.angelica.glsm.GLStateManager;
 import net.coderbot.iris.gl.state.FogMode;
+import net.coderbot.iris.gl.state.StateUpdateNotifiers;
 import net.coderbot.iris.gl.uniform.DynamicUniformHolder;
 import org.joml.Vector3d;
 import org.joml.Vector4f;
@@ -22,6 +23,12 @@ public class IrisInternalUniforms {
         return GLStateManager.getAlphaState().getReference();
     }
 
+    private static int getEffectiveAlphaFunc() {
+        if (!GLStateManager.getAlphaTest().isEnabled()) return 7;
+        final int func = GLStateManager.getAlphaState().getFunction();
+        return func & 0x7;
+    }
+
     public static void addFogUniforms(DynamicUniformHolder uniforms, FogMode fogMode) {
         uniforms.uniform4f(PER_FRAME, "iris_FogColor", () -> {
             final Vector3d color = GLStateManager.getFogState().getFogColor();
@@ -34,7 +41,8 @@ public class IrisInternalUniforms {
             .uniform1f(PER_FRAME, "iris_FogDensity", () -> Math.max(0.0F, GLStateManager.getFogState().getDensity()));
 
         uniforms
-            .uniform1f(PER_FRAME, "iris_currentAlphaTest", IrisInternalUniforms::getEffectiveAlphaRef)
-            .uniform1f(PER_FRAME, "alphaTestRef", IrisInternalUniforms::getEffectiveAlphaRef);
+            .uniform1f("iris_currentAlphaTest", IrisInternalUniforms::getEffectiveAlphaRef, StateUpdateNotifiers.alphaTestNotifier)
+            .uniform1f("alphaTestRef", IrisInternalUniforms::getEffectiveAlphaRef, StateUpdateNotifiers.alphaTestNotifier)
+            .uniform1i("iris_currentAlphaFunc", IrisInternalUniforms::getEffectiveAlphaFunc, StateUpdateNotifiers.alphaFuncNotifier);
     }
 }


### PR DESCRIPTION
Previously, Iris shaders only discarded fragments with iris_currentAlphaTest using a hardcoded <= comparison. 
This replaces that with iris_alphaTestPass(), which supports all 8 GL alpha test functions (NEVER/LESS/EQUAL/LEQUAL/GREATER/NOTEQUAL/GEQUAL/ALWAYS).


- Connect notifiers in IrisGLSMBridge so Iris uniforms update reactively on alpha state changes
- Add iris_currentAlphaFunc uniform (dynamic, int) alongside the existing iris_currentAlphaTest; getEffectiveAlphaFunc() encodes GL_NEVER..GL_ALWAYS as 0..7 via & 0x7

This change contributes to improved rendering of textures including translucency, in RTM. (https://github.com/Kai-Z-JP/KaizPatchX/issues/491)

train windows
| before | after |
| -- | -- |
| <img width="800" alt="image" src="https://github.com/user-attachments/assets/2614afdb-c89f-472d-ba41-d23f397424ba" /> | <img width="800" alt="2026-04-14_10 27 42" src="https://github.com/user-attachments/assets/d66b24a7-f4e0-45e1-9fb7-9c8a2f49880b" /> |
