### PR TITLE
Add targeting of snow-covered blocks.

### DIFF
--- a/src/main/java/com/gtnewhorizons/angelica/rendering/celeritas/AngelicaChunkBuilderMeshingTask.java
+++ b/src/main/java/com/gtnewhorizons/angelica/rendering/celeritas/AngelicaChunkBuilderMeshingTask.java
@@ -8,7 +8,10 @@ import com.gtnewhorizons.angelica.rendering.celeritas.api.IrisShaderProvider;
 import com.gtnewhorizons.angelica.rendering.celeritas.api.IrisShaderProviderHolder;
 import com.gtnewhorizons.angelica.rendering.celeritas.iris.BlockRenderContext;
 import com.gtnewhorizons.angelica.rendering.celeritas.iris.ContextAwareChunkVertexEncoder;
+import com.prupe.mcpatcher.mal.block.RenderBlocksUtils;
 import it.unimi.dsi.fastutil.objects.Reference2ReferenceMap;
+import net.coderbot.iris.block_rendering.BlockMaterialMapping;
+import net.coderbot.iris.block_rendering.BlockRenderingSettings;
 import net.coderbot.iris.vertices.ExtendedDataHelper;
 import net.minecraft.block.Block;
 import net.minecraft.client.Minecraft;
@@ -261,7 +264,13 @@ public abstract class AngelicaChunkBuilderMeshingTask extends ChunkBuilderTask<C
             if (isFluid) {
                 contextEncoder.prepareToRenderFluid(blockRenderContext, block, lightValue);
             } else {
-                contextEncoder.prepareToRenderBlock(blockRenderContext, block, metadata,
+                int effectiveMeta = metadata;
+                if (BlockRenderingSettings.INSTANCE.hasSnowyEntries()
+                    && BlockRenderingSettings.INSTANCE.getSnowyBlocks().contains(block)
+                    && RenderBlocksUtils.isSnowCovered(renderBlocks.blockAccess, x, y, z)) {
+                    effectiveMeta |= BlockMaterialMapping.SNOWY_META_BIT;
+                }
+                contextEncoder.prepareToRenderBlock(blockRenderContext, block, effectiveMeta,
                     ExtendedDataHelper.BLOCK_RENDER_TYPE, lightValue);
             }
         }

--- a/src/main/java/com/prupe/mcpatcher/mal/block/RenderBlocksUtils.java
+++ b/src/main/java/com/prupe/mcpatcher/mal/block/RenderBlocksUtils.java
@@ -157,7 +157,7 @@ public class RenderBlocksUtils {
         return isSnow ? Blocks.snow_layer.getIcon(blockAccess, x, y, z, face) : topIcon;
     }
 
-    private static boolean isSnowCovered(IBlockAccess blockAccess, int x, int y, int z) {
+    public static boolean isSnowCovered(IBlockAccess blockAccess, int x, int y, int z) {
         Block topBlock = blockAccess.getBlock(x, y + 1, z);
         return topBlock == Blocks.snow_layer || topBlock == Blocks.snow;
     }

--- a/src/main/java/net/coderbot/iris/block_rendering/BlockMaterialMapping.java
+++ b/src/main/java/net/coderbot/iris/block_rendering/BlockMaterialMapping.java
@@ -7,7 +7,8 @@ import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.objects.Reference2ObjectMap;
 import it.unimi.dsi.fastutil.objects.Reference2ObjectOpenHashMap;
 import it.unimi.dsi.fastutil.objects.Reference2ReferenceOpenHashMap;
-import net.coderbot.iris.Iris;
+import it.unimi.dsi.fastutil.objects.ReferenceOpenHashSet;
+import it.unimi.dsi.fastutil.objects.ReferenceSet;
 import net.coderbot.iris.shaderpack.materialmap.BlockEntry;
 import net.coderbot.iris.shaderpack.materialmap.BlockRenderType;
 import net.coderbot.iris.shaderpack.materialmap.FlatteningMap;
@@ -21,45 +22,46 @@ import java.util.Map;
 import java.util.Set;
 
 public class BlockMaterialMapping {
+
+	/** Meta-key bit OR'd in at runtime when a snowy-tagged block has snow above it. */
+	public static final int SNOWY_META_BIT = 0x10;
+
 	/**
 	 * Creates a two-level map structure for block material IDs.
 	 * Based on Iris's BlockState mapping approach adapted for 1.7.10's metadata system.
 	 */
-	public static Reference2ObjectMap<Block, Int2IntMap> createBlockMetaIdMap(Int2ObjectMap<List<BlockEntry>> blockPropertiesMap) {
-		Reference2ObjectMap<Block, Int2IntMap> blockMatches = new Reference2ObjectOpenHashMap<>();
+	public static Reference2ObjectMap<Block, Int2IntMap> createBlockMetaIdMap(Int2ObjectMap<List<BlockEntry>> blockPropertiesMap, boolean skipFlattening) {
+		final Reference2ObjectMap<Block, Int2IntMap> blockMatches = new Reference2ObjectOpenHashMap<>();
+		final ReferenceSet<Block> snowyBlocks = new ReferenceOpenHashSet<>();
 
 		blockPropertiesMap.forEach((intId, entries) -> {
 			for (BlockEntry entry : entries) {
-				addBlockMetas(entry, blockMatches, intId);
+				addBlockMetas(entry, blockMatches, intId, skipFlattening, snowyBlocks);
 			}
 		});
 
+		BlockRenderingSettings.INSTANCE.setHasSnowyEntries(!snowyBlocks.isEmpty());
+		BlockRenderingSettings.INSTANCE.setSnowyBlocks(snowyBlocks);
 		return blockMatches;
 	}
 
 	public static Map<Block, BlockRenderLayer> createBlockTypeMap(Map<NamespacedId, BlockRenderType> blockPropertiesMap) {
-		Map<Block, BlockRenderLayer> blockTypeIds = new Reference2ReferenceOpenHashMap<>();
+		final Map<Block, BlockRenderLayer> blockTypeIds = new Reference2ReferenceOpenHashMap<>();
 
 		blockPropertiesMap.forEach((id, blockType) -> {
-			Block block = resolveBlock(id);
+			Block block = resolveBlockOrNull(id);
 
-			// Try flattening map for modern names
-			if ((block == null || block == Blocks.air) && "minecraft".equals(id.getNamespace())) {
-				List<BlockEntry> legacyEntries = FlatteningMap.toLegacy(id.getName(), Map.of());
+			// Modern names like "grass_block" don't exist in 1.7.10's registry; fall back to flattening.
+			if (block == null && "minecraft".equals(id.getNamespace())) {
+				final List<BlockEntry> legacyEntries = FlatteningMap.toLegacy(id.getName(), Map.of());
 				if (legacyEntries != null) {
-					// Use the first entry for render type (render type applies per-block)
-					block = resolveBlock(legacyEntries.getFirst().getId());
+					block = resolveBlockOrNull(legacyEntries.getFirst().getId());
 				}
 			}
 
-			if (block == null || block == Blocks.air) {
-				return;
-			}
-
+			if (block == null) return;
 			final BlockRenderLayer layer = convertBlockToRenderLayer(blockType);
-			if (layer != null) {
-				blockTypeIds.put(block, layer);
-			}
+			if (layer != null) blockTypeIds.put(block, layer);
 		});
 
 		return blockTypeIds;
@@ -82,33 +84,29 @@ public class BlockMaterialMapping {
 	 * Adds block+metadata combinations to the material ID map.
 	 * Based on Iris's addBlockStates method, adapted for 1.7.10 metadata system.
 	 */
-	private static void addBlockMetas(BlockEntry entry, Reference2ObjectMap<Block, Int2IntMap> idMap, int intId) {
-		NamespacedId id = entry.getId();
-		String name = id.getName();
-		boolean hasStateProps = !entry.getStateProperties().isEmpty();
-		boolean hasExplicitMetas = !entry.getMetas().isEmpty();
+	private static void addBlockMetas(BlockEntry entry, Reference2ObjectMap<Block, Int2IntMap> idMap, int intId, boolean skipFlattening, ReferenceSet<Block> snowyBlocks) {
+		final NamespacedId id = entry.getId();
+		final Map<String, String> stateProps = entry.getStateProperties();
+		final String snowy = stateProps.get("snowy");
+		final int snowyBit = "true".equals(snowy) ? SNOWY_META_BIT : 0;
 
-        if ("minecraft".equals(id.getNamespace()) && (hasStateProps || !hasExplicitMetas)) {
-			List<BlockEntry> legacyEntries = FlatteningMap.toLegacy(name, entry.getStateProperties());
-			if (legacyEntries != null) {
-				for (BlockEntry legacy : legacyEntries) {
-					applyMetas(resolveBlock(legacy.getId()), legacy.getMetas(), idMap, intId);
-				}
-				return;
-			}
+		// Vanilla modern names go through FlatteningMap; legacy-section packs and modded blocks
+		// resolve directly from the registry.
+		List<BlockEntry> targets = null;
+		if (!skipFlattening && "minecraft".equals(id.getNamespace()) && (!stateProps.isEmpty() || entry.getMetas().isEmpty())) {
+			targets = FlatteningMap.toLegacy(id.getName(), stateProps);
 		}
+		if (targets == null) targets = List.of(entry);
 
-		// Fall back to registry with the entry's own metas
-		Block block = resolveBlock(id);
-		applyMetas(block, entry.getMetas(), idMap, intId);
+		for (BlockEntry target : targets) {
+			final Block block = resolveBlockOrNull(target.getId());
+			if (block == null) continue;
+			applyMetas(block, target.getMetas(), idMap, intId, snowyBit);
+			if (snowy != null) snowyBlocks.add(block);
+		}
 	}
-    // If the block doesn't exist, by default the registry will return AIR. That probably isn't what we want.
-    // TODO: Assuming that Registry.BLOCK.getDefaultId() == "minecraft:air" here
-	private static void applyMetas(Block block, Set<Integer> metas, Reference2ObjectMap<Block, Int2IntMap> idMap, int intId) {
-		if (block == null || block == Blocks.air) {
-			return;
-		}
 
+	private static void applyMetas(Block block, Set<Integer> metas, Reference2ObjectMap<Block, Int2IntMap> idMap, int intId, int snowyBit) {
 		Int2IntMap metaMap = idMap.get(block);
 		if (metaMap == null) {
 			metaMap = new Int2IntOpenHashMap();
@@ -117,18 +115,18 @@ public class BlockMaterialMapping {
 		}
 
 		if (metas.isEmpty()) {
-			for (int meta = 0; meta < 16; meta++) {
-				metaMap.putIfAbsent(meta, intId);
-			}
+			for (int meta = 0; meta < 16; meta++) metaMap.putIfAbsent(meta | snowyBit, intId);
 		} else {
-			for (int meta : metas) {
-				metaMap.putIfAbsent(meta, intId);
-			}
+			for (int meta : metas) metaMap.putIfAbsent(meta | snowyBit, intId);
 		}
 	}
 
-	private static Block resolveBlock(NamespacedId id) {
-		final ResourceLocation resourceLocation = new ResourceLocation(id.getNamespace(), id.getName());
-		return (Block) Block.blockRegistry.getObject(resourceLocation.toString());
+	/**
+	 * Returns the registered Block for an id, or null if unknown.
+	 * The registry returns Blocks.air (its default) for missing keys, which we coerce to null.
+	 */
+	private static Block resolveBlockOrNull(NamespacedId id) {
+		final Block block = (Block) Block.blockRegistry.getObject(new ResourceLocation(id.getNamespace(), id.getName()).toString());
+		return block == Blocks.air ? null : block;
 	}
 }

--- a/src/main/java/net/coderbot/iris/block_rendering/BlockRenderingSettings.java
+++ b/src/main/java/net/coderbot/iris/block_rendering/BlockRenderingSettings.java
@@ -4,7 +4,10 @@ import com.gtnewhorizons.angelica.rendering.celeritas.BlockRenderLayer;
 import it.unimi.dsi.fastutil.ints.Int2IntMap;
 import it.unimi.dsi.fastutil.objects.Object2IntFunction;
 import it.unimi.dsi.fastutil.objects.Reference2ObjectMap;
+import it.unimi.dsi.fastutil.objects.ReferenceSet;
+import it.unimi.dsi.fastutil.objects.ReferenceSets;
 import lombok.Getter;
+import lombok.Setter;
 import net.coderbot.iris.shaderpack.materialmap.NamespacedId;
 import net.minecraft.block.Block;
 import net.minecraft.client.Minecraft;
@@ -19,12 +22,21 @@ public class BlockRenderingSettings {
     private boolean reloadRequired;
 	private Reference2ObjectMap<Block, Int2IntMap> blockMetaMatches;
 	private Map<Block, BlockRenderLayer> blockTypeIds;
-	private Object2IntFunction<NamespacedId> entityIds;
-	private Object2IntFunction<NamespacedId> itemIds;
-	private float ambientOcclusionLevel;
+    // note: no reload needed, entities are rebuilt every frame.
+    @Setter
+    private Object2IntFunction<NamespacedId> entityIds;
+    // note: no reload needed, items are rendered every frame.
+    @Setter
+    private Object2IntFunction<NamespacedId> itemIds;
+	@Getter
+    private float ambientOcclusionLevel;
 	private boolean disableDirectionalShading;
 	private boolean useSeparateAo;
 	private boolean useExtendedVertexFormat;
+	@Setter
+    private boolean hasSnowyEntries;
+	@Getter
+    private ReferenceSet<Block> snowyBlocks = ReferenceSets.emptySet();
 
 	public BlockRenderingSettings() {
 		reloadRequired = false;
@@ -34,6 +46,7 @@ public class BlockRenderingSettings {
 		disableDirectionalShading = false;
 		useSeparateAo = false;
 		useExtendedVertexFormat = false;
+		hasSnowyEntries = false;
 	}
 
     public void clearReloadRequired() {
@@ -74,6 +87,14 @@ public class BlockRenderingSettings {
 		this.blockMetaMatches = blockMetaIds;
 	}
 
+	public boolean hasSnowyEntries() {
+		return hasSnowyEntries;
+	}
+
+    public void setSnowyBlocks(ReferenceSet<Block> snowyBlocks) {
+		this.snowyBlocks = snowyBlocks != null ? snowyBlocks : ReferenceSets.emptySet();
+	}
+
 	public void setBlockTypeIds(Map<Block, BlockRenderLayer> blockTypeIds) {
 		if (this.blockTypeIds != null && this.blockTypeIds.equals(blockTypeIds)) {
 			return;
@@ -83,21 +104,7 @@ public class BlockRenderingSettings {
 		this.blockTypeIds = blockTypeIds;
 	}
 
-	public void setEntityIds(Object2IntFunction<NamespacedId> entityIds) {
-		// note: no reload needed, entities are rebuilt every frame.
-		this.entityIds = entityIds;
-	}
-
-	public void setItemIds(Object2IntFunction<NamespacedId> itemIds) {
-		// note: no reload needed, items are rendered every frame.
-		this.itemIds = itemIds;
-	}
-
-	public float getAmbientOcclusionLevel() {
-		return ambientOcclusionLevel;
-	}
-
-	public void setAmbientOcclusionLevel(float ambientOcclusionLevel) {
+    public void setAmbientOcclusionLevel(float ambientOcclusionLevel) {
 		if (ambientOcclusionLevel == this.ambientOcclusionLevel) {
 			return;
 		}

--- a/src/main/java/net/coderbot/iris/pipeline/DeferredWorldRenderingPipeline.java
+++ b/src/main/java/net/coderbot/iris/pipeline/DeferredWorldRenderingPipeline.java
@@ -279,7 +279,9 @@ public class DeferredWorldRenderingPipeline implements WorldRenderingPipeline, R
             holder -> CommonUniforms.addNonDynamicUniforms(holder, programs.getPack().getIdMap(), programs.getPackDirectives(), this.updateNotifier)
         );
 
-		BlockRenderingSettings.INSTANCE.setBlockMetaMatches(BlockMaterialMapping.createBlockMetaIdMap(programs.getPack().getIdMap().getBlockProperties()));
+		BlockRenderingSettings.INSTANCE.setBlockMetaMatches(BlockMaterialMapping.createBlockMetaIdMap(
+			programs.getPack().getIdMap().getBlockProperties(),
+			programs.getPack().getIdMap().hasLegacySection()));
 		BlockRenderingSettings.INSTANCE.setBlockTypeIds(BlockMaterialMapping.createBlockTypeMap(programs.getPack().getIdMap().getBlockRenderTypeMap()));
 
 		BlockRenderingSettings.INSTANCE.setEntityIds(programs.getPack().getIdMap().getEntityIdMap());

--- a/src/main/java/net/coderbot/iris/shaderpack/IdMap.java
+++ b/src/main/java/net/coderbot/iris/shaderpack/IdMap.java
@@ -35,6 +35,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
+import java.util.regex.Pattern;
 
 /**
  * A utility class for parsing entries in item.properties, block.properties, and entities.properties files in shaderpacks
@@ -61,14 +62,24 @@ public class IdMap {
 	@Getter
     private Map<NamespacedId, BlockRenderType> blockRenderTypeMap;
 
+	/** True when block.properties contained a preprocessor directive guarding a 1.7.10-specific section. */
+	private final boolean hasLegacySection;
+
+	public boolean hasLegacySection() {
+		return hasLegacySection;
+	}
+
+	private static final Pattern LEGACY_DIRECTIVE_PATTERN = Pattern.compile(
+		"(?m)^\\s*#\\s*(?:if|elif|ifdef|ifndef)\\b[^\\n]*\\bMC_VERSION\\b[^\\n]*\\b10710\\b");
+
 	IdMap(Path shaderPath, ShaderPackOptions shaderPackOptions, Iterable<StringPair> environmentDefines) {
 		// Check if block.properties has a dedicated 1.7.10 section
 		String rawBlockProperties = readProperties(shaderPath, "block.properties");
-		boolean hasLegacySection = rawBlockProperties != null
-			&& rawBlockProperties.contains("MC_VERSION") && rawBlockProperties.contains("10710");
+		this.hasLegacySection = rawBlockProperties != null
+			&& LEGACY_DIRECTIVE_PATTERN.matcher(rawBlockProperties).find();
 
 		Iterable<StringPair> resolvedDefines;
-		if (hasLegacySection) {
+		if (this.hasLegacySection) {
 			// Pack has a 1.7.10 section
 			resolvedDefines = environmentDefines;
 			loadProperties(shaderPath, "block.properties", shaderPackOptions, environmentDefines).ifPresent(blockProperties -> {


### PR DESCRIPTION
This lets us be able to do "grass:snowy=true" in block.properties now by reusing some logic in mcpatcher.

Before: 
<img width="2560" height="1368" alt="2026-04-25_17 21 59" src="https://github.com/user-attachments/assets/572bb81b-50e2-48e3-9606-842ba61b4609" />

After: 
<img width="2560" height="1368" alt="2026-04-25_17 21 47" src="https://github.com/user-attachments/assets/a6342b93-e067-4a8d-ab62-414519daae41" />
