### PR TITLE
[Memory-opti:fix leak] Fix dynamic lights world client leaks

### DIFF
--- a/src/main/java/com/gtnewhorizons/angelica/dynamiclights/DynamicLights.java
+++ b/src/main/java/com/gtnewhorizons/angelica/dynamiclights/DynamicLights.java
@@ -181,6 +181,19 @@ public class DynamicLights {
     }
 
     /**
+     * Removes all tracked light sources, to call when unloading the client world
+     */
+    public void removeAllLightSources() {
+        this.lightSourcesLock.writeLock().lock();
+
+        this.dynamicLightSources.clear();
+        this.lightSourceCount = 0;
+        rebuildLightSourceArray();
+
+        this.lightSourcesLock.writeLock().unlock();
+    }
+
+    /**
      * Removes light sources if the filter matches.
      *
      * @param filter the removal filter

--- a/src/main/java/com/gtnewhorizons/angelica/proxy/ClientProxy.java
+++ b/src/main/java/com/gtnewhorizons/angelica/proxy/ClientProxy.java
@@ -106,26 +106,6 @@ public final class ClientProxy extends CommonProxy {
         blockError = new BlockError();
     }
 
-    @SubscribeEvent
-    public void worldLoad(WorldEvent.Load event) {
-        if (GLStateManager.isRunningSplash()) {
-            GLStateManager.setRunningSplash(false);
-            LOGGER.info("World loaded - Enabling GLSM Cache");
-        }
-
-        if (AngelicaConfig.enableCeleritas) {
-            ChunkTaskRegistry.reset();
-            ChunkTaskRegistry.registerProvider(DefaultChunkTaskProvider.INSTANCE);
-            ChunkTaskRegistry.registerProvider(ThreadedChunkTaskProvider.INSTANCE);
-
-            // Register all blocks. Because blockids are unique to a world, this must be done each load
-            GameData.getBlockRegistry().typeSafeIterable().forEach(o -> {
-                AngelicaBlockSafetyRegistry.canBlockRenderOffThread(o, true, true);
-                AngelicaBlockSafetyRegistry.canBlockRenderOffThread(o, false, true);
-            });
-        }
-    }
-
     @Override
     public void init(FMLInitializationEvent event) {
         super.init(event);
@@ -170,7 +150,6 @@ public final class ClientProxy extends CommonProxy {
         }
     }
 
-
     @Override
     public void postInit(FMLPostInitializationEvent event) {
         super.postInit(event);
@@ -190,11 +169,38 @@ public final class ClientProxy extends CommonProxy {
         }
     }
 
+    @SubscribeEvent
+    public void worldLoad(WorldEvent.Load event) {
+        if (!event.world.isRemote) return;
+        if (GLStateManager.isRunningSplash()) {
+            GLStateManager.setRunningSplash(false);
+            LOGGER.info("World loaded - Enabling GLSM Cache");
+        }
+
+        if (AngelicaConfig.enableCeleritas) {
+            ChunkTaskRegistry.reset();
+            ChunkTaskRegistry.registerProvider(DefaultChunkTaskProvider.INSTANCE);
+            ChunkTaskRegistry.registerProvider(ThreadedChunkTaskProvider.INSTANCE);
+
+            // Register all blocks. Because blockids are unique to a world, this must be done each load
+            GameData.getBlockRegistry().typeSafeIterable().forEach(o -> {
+                AngelicaBlockSafetyRegistry.canBlockRenderOffThread(o, true, true);
+                AngelicaBlockSafetyRegistry.canBlockRenderOffThread(o, false, true);
+            });
+        }
+    }
+
+    @SubscribeEvent
+    public void onWorldUnload(WorldEvent.Unload event) {
+        if (!event.world.isRemote) return;
+        DynamicLights.get().removeAllLightSources();
+    }
+
     float lastIntegratedTickTime;
 
     @SubscribeEvent
     public void onTick(TickEvent.ServerTickEvent event) {
-        if (FMLCommonHandler.instance().getSide().isClient() && event.phase == TickEvent.Phase.END) {
+        if (event.phase == TickEvent.Phase.END) {
             final IntegratedServer srv = Minecraft.getMinecraft().getIntegratedServer();
             if (srv != null) {
                 final long currentTickTime = srv.tickTimeArray[srv.getTickCounter() % 100];

--- a/src/mixin/java/com/gtnewhorizons/angelica/mixins/early/angelica/dynamiclights/MixinEntity.java
+++ b/src/mixin/java/com/gtnewhorizons/angelica/mixins/early/angelica/dynamiclights/MixinEntity.java
@@ -42,8 +42,6 @@ public abstract class MixinEntity implements IDynamicLightSource {
     @Unique
     private int angelica$lastLuminance = 0;
     @Unique
-    private static long angelica$lastUpdate = 0;
-    @Unique
     private double angelica$prevX;
     @Unique
     private double angelica$prevY;
@@ -53,7 +51,6 @@ public abstract class MixinEntity implements IDynamicLightSource {
     private LongOpenHashSet angelica$trackedLitChunkPos = null;
     @Unique
     private LongOpenHashSet angelica$prevTrackedLitChunkPos = null;
-
 
     @Override
     public double angelica$getDynamicLightX() {

--- a/src/mixin/java/com/gtnewhorizons/angelica/mixins/early/angelica/dynamiclights/MixinWorld.java
+++ b/src/mixin/java/com/gtnewhorizons/angelica/mixins/early/angelica/dynamiclights/MixinWorld.java
@@ -6,7 +6,6 @@ import com.llamalad7.mixinextras.injector.ModifyReturnValue;
 import net.minecraft.block.Block;
 import net.minecraft.entity.Entity;
 import net.minecraft.world.World;
-import net.minecraft.world.WorldSettings;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
@@ -17,13 +16,11 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 public abstract class MixinWorld {
 
     @Shadow
-    protected abstract void initialize(WorldSettings p_72963_1_);
-    @Shadow
     public abstract Block getBlock(int p_147439_1_, int p_147439_2_, int p_147439_3_);
 
     @Inject(method = "onEntityRemoved", at = @At("HEAD"))
-    private void angelica$removeEntity(Entity entity, CallbackInfo ci){
-        if (entity instanceof IDynamicLightSource lightSource){
+    private void angelica$removeEntity(Entity entity, CallbackInfo ci) {
+        if (entity.worldObj.isRemote && entity instanceof IDynamicLightSource lightSource) {
             lightSource.angelica$setDynamicLightEnabled(false);
         }
     }


### PR DESCRIPTION
The dynamic lights collections wasn't getting cleared when unloading world.

I changed the world mixin to call the dynamic light hook only for client entities.
I changed the client proxy world Load hook to only run for client worlds.
I added a hook when unloading the client world to clean the dynamic light collection.

<img width="513" height="153" alt="image" src="https://github.com/user-attachments/assets/7879135e-3eff-421e-9e6e-51ae7d39535b" />
<img width="581" height="108" alt="image" src="https://github.com/user-attachments/assets/e4ef354a-6776-4f39-bbd0-56fde8b9f295" />

