### PR TITLE
Increase MAX_COLOR_BUFFERS limit to 32

### DIFF
--- a/src/main/java/net/coderbot/iris/shaderpack/IrisLimits.java
+++ b/src/main/java/net/coderbot/iris/shaderpack/IrisLimits.java
@@ -8,5 +8,5 @@ public class IrisLimits {
 	 * It's not recommended to raise this higher than 16 until code for avoiding allocation of unused color textures
 	 * is implemented.
 	 */
-	public static final int MAX_COLOR_BUFFERS = 16;
+	public static final int MAX_COLOR_BUFFERS = 32;
 }


### PR DESCRIPTION
IMS has done this as well in modern iris 1.10.0+ and didn't change anything else and it works just fine. Shaders will likely use these