### PR TITLE
Fix stale uniforms when switching shader program

### DIFF
--- a/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/CompatUniformManager.java
+++ b/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/CompatUniformManager.java
@@ -9,13 +9,10 @@ import com.gtnewhorizons.angelica.glsm.states.MaterialState;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 
 import static com.gtnewhorizons.angelica.glsm.backend.BackendManager.RENDER_BACKEND;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.joml.Matrix3f;
 import org.joml.Matrix4f;
 import org.lwjgl.BufferUtils;
 import org.lwjgl.opengl.GL11;
-import org.lwjgl.opengl.GL20;
 
 import java.nio.FloatBuffer;
 

--- a/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/GLStateManager.java
+++ b/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/GLStateManager.java
@@ -4295,6 +4295,7 @@ public class GLStateManager {
             if (GLSMHooks.PROGRAM_CHANGE.hasListeners()) {
                 GLSMHooks.programChangeEvent.previousProgram = prev;
                 GLSMHooks.programChangeEvent.newProgram = 0;
+                GLSMHooks.programChangeEvent.postBind = false;
                 GLSMHooks.PROGRAM_CHANGE.post(GLSMHooks.programChangeEvent);
             }
             ffp.activate();
@@ -4315,6 +4316,7 @@ public class GLStateManager {
             if (GLSMHooks.PROGRAM_CHANGE.hasListeners()) {
                 GLSMHooks.programChangeEvent.previousProgram = prev;
                 GLSMHooks.programChangeEvent.newProgram = program;
+                GLSMHooks.programChangeEvent.postBind = false;
                 GLSMHooks.PROGRAM_CHANGE.post(GLSMHooks.programChangeEvent);
             }
             if (initConfig != null && initConfig.isLwjglDebug()) {
@@ -4323,6 +4325,12 @@ public class GLStateManager {
             }
             RENDER_BACKEND.useProgram(program);
             CompatUniformManager.onUseProgram(program);
+            if (GLSMHooks.PROGRAM_CHANGE.hasListeners()) {
+                GLSMHooks.programChangeEvent.previousProgram = prev;
+                GLSMHooks.programChangeEvent.newProgram = program;
+                GLSMHooks.programChangeEvent.postBind = true;
+                GLSMHooks.PROGRAM_CHANGE.post(GLSMHooks.programChangeEvent);
+            }
         }
     }
 

--- a/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/hooks/events/ProgramChangeEvent.java
+++ b/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/hooks/events/ProgramChangeEvent.java
@@ -5,4 +5,5 @@ import net.minecraftforge.eventbus.api.event.MutableEvent;
 public final class ProgramChangeEvent extends MutableEvent {
     public int previousProgram;
     public int newProgram;
+    public boolean postBind;
 }

--- a/src/main/java/com/gtnewhorizons/angelica/iris/IrisGLSMBridge.java
+++ b/src/main/java/com/gtnewhorizons/angelica/iris/IrisGLSMBridge.java
@@ -16,7 +16,6 @@ import net.coderbot.iris.pipeline.DeferredWorldRenderingPipeline;
 import net.coderbot.iris.pipeline.WorldRenderingPipeline;
 import net.coderbot.iris.samplers.IrisSamplers;
 import net.coderbot.iris.texture.pbr.PBRTextureManager;
-import net.coderbot.iris.vertices.ImmediateState;
 
 public class IrisGLSMBridge {
 
@@ -149,20 +148,37 @@ public class IrisGLSMBridge {
             }
         });
 
-        GLSMHooks.PROGRAM_CHANGE.addListener(event -> ProgramUniforms.clearActiveUniforms());
+        GLSMHooks.PROGRAM_CHANGE.addListener(event -> {
+            if (!Iris.enabled) return;
+            if (event.postBind) return;
+            ProgramUniforms.clearActiveUniforms();
+        });
 
         GLSMHooks.PROGRAM_CHANGE.addListener(event -> {
             if (!Iris.enabled) return;
+            if (event.postBind) return;
+            
             final WorldRenderingPipeline pipeline = Iris.getPipelineManager().getPipelineNullable();
             if (!(pipeline instanceof DeferredWorldRenderingPipeline drp)) return;
             if (!drp.shouldOverrideShaders()) return;
             if (drp.getActivePassProgramId() == -1) return;
-
-            if (!ImmediateState.isRenderingLevel || DepthColorStorage.isOwnedProgram(event.newProgram)) {
+            
+            if (DepthColorStorage.isOwnedProgram(event.newProgram)) {
                 DepthColorStorage.unlockDepthColor();
-            } else {
-                drp.onModProgramOverride();
             }
         });
+        
+        GLSMHooks.PROGRAM_CHANGE.addListener(event -> {
+            if (!Iris.enabled) return;
+            if (!event.postBind) return;
+            WorldRenderingPipeline pipeline = Iris.getPipelineManager().getPipelineNullable();
+            if (pipeline instanceof DeferredWorldRenderingPipeline drp) {
+                DeferredWorldRenderingPipeline.Pass activePass = drp.getActivePassProgram();
+                if (activePass != null && activePass.getProgram() != null && activePass.getProgram().getProgramId() == event.newProgram) {
+                    activePass.getProgram().getUniforms().update();
+                }
+            }
+        });
+
     }
 }

--- a/src/main/java/net/coderbot/iris/gl/program/Program.java
+++ b/src/main/java/net/coderbot/iris/gl/program/Program.java
@@ -1,12 +1,19 @@
 package net.coderbot.iris.gl.program;
 
+import lombok.Getter;
 import net.coderbot.iris.gl.GlResource;
 import net.coderbot.iris.gl.blending.DepthColorStorage;
 import com.gtnewhorizons.angelica.glsm.GLStateManager;
 
 public final class Program extends GlResource {
+	
+	@Getter
 	private final ProgramUniforms uniforms;
+	
+	@Getter
 	private final ProgramSamplers samplers;
+	
+	@Getter
 	private final ProgramImages images;
 
 	Program(int program, ProgramUniforms uniforms, ProgramSamplers samplers, ProgramImages images) {
@@ -18,15 +25,15 @@ public final class Program extends GlResource {
 
 		DepthColorStorage.registerOwnedProgram(program);
 	}
-
+	
 	public void use() {
 		GLStateManager.glUseProgram(getGlId());
-
+		
 		uniforms.update();
 		samplers.update();
 		images.update();
 	}
-
+	
 	public static void unbind() {
 		ProgramUniforms.clearActiveUniforms();
 		ProgramSamplers.clearActiveSamplers();
@@ -38,12 +45,7 @@ public final class Program extends GlResource {
 		DepthColorStorage.unregisterOwnedProgram(getGlId());
 		GLStateManager.glDeleteProgram(getGlId());
 	}
-
-	/**
-	 * @return the OpenGL ID of this program.
-	 * @deprecated this should be encapsulated eventually
-	 */
-	@Deprecated
+	
 	public int getProgramId() {
 		return getGlId();
 	}

--- a/src/main/java/net/coderbot/iris/pipeline/DeferredWorldRenderingPipeline.java
+++ b/src/main/java/net/coderbot/iris/pipeline/DeferredWorldRenderingPipeline.java
@@ -181,9 +181,7 @@ public class DeferredWorldRenderingPipeline implements WorldRenderingPipeline, R
 	private final boolean allowConcurrentCompute;
 	private final OptionalInt forcedShadowRenderDistanceChunks;
 	private final CloudSetting dhCloudSetting;
-
 	private Pass current = null;
-
 	private WorldRenderingPhase overridePhase = null;
 	private WorldRenderingPhase phase = WorldRenderingPhase.NONE;
 	private boolean isBeforeTranslucent;
@@ -769,7 +767,11 @@ public class DeferredWorldRenderingPipeline implements WorldRenderingPipeline, R
 	public boolean shouldOverrideShaders() {
 		return isRenderingWorld && !isRenderingFullScreenPass && !isPostChain && isMainBound;
 	}
-
+	
+	public Pass getActivePassProgram() {
+		return current;
+	}
+	
 	public int getActivePassProgramId() {
 		if (current == null) return -1;
 		final Program p = current.getProgram();
@@ -1050,7 +1052,7 @@ public class DeferredWorldRenderingPipeline implements WorldRenderingPipeline, R
 		return shadowRenderTargets != null;
 	}
 
-	private final class Pass {
+	public final class Pass {
 		@Nullable
 		private final Program program;
 		private final GlFramebuffer framebufferBeforeTranslucents;

--- a/src/main/java/net/coderbot/iris/vertices/ImmediateState.java
+++ b/src/main/java/net/coderbot/iris/vertices/ImmediateState.java
@@ -1,9 +1,0 @@
-package net.coderbot.iris.vertices;
-
-/**
- * Some annoying global state needed for the extended vertex format disabling optimization.
- */
-public class ImmediateState {
-	public static boolean isRenderingLevel = false;
-	public static boolean renderWithExtendedVertexFormat = true;
-}


### PR DESCRIPTION

When `glUseProgram` was called, iris cleared all active uniforms (`ProgramUniforms.clearActiveUniforms()`)
However, when the original program was restored again, it's uniforms were not restored


Very easy to notice in the example of sign (text rendering) and other TE

Because text rendering (BatchingFontRenderer) does:

```java

private void flushBatch() {
...
    final int prevProgram = GLStateManager.glGetInteger(GL20.GL_CURRENT_PROGRAM);
...
    GLStateManager.glUseProgram(fontShaderId);
...
	GLStateManager.glDrawElements(GL11.GL_TRIANGLES, cmd.idxCount, GL11.GL_UNSIGNED_SHORT, (long) cmd.startVtx * 2L);
...
	GLStateManager.glUseProgram(prevProgram);
...
}

```

Thus, for example, sign has blockEntityId == 5024, other TE must have blockEntityId == 0

The call stack looks something like this:

```
CapturedRenderingState.INSTANCE.setCurrentBlockEntity(5024)
this.blockEntityIdListener != null == true
	this.blockEntityIdListener.run()
renderTileEntityAt(TileEntitySign)
	fontrenderer.drawString(...)
	final int prevProgram = GLStateManager.glGetInteger(GL20.GL_CURRENT_PROGRAM)
	GLStateManager.glUseProgram(fontShaderId)
		ProgramUniforms.clearActiveUniforms()
		this.blockEntityIdListener = null
	GLStateManager.glDrawElements(GL11.GL_TRIANGLES, cmd.idxCount, GL11.GL_UNSIGNED_SHORT, (long) cmd.startVtx * 2L)
	GLStateManager.glUseProgram(prevProgram)
CapturedRenderingState.INSTANCE.setCurrentBlockEntity(0)
this.blockEntityIdListener != null == false
...

```

So, blockEntityId remained 5024, although it should have been reset to 0

(Set sign's blockId to ender portal's, for better visibility)

<img width="1920" height="1017" alt="2026-05-02_20 27 42" src="https://github.com/user-attachments/assets/72a67b90-b126-47b8-8998-d75fd800ea88" />


<img width="1920" height="1017" alt="2026-05-02_20 24 44" src="https://github.com/user-attachments/assets/760ff27c-92bc-45a2-9e3d-f824aa9ea1bf" />
