### PR TITLE
Fix CTM inventory texture bleed

### DIFF
--- a/src/mixin/java/com/gtnewhorizons/angelica/mixins/early/rendering/MixinRenderBlocks.java
+++ b/src/mixin/java/com/gtnewhorizons/angelica/mixins/early/rendering/MixinRenderBlocks.java
@@ -205,16 +205,15 @@ public abstract class MixinRenderBlocks {
             return;
         }
 
+        CompactCtmQuadProcessor processor = getCompactProcessor();
+        CTMUtils.clearCurrentCompact();
         if (this.blockAccess == null) {
             return;
         }
-
-        CompactCtmQuadProcessor processor = getCompactProcessor();
         if (processor == null) {
             return;
         }
 
-        compactCtmRendering = true;
         try {
             boolean handled = processor.processFace(
                 (RenderBlocks)(Object)this,


### PR DESCRIPTION
In working on the Bose-Einstein PR, we found that one of the (CTM-enabled) casings could bleed onto other items:
<img width="650" height="59" alt="image" src="https://github.com/user-attachments/assets/738ffb9c-5eeb-48d8-928d-c70fdf96c119" />

This PR prevents that from happening (ignore the first block change, that's an unrelated bug):
<img width="643" height="64" alt="image" src="https://github.com/user-attachments/assets/a537ee69-5495-4b07-b259-f45c07e100c9" />

Other CTM should be fine, confirmed on NAC glass:
https://cdn.discordapp.com/attachments/1494775632687534120/1500704438065561610/image.png?ex=69f9676b&is=69f815eb&hm=263d3c9db4e38a3e28de40dbbd1f6a2bff44eb11429e0177e9325bca0a87fb00&

Key to the issue was that, if there was a GT controller before the items, the bleed did not occur. `CURRENT_COMPACT` would be set by this renderer, AE2 blocks would hit it (since they have a valid `blockAccess`, so skipped the null check), and thus the leak. This new flow grabs the CTM processor, clears the holder, and does the recursive calls with the processor.

Removed the `compactCtmRendering = true;` line since it's redundant, being after a return when it's false.