### PR TITLE
Remove DSA from GLSM & other stuff

### DIFF
--- a/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/GLStateManager.java
+++ b/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/GLStateManager.java
@@ -627,16 +627,6 @@ public class GLStateManager {
         return BYPASS_CACHE || !isCachingEnabled();
     }
 
-    /**
-     * Returns true if we should use DSA for texture operations. DSA relies on cached texture bindings, which aren't tracked when caching is disabled. Also,
-     * proxy textures are special query textures that shouldn't use DSA.
-     */
-    private static boolean shouldUseDSA(int target) {
-        if (!isCachingEnabled()) return false;
-        // Proxy textures are for capability queries, not real textures
-        return target != GL11.GL_PROXY_TEXTURE_1D && target != GL11.GL_PROXY_TEXTURE_2D && target != GL12.GL_PROXY_TEXTURE_3D;
-    }
-
     // LWJGL Overrides
     public static void glEnable(int cap) {
         final RecordMode mode = DisplayListManager.getRecordMode();
@@ -1834,13 +1824,7 @@ public class GLStateManager {
         }
         TextureInfoCache.INSTANCE.onTexImage2D(target, level, internalformat, width, height, border, format, type, pixels);
         suspendPixelUnpackBuffer();
-        if (shouldUseDSA(target)) {
-            // Use DSA to upload directly to the texture
-            RenderSystem.textureImage2D(getBoundTextureForServerState(), target, level, internalformat, width, height, border, format, type, pixels);
-        } else {
-            // Non-main thread or proxy texture - use direct GL call
-            RENDER_BACKEND.texImage2D(target, level, internalformat, width, height, border, format, type, pixels);
-        }
+        RENDER_BACKEND.texImage2D(target, level, internalformat, width, height, border, format, type, pixels);
         restorePixelUnpackBuffer();
     }
 
@@ -1885,11 +1869,7 @@ public class GLStateManager {
         }
         TextureInfoCache.INSTANCE.onTexImage2D(target, level, internalformat, width, height, border, format, type, pixels != null ? pixels.asIntBuffer() : null);
         suspendPixelUnpackBuffer();
-        if (shouldUseDSA(target)) {
-            RenderSystem.textureImage2D(getBoundTextureForServerState(), target, level, internalformat, width, height, border, format, type, pixels);
-        } else {
-            RENDER_BACKEND.texImage2D(target, level, internalformat, width, height, border, format, type, pixels);
-        }
+        RENDER_BACKEND.texImage2D(target, level, internalformat, width, height, border, format, type, pixels);
         restorePixelUnpackBuffer();
     }
 
@@ -4413,6 +4393,7 @@ public class GLStateManager {
 
     public static int glGetError() {
         if (!RENDER_BACKEND.hasContext()) return 0;
+        if (initConfig.noErrorChecks()) return 0;
         return RENDER_BACKEND.getError();
     }
 
@@ -4467,13 +4448,7 @@ public class GLStateManager {
             }
         }
         suspendPixelUnpackBuffer();
-        if (shouldUseDSA(target)) {
-            // Use DSA to upload directly to the texture - keeps GL binding state unchanged
-            RenderSystem.textureSubImage2D(getBoundTextureForServerState(), target, level, xoffset, yoffset, width, height, format, type, pixels);
-        } else {
-            // Non-main thread or proxy texture - use direct GL call
-            RENDER_BACKEND.texSubImage2D(target, level, xoffset, yoffset, width, height, format, type, pixels);
-        }
+        RENDER_BACKEND.texSubImage2D(target, level, xoffset, yoffset, width, height, format, type, pixels);
         restorePixelUnpackBuffer();
     }
 
@@ -4486,13 +4461,7 @@ public class GLStateManager {
             }
         }
         suspendPixelUnpackBuffer();
-        if (shouldUseDSA(target)) {
-            // Use DSA to upload directly to the texture
-            RenderSystem.textureSubImage2D(getBoundTextureForServerState(), target, level, xoffset, yoffset, width, height, format, type, pixels);
-        } else {
-            // Non-main thread or proxy texture - use direct GL call
-            RENDER_BACKEND.texSubImage2D(target, level, xoffset, yoffset, width, height, format, type, pixels);
-        }
+        RENDER_BACKEND.texSubImage2D(target, level, xoffset, yoffset, width, height, format, type, pixels);
         restorePixelUnpackBuffer();
     }
 
@@ -5212,7 +5181,7 @@ public class GLStateManager {
     }
 
     public static boolean isFramebufferEnabled() {
-        return initConfig != null && initConfig.isFramebufferSupported() && initConfig.isFboEnabled();
+        return true;
     }
 
     private static final boolean FFP_WARN_ON_UNSUPPORTED = Boolean.parseBoolean(System.getProperty("angelica.ffp.warnOnUnsupported", "false"));

--- a/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/hooks/GLSMInitConfig.java
+++ b/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/hooks/GLSMInitConfig.java
@@ -8,20 +8,18 @@ import java.util.function.Consumer;
 public final class GLSMInitConfig {
     private final boolean lwjglDebug;
     private final StreamingUploader.UploadStrategy streamingUploadStrategy;
-    private final boolean framebufferSupported;
-    private final boolean fboEnabled;
     private final Consumer<DirectTessellator> directDrawer;
     private final Runnable streamingDrawerDestroy;
     private final int displayWidth;
     private final int displayHeight;
     private final Runnable postInitCallback;
     private final boolean enableDSA;
+    private final boolean noErrorChecks;
 
     private GLSMInitConfig(Builder builder) {
         this.lwjglDebug = builder.lwjglDebug;
         this.streamingUploadStrategy = builder.streamingUploadStrategy;
-        this.framebufferSupported = builder.framebufferSupported;
-        this.fboEnabled = builder.fboEnabled;
+        this.noErrorChecks = builder.noErrorChecks;
         this.directDrawer = builder.directDrawer;
         this.streamingDrawerDestroy = builder.streamingDrawerDestroy;
         this.displayWidth = builder.displayWidth;
@@ -36,26 +34,24 @@ public final class GLSMInitConfig {
 
     public boolean isLwjglDebug() { return lwjglDebug; }
     public StreamingUploader.UploadStrategy getStreamingUploadStrategy() { return streamingUploadStrategy; }
-    public boolean isFramebufferSupported() { return framebufferSupported; }
-    public boolean isFboEnabled() { return fboEnabled; }
     public Consumer<DirectTessellator> getDirectDrawer() { return directDrawer; }
     public Runnable getStreamingDrawerDestroy() { return streamingDrawerDestroy; }
     public int getDisplayWidth() { return displayWidth; }
     public int getDisplayHeight() { return displayHeight; }
     public Runnable getPostInitCallback() { return postInitCallback; }
     public boolean isDSAEnabled() { return enableDSA; }
+    public boolean noErrorChecks() { return noErrorChecks; }
 
     public static final class Builder {
         private boolean lwjglDebug = false;
         private StreamingUploader.UploadStrategy streamingUploadStrategy = StreamingUploader.UploadStrategy.BUFFER_DATA;
-        private boolean framebufferSupported = false;
-        private boolean fboEnabled = false;
         private Consumer<DirectTessellator> directDrawer = null;
         private Runnable streamingDrawerDestroy = null;
         private int displayWidth = 0;
         private int displayHeight = 0;
         private Runnable postInitCallback = null;
         private boolean enableDSA = false;
+        private boolean noErrorChecks;
 
         private Builder() {}
 
@@ -69,13 +65,8 @@ public final class GLSMInitConfig {
             return this;
         }
 
-        public Builder framebufferSupported(boolean framebufferSupported) {
-            this.framebufferSupported = framebufferSupported;
-            return this;
-        }
-
-        public Builder fboEnabled(boolean fboEnabled) {
-            this.fboEnabled = fboEnabled;
+        public Builder noErrorChecks(boolean noErrorChecks) {
+            this.noErrorChecks = noErrorChecks;
             return this;
         }
 

--- a/src/main/java/com/gtnewhorizons/angelica/config/AngelicaConfig.java
+++ b/src/main/java/com/gtnewhorizons/angelica/config/AngelicaConfig.java
@@ -302,4 +302,9 @@ public class AngelicaConfig {
     @Config.RequiresMcRestart
     public static boolean disableGLVersionPinning;
 
+    @Config.Comment("Disables GL Error checks. Always set to false in dev env or if LWJGL debug is on. Improves performance.")
+    @Config.DefaultBoolean(true)
+    @Config.RequiresMcRestart
+    public static boolean disableErrorChecks;
+
 }

--- a/src/main/java/com/gtnewhorizons/angelica/hudcaching/HUDCaching.java
+++ b/src/main/java/com/gtnewhorizons/angelica/hudcaching/HUDCaching.java
@@ -76,7 +76,7 @@ public class HUDCaching {
         GLStateManager.glActiveTexture(GL13.GL_TEXTURE0);
         GLStateManager.enableTexture();
 
-        if (!AngelicaConfig.hudCachingActive || !GLStateManager.isFramebufferEnabled()) {
+        if (!AngelicaConfig.hudCachingActive) {
             ingame.renderGameOverlay(partialTicks, hasScreen, mouseX, mouseY);
             return;
         }

--- a/src/mixin/java/com/gtnewhorizons/angelica/mixins/early/angelica/startup/MixinInitGLStateManager.java
+++ b/src/mixin/java/com/gtnewhorizons/angelica/mixins/early/angelica/startup/MixinInitGLStateManager.java
@@ -32,7 +32,7 @@ public class MixinInitGLStateManager {
             .displaySize(mc.displayWidth, mc.displayHeight)
             .lwjglDebug(AngelicaMod.lwjglDebug)
             .streamingUploadStrategy(ClientProxy.options().advanced.streamingUploadStrategy)
-            .noErrorChecks(AngelicaConfig.disableErrorChecks && !GTNHLibCore.isObf() && !AngelicaMod.lwjglDebug)
+            .noErrorChecks(AngelicaConfig.disableErrorChecks && GTNHLibCore.isObf() && !AngelicaMod.lwjglDebug)
             .enableDSA(AngelicaConfig.enableDSA)
             .directDrawer(TessellatorStreamingDrawer::drawDirect)
             .streamingDrawerDestroy(TessellatorStreamingDrawer::destroy)

--- a/src/mixin/java/com/gtnewhorizons/angelica/mixins/early/angelica/startup/MixinInitGLStateManager.java
+++ b/src/mixin/java/com/gtnewhorizons/angelica/mixins/early/angelica/startup/MixinInitGLStateManager.java
@@ -1,5 +1,6 @@
 package com.gtnewhorizons.angelica.mixins.early.angelica.startup;
 
+import com.gtnewhorizon.gtnhlib.core.GTNHLibCore;
 import com.gtnewhorizons.angelica.AngelicaMod;
 import com.gtnewhorizons.angelica.client.rendering.TextureTracker;
 import com.gtnewhorizons.angelica.config.AngelicaConfig;
@@ -25,13 +26,13 @@ public class MixinInitGLStateManager {
     @Inject(method = "initializeTextures", at = @At("RETURN"))
     private static void angelica$initializeGLStateManager(CallbackInfo ci) {
         final Minecraft mc = Minecraft.getMinecraft();
+        mc.gameSettings.fboEnable = true; // Angelica & many other GTNH features require FBO's
         GLStateManager.setDrawableGL(Display.getDrawable());
         GLStateManager.initialize(GLSMInitConfig.builder()
             .displaySize(mc.displayWidth, mc.displayHeight)
             .lwjglDebug(AngelicaMod.lwjglDebug)
             .streamingUploadStrategy(ClientProxy.options().advanced.streamingUploadStrategy)
-            .framebufferSupported(OpenGlHelper.framebufferSupported)
-            .fboEnabled(mc.gameSettings.fboEnable)
+            .noErrorChecks(AngelicaConfig.disableErrorChecks && !GTNHLibCore.isObf() && !AngelicaMod.lwjglDebug)
             .enableDSA(AngelicaConfig.enableDSA)
             .directDrawer(TessellatorStreamingDrawer::drawDirect)
             .streamingDrawerDestroy(TessellatorStreamingDrawer::destroy)


### PR DESCRIPTION
- Remove DSA from GLSM
- Always set fboEnable to true & remove the fbo checks (the game doesn't render with fboEnable=false and many gtnh features require it to be on anyway. There is no reason for it to be off)
- Add a config to not query any glGetError (currently it's enabled by default, I can change that if you'd rather have it disabled by default)