### PR TITLE
[Memory-opti:fix leak] fix world client leak in CTMUtils

### DIFF
--- a/src/main/java/com/prupe/mcpatcher/ctm/CTMUtils.java
+++ b/src/main/java/com/prupe/mcpatcher/ctm/CTMUtils.java
@@ -180,6 +180,7 @@ public class CTMUtils {
             local.renderBlockState.setBlock(block, blockAccess, x, y, z);
             local.renderBlockState.setFace(face);
             TileOverride lastOverride = local.ijkIterator.go(local.renderBlockState, icon);
+            local.renderBlockState.blockAccess = null;
             if (lastOverride != null) {
                 return skipDefaultRendering(block) ? RenderBlocksUtils.blankIcon : local.ijkIterator.getIcon();
             }


### PR DESCRIPTION
<img width="531" height="168" alt="image" src="https://github.com/user-attachments/assets/d9cf7854-2fcf-43e2-ad86-6795efeffd45" />
