### PR TITLE
Fix DH framebuffer UNSUPPORTED after resize

### DIFF
--- a/src/main/java/net/coderbot/iris/gl/framebuffer/GlFramebuffer.java
+++ b/src/main/java/net/coderbot/iris/gl/framebuffer/GlFramebuffer.java
@@ -48,6 +48,9 @@ public class GlFramebuffer extends GlResource {
 	public void addDepthAttachmentBypass(int texture) {
 		final int fb = getGlId();
 		RenderSystem.framebufferTexture2D(fb, GL30.GL_FRAMEBUFFER, GL30.GL_DEPTH_ATTACHMENT, GL11.GL_TEXTURE_2D, texture, 0);
+		// Detach any stale stencil left over from a prior combined-stencil attach; otherwise drivers
+		// reject the FBO as UNSUPPORTED when the depth attachment no longer matches the stencil.
+		RenderSystem.framebufferTexture2D(fb, GL30.GL_FRAMEBUFFER, GL30.GL_STENCIL_ATTACHMENT, GL11.GL_TEXTURE_2D, 0, 0);
 		this.hasDepthAttachment = true;
 	}
 


### PR DESCRIPTION
Fixes https://github.com/DarkShadow44/DistantHorizonsStandalone/issues/83

When you have DH rendering and shaders active resizing the window (e.g. by F11 or maximizing) breaks the LOD rendering, and DH spams a lot of rendering errors. Underlying issue is an invalid framebuffer. My solution is to make sure DH buffers don't have stencil attachments. In upstream the entire stencil path seems unused, so they never had that issue.