### PR TITLE
Fix profiler attribution of angelica_dynamic_lighting section

### DIFF
--- a/src/mixin/java/com/gtnewhorizons/angelica/mixins/early/angelica/dynamiclights/MixinEntityRenderer.java
+++ b/src/mixin/java/com/gtnewhorizons/angelica/mixins/early/angelica/dynamiclights/MixinEntityRenderer.java
@@ -17,7 +17,13 @@ public class MixinEntityRenderer {
 
     @Inject(method = "renderWorld", at = @At("HEAD"))
     private void updateDynamicLights(float p_78471_1_, long p_78471_2_, CallbackInfo ci){
-        mc.mcProfiler.endStartSection("angelica_dynamic_lighting");
+        // Use startSection / endSection so the section only encompasses our updateAll call —
+        // not all of vanilla renderWorld, which would happen with endStartSection (vanilla's
+        // own startSection calls inside renderWorld would nest under us). The previous
+        // structure made the F3 profiler attribute every child cost (entity shadows,
+        // particles, etc.) to angelica_dynamic_lighting.
+        mc.mcProfiler.startSection("angelica_dynamic_lighting");
         DynamicLights.get().updateAll(SodiumWorldRenderer.getInstance());
+        mc.mcProfiler.endSection();
     }
 }


### PR DESCRIPTION
## Summary

The `angelica_dynamic_lighting` mixin called `endStartSection` at the head of `renderWorld` but never ended its section, so vanilla's `startSection` calls inside `renderWorld` (entities, particles, etc.) nested *under* it. The F3 profiler then attributed every child cost to `angelica_dynamic_lighting`, making it look like it dominated frame time when the real work was elsewhere.

Switches to `startSection` / `endSection` so the section only encompasses the actual `updateAll` call.

## Test plan

- [x] F3 profiler shows `angelica_dynamic_lighting` as its own short section
- [x] Sibling sections (entities, particles) no longer accumulate under it