### PR TITLE
Enable shadow-pass entity culling (frustum + distance)

### DIFF
--- a/src/main/java/net/coderbot/iris/pipeline/ShadowRenderer.java
+++ b/src/main/java/net/coderbot/iris/pipeline/ShadowRenderer.java
@@ -358,13 +358,23 @@ public class ShadowRenderer {
 
 		List<Entity> renderedEntities = new ArrayList<>(32);
 
-		// TODO: I'm sure that this can be improved / optimized.
-        // TODO: Entity culling
+		// Without this cull, we iterate the ENTIRE loadedEntityList every frame and run each
+		// entity's full model build_geometry in the shadow pass — in GTNH worlds with hundreds
+		// of loaded entities (mobs in unloaded chunks, items, GT machines) that single loop was
+		// 33% of frame time. Distance + frustum cull cuts it to entities that can actually
+		// contribute to the on-screen shadow map.
+		final double shadowRangeBlocks = Math.max(IrisVideoSettings.shadowDistance, 4) * 16.0;
+		final double shadowRangeSq = shadowRangeBlocks * shadowRangeBlocks;
 		for (Entity entity : getLevel().loadedEntityList) {
-			if (false/*!dispatcher.shouldRender(entity, frustum, cameraX, cameraY, cameraZ) || entity.isSpectator()*/) {
+			final double dx = entity.posX - cameraX;
+			final double dy = entity.posY - cameraY;
+			final double dz = entity.posZ - cameraZ;
+			if (dx * dx + dy * dy + dz * dz > shadowRangeSq) {
 				continue;
 			}
-
+			if (entity.boundingBox != null && !frustum.isBoundingBoxInFrustum(entity.boundingBox)) {
+				continue;
+			}
 			renderedEntities.add(entity);
 		}
 

--- a/src/mixin/java/com/gtnewhorizons/angelica/mixins/early/angelica/dynamiclights/MixinEntityRenderer.java
+++ b/src/mixin/java/com/gtnewhorizons/angelica/mixins/early/angelica/dynamiclights/MixinEntityRenderer.java
@@ -17,7 +17,13 @@ public class MixinEntityRenderer {
 
     @Inject(method = "renderWorld", at = @At("HEAD"))
     private void updateDynamicLights(float p_78471_1_, long p_78471_2_, CallbackInfo ci){
-        mc.mcProfiler.endStartSection("angelica_dynamic_lighting");
+        // Use startSection / endSection so the section only encompasses our updateAll call —
+        // not all of vanilla renderWorld, which would happen with endStartSection (vanilla's
+        // own startSection calls inside renderWorld would nest under us). The previous
+        // structure made the F3 profiler attribute every child cost (entity shadows,
+        // particles, etc.) to angelica_dynamic_lighting.
+        mc.mcProfiler.startSection("angelica_dynamic_lighting");
         DynamicLights.get().updateAll(SodiumWorldRenderer.getInstance());
+        mc.mcProfiler.endSection();
     }
 }


### PR DESCRIPTION
## Summary

`ShadowRenderer.renderEntities` had its culling check hardcoded to `if (false)` with a TODO, so every frame iterated the entire `loadedEntityList` and ran each entity's full model `build_geometry` into the shadow map. In GTNH worlds with hundreds of loaded entities (mobs in unloaded chunks, items, GT machines) this single loop was ~33% of frame time before the fix.

Applies a distance cull at `shadowDistance * 16` blocks and a frustum cull against the shadow camera's frustum, matching what vanilla MC already does for the main entity pass.

> **Note:** stacked on top of #1743 (profiler attribution fix). The two commits touch disjoint files; whichever PR merges first, the other will rebase cleanly to drop the merged commit.

## Test plan

- [x] Shadows still render correctly for entities within `shadowDistance`
- [x] Entities outside the shadow frustum no longer build geometry each frame
- [x] Frame-time improvement on entity-heavy worlds (GTNH)