### PR TITLE
Adjust options screen width

### DIFF
--- a/src/main/java/me/flashyreese/mods/reeses_sodium_options/client/gui/ReeseSodiumVideoOptionsScreen.java
+++ b/src/main/java/me/flashyreese/mods/reeses_sodium_options/client/gui/ReeseSodiumVideoOptionsScreen.java
@@ -33,6 +33,9 @@ import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 public class ReeseSodiumVideoOptionsScreen extends SodiumOptionsGUI {
+    private static final float ASPECT_RATIO = 5f / 4f;
+    private static final int MINIMUM_WIDTH = 550;
+
     @Nullable
     private Element focused;
 
@@ -88,10 +91,10 @@ public class ReeseSodiumVideoOptionsScreen extends SodiumOptionsGUI {
     protected BasicFrame.Builder parentFrameBuilder() {
         final BasicFrame.Builder basicFrameBuilder;
 
-        // Calculates if resolution exceeds 16:9 ratio, force 16:9
+        // Clamp width on wide screens
         int newWidth = this.width;
-        if ((float) this.width / (float) this.height > 1.77777777778) {
-            newWidth = (int) (this.height * 1.77777777778);
+        if (this.width > MINIMUM_WIDTH && (float) this.width / (float) this.height > ASPECT_RATIO) {
+            newWidth = Math.max(MINIMUM_WIDTH, (int) (this.height * ASPECT_RATIO));
         }
 
         final Dim2i basicFrameDim = new Dim2i((this.width - newWidth) / 2, 0, newWidth, this.height);


### PR DESCRIPTION
Clamps option screen aspect ratio to 5/4 instead of 16/9 so it is not too wide. This makes it look [similar](https://git.taumc.org/embeddedt/celeritas/src/branch/stonecutter/common/src/main/java/org/embeddedt/embeddium/impl/gui/CeleritasVideoOptionsController.java#L63) to Celeritas.

Before:
<img width="1280" height="720" alt="angelica before" src="https://github.com/user-attachments/assets/636ec395-c1f2-4335-aa99-2c3f0dd387b4" />

After:
<img width="1280" height="720" alt="angelica after" src="https://github.com/user-attachments/assets/e4d1dca2-07e4-49b2-b440-44eab9decc2e" />