### PR TITLE
Clear block and item renderlist on resource reload

### DIFF
--- a/src/main/java/com/gtnewhorizons/angelica/proxy/ClientProxy.java
+++ b/src/main/java/com/gtnewhorizons/angelica/proxy/ClientProxy.java
@@ -29,6 +29,8 @@ import com.gtnewhorizons.angelica.rendering.celeritas.CeleritasSetup;
 import com.gtnewhorizons.angelica.rendering.celeritas.threading.ChunkTaskRegistry;
 import com.gtnewhorizons.angelica.rendering.celeritas.threading.DefaultChunkTaskProvider;
 import com.gtnewhorizons.angelica.rendering.celeritas.threading.ThreadedChunkTaskProvider;
+import com.gtnewhorizons.angelica.rendering.items.BlockRenderListManager;
+import com.gtnewhorizons.angelica.rendering.items.ItemRenderListManager;
 import com.gtnewhorizons.angelica.utils.AnimationMode;
 import com.gtnewhorizons.angelica.utils.ManagedEnum;
 import com.gtnewhorizons.angelica.zoom.Zoom;
@@ -144,6 +146,10 @@ public final class ClientProxy extends CommonProxy {
         }
         if (AngelicaConfig.enableDynamicLights) {
             EntityLightConfig.init(new java.io.File(mc.mcDataDir, "config"));
+        }
+        if(AngelicaConfig.optimizeInWorldItemRendering){
+            ItemRenderListManager.registerReloadListener();
+            BlockRenderListManager.registerReloadListener();
         }
 
         // Register debug commands in dev environment only

--- a/src/main/java/com/gtnewhorizons/angelica/rendering/items/BlockRenderListManager.java
+++ b/src/main/java/com/gtnewhorizons/angelica/rendering/items/BlockRenderListManager.java
@@ -4,6 +4,8 @@ import com.gtnewhorizons.angelica.glsm.DisplayListManager;
 import com.gtnewhorizons.angelica.glsm.GLStateManager;
 import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 import net.minecraft.block.Block;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.resources.IReloadableResourceManager;
 import org.lwjgl.opengl.GL11;
 
 public class BlockRenderListManager {
@@ -44,6 +46,17 @@ public class BlockRenderListManager {
         DisplayListManager.discardMatrixTransforms();
         GLStateManager.glEndList();
         displayListMap.put(new BlockMeta(block, meta), list);
+    }
+
+    public static void registerReloadListener(){
+        IReloadableResourceManager resourceManager = (IReloadableResourceManager) Minecraft.getMinecraft()
+            .getResourceManager();
+        resourceManager.registerReloadListener(_ -> {
+            for (int list : displayListMap.values()) {
+                GLStateManager.glDeleteLists(list, 1);
+            }
+            displayListMap.clear();
+        });
     }
 
 

--- a/src/main/java/com/gtnewhorizons/angelica/rendering/items/ItemRenderListManager.java
+++ b/src/main/java/com/gtnewhorizons/angelica/rendering/items/ItemRenderListManager.java
@@ -37,6 +37,7 @@ import it.unimi.dsi.fastutil.objects.Object2ObjectLinkedOpenHashMap;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.resources.IReloadableResourceManager;
 import org.lwjgl.opengl.GL11;
 
 public class ItemRenderListManager {
@@ -96,6 +97,17 @@ public class ItemRenderListManager {
 
     private static int getElapsedTicks() {
         return Minecraft.getMinecraft().thePlayer.ticksExisted;
+    }
+
+    public static void registerReloadListener(){
+        IReloadableResourceManager resourceManager = (IReloadableResourceManager) Minecraft.getMinecraft()
+            .getResourceManager();
+        resourceManager.registerReloadListener(_ -> {
+            for (CachedVBO value : vboCache.values()) {
+                value.delete();
+            }
+            vboCache.clear();
+        });
     }
 
     public static final class CachedVBO {


### PR DESCRIPTION
These caches become incorrect if the UVs of a block/item change due to a resourcepack changing the texture atlas. 

Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/24832