### PR TITLE
Fix issues that directly affects Euphoria Patches + Complementary

### DIFF
--- a/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/CompatUniformManager.java
+++ b/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/CompatUniformManager.java
@@ -132,6 +132,33 @@ public class CompatUniformManager {
 
     private CompatUniformManager() {}
 
+    /**
+     * Normalize each column of a 3x3 matrix in place. Used to strip the residual 1/scale that
+     * inverse-transpose introduces.
+     */
+    private static void normalizeColumnsInPlace(Matrix3f m) {
+        normalizeColumn(m, 0);
+        normalizeColumn(m, 1);
+        normalizeColumn(m, 2);
+    }
+
+    private static void normalizeColumn(Matrix3f m, int col) {
+        final float x, y, z;
+        switch (col) {
+            case 0 -> { x = m.m00(); y = m.m01(); z = m.m02(); }
+            case 1 -> { x = m.m10(); y = m.m11(); z = m.m12(); }
+            default -> { x = m.m20(); y = m.m21(); z = m.m22(); }
+        }
+        final float lenSq = x * x + y * y + z * z;
+        if (lenSq < 1e-20f) return;
+        final float inv = 1.0f / (float) Math.sqrt(lenSq);
+        switch (col) {
+            case 0 -> m.set(0, 0, x * inv).set(0, 1, y * inv).set(0, 2, z * inv);
+            case 1 -> m.set(1, 0, x * inv).set(1, 1, y * inv).set(1, 2, z * inv);
+            default -> m.set(2, 0, x * inv).set(2, 1, y * inv).set(2, 2, z * inv);
+        }
+    }
+
     public static void onLinkProgram(int program) {
         int[] locs = new int[LOC_COUNT];
         boolean hasAny = false;
@@ -222,13 +249,17 @@ public class CompatUniformManager {
             // Normal Matrix (inverse-transpose of upper-left 3x3 of ModelView)
             if (locs[LOC_NORMAL] != -1 || locs[LOC_IRIS_NORMAL] != -1) {
                 mv.normal(normalMatrix);
-                normalMatrix.get(mat3Buf);
                 if (locs[LOC_NORMAL] != -1) {
+                    normalMatrix.get(mat3Buf);
                     RENDER_BACKEND.uniformMatrix3(locs[LOC_NORMAL], false, mat3Buf);
                 }
+                // Column-normalized to unit magnitude
                 if (locs[LOC_IRIS_NORMAL] != -1) {
+                    normalizeColumnsInPlace(normalMatrix);
+                    normalMatrix.get(mat3Buf);
                     RENDER_BACKEND.uniformMatrix3(locs[LOC_IRIS_NORMAL], false, mat3Buf);
                 }
+
             }
         }
 

--- a/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/CompatUniformManager.java
+++ b/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/CompatUniformManager.java
@@ -11,6 +11,7 @@ import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import static com.gtnewhorizons.angelica.glsm.backend.BackendManager.RENDER_BACKEND;
 import org.joml.Matrix3f;
 import org.joml.Matrix4f;
+import org.joml.Vector3f;
 import org.lwjgl.BufferUtils;
 import org.lwjgl.opengl.GL11;
 
@@ -112,6 +113,7 @@ public class CompatUniformManager {
     private static final FloatBuffer clipPlaneBuf = BufferUtils.createFloatBuffer(32); // 8 planes * vec4
     private static final Matrix3f normalMatrix = new Matrix3f();
     private static final Matrix4f scratchMatrix = new Matrix4f();
+    private static final Vector3f scratchCol = new Vector3f();
 
     private static final float LIGHTMAP_SCALE = 1.0f / 256.0f;
     private static final FloatBuffer lightmapMatrixBuf;
@@ -137,26 +139,9 @@ public class CompatUniformManager {
      * inverse-transpose introduces.
      */
     private static void normalizeColumnsInPlace(Matrix3f m) {
-        normalizeColumn(m, 0);
-        normalizeColumn(m, 1);
-        normalizeColumn(m, 2);
-    }
-
-    private static void normalizeColumn(Matrix3f m, int col) {
-        final float x, y, z;
-        switch (col) {
-            case 0 -> { x = m.m00(); y = m.m01(); z = m.m02(); }
-            case 1 -> { x = m.m10(); y = m.m11(); z = m.m12(); }
-            default -> { x = m.m20(); y = m.m21(); z = m.m22(); }
-        }
-        final float lenSq = x * x + y * y + z * z;
-        if (lenSq < 1e-20f) return;
-        final float inv = 1.0f / (float) Math.sqrt(lenSq);
-        switch (col) {
-            case 0 -> m.set(0, 0, x * inv).set(0, 1, y * inv).set(0, 2, z * inv);
-            case 1 -> m.set(1, 0, x * inv).set(1, 1, y * inv).set(1, 2, z * inv);
-            default -> m.set(2, 0, x * inv).set(2, 1, y * inv).set(2, 2, z * inv);
-        }
+        m.setColumn(0, m.getColumn(0, scratchCol).normalize());
+        m.setColumn(1, m.getColumn(1, scratchCol).normalize());
+        m.setColumn(2, m.getColumn(2, scratchCol).normalize());
     }
 
     public static void onLinkProgram(int program) {

--- a/src/main/java/com/gtnewhorizons/angelica/rendering/celeritas/CeleritasWorldRenderer.java
+++ b/src/main/java/com/gtnewhorizons/angelica/rendering/celeritas/CeleritasWorldRenderer.java
@@ -118,7 +118,16 @@ public class CeleritasWorldRenderer extends SimpleWorldRenderer<WorldClient, Ang
     protected ChunkRenderMatrices createChunkRenderMatrices() {
         final boolean shadowPass = renderSectionManager.isInShadowPass();
         final Matrix4f projection = shadowPass ? ShadowRenderer.PROJECTION : RenderingState.INSTANCE.getProjectionMatrix();
-        final Matrix4f modelView = shadowPass ? ShadowRenderer.MODELVIEW : RenderingState.INSTANCE.getModelViewMatrix();
+        Matrix4f modelView = shadowPass ? ShadowRenderer.MODELVIEW : RenderingState.INSTANCE.getModelViewMatrix();
+        if (!shadowPass) {
+            // Minecraft's setupCameraTransform bakes translate(0, -eyeHeight, 0) into the modelview.
+            // Chunk rendering passes eye position to drawChunkLayer so vertices arrive at
+            // the shader as (vert_world - eye).
+            final Entity view = mc.renderViewEntity;
+            if (view != null) {
+                modelView = new Matrix4f(modelView).translate(0f, view.getEyeHeight(), 0f);
+            }
+        }
         return new ChunkRenderMatrices(projection, modelView);
     }
 

--- a/src/main/java/com/gtnewhorizons/angelica/rendering/celeritas/iris/IrisExtendedChunkVertexEncoder.java
+++ b/src/main/java/com/gtnewhorizons/angelica/rendering/celeritas/iris/IrisExtendedChunkVertexEncoder.java
@@ -26,6 +26,11 @@ public class IrisExtendedChunkVertexEncoder implements ContextAwareChunkVertexEn
     private static final int NORMAL_OFFSET = IrisExtendedChunkVertexType.VERTEX_FORMAT.getAttribute("iris_Normal").getPointer();
     private static final int MC_ENTITY_OFFSET = IrisExtendedChunkVertexType.VERTEX_FORMAT.getAttribute("mc_Entity").getPointer();
     private static final int MID_BLOCK_OFFSET = IrisExtendedChunkVertexType.VERTEX_FORMAT.getAttribute("at_midBlock").getPointer();
+    private static final int A_TEXCOORD_OFFSET = IrisExtendedChunkVertexType.VERTEX_FORMAT.getAttribute("a_TexCoord").getPointer();
+
+    // One unit of UV-space shift toward the quad centroid. Stops bilinear /
+    // mipmap sampling from bleeding pixels from neighboring atlas cells.
+    private static final float TEX_CENTROID_BIAS = 1.0f / 32768.0f;
 
     private final ChunkVertexEncoder baseEncoder = IrisExtendedChunkVertexType.BASE_TYPE.createEncoder();
     private final CeleritasQuadView quad = new CeleritasQuadView();
@@ -97,6 +102,14 @@ public class IrisExtendedChunkVertexEncoder implements ContextAwareChunkVertexEn
             memPutInt(ptr + MID_TEX_OFFSET - STRIDE, midUV);
             memPutInt(ptr + MID_TEX_OFFSET - STRIDE * 2, midUV);
             memPutInt(ptr + MID_TEX_OFFSET - STRIDE * 3, midUV);
+
+            for (int vIdx = 0; vIdx < 4; vIdx++) {
+                final long uvBase = ptr - (long) (3 - vIdx) * STRIDE + A_TEXCOORD_OFFSET;
+                final float vU = memGetFloat(uvBase);
+                final float vV = memGetFloat(uvBase + 4L);
+                memPutFloat(uvBase, vU + (vU < midU ? TEX_CENTROID_BIAS : -TEX_CENTROID_BIAS));
+                memPutFloat(uvBase + 4L, vV + (vV < midV ? TEX_CENTROID_BIAS : -TEX_CENTROID_BIAS));
+            }
 
             quad.setup(ptr, STRIDE);
             NormalHelper.computeFaceNormal(normal, quad);

--- a/src/main/java/net/coderbot/iris/gl/buffer/ShaderStorageBuffer.java
+++ b/src/main/java/net/coderbot/iris/gl/buffer/ShaderStorageBuffer.java
@@ -2,16 +2,17 @@ package net.coderbot.iris.gl.buffer;
 
 import com.gtnewhorizons.angelica.glsm.GLStateManager;
 import com.gtnewhorizons.angelica.glsm.RenderSystem;
+import lombok.Getter;
 import org.embeddedt.embeddium.impl.gl.debug.GLDebug;
 import org.lwjgl.opengl.GL11;
-import org.lwjgl.opengl.GL15;
 import org.lwjgl.opengl.GL30;
 import org.lwjgl.opengl.GL43;
 
 public class ShaderStorageBuffer {
 	protected final int index;
 	protected final ShaderStorageInfo info;
-	protected int id;
+	@Getter
+    protected int id;
 
 	public ShaderStorageBuffer(int index, ShaderStorageInfo info) {
 		this.id = RenderSystem.createBuffers();
@@ -45,16 +46,13 @@ public class ShaderStorageBuffer {
 		GLStateManager.glBindBuffer(GL43.GL_SHADER_STORAGE_BUFFER, newId);
 
 		// Calculation time
-		int newWidth = (int) (width * info.scaleX());
-		int newHeight = (int) (height * info.scaleY());
-		int finalSize = (newHeight * newWidth) * info.size();
+		long newWidth = (long) (width * info.scaleX());
+		long newHeight = (long) (height * info.scaleY());
+		long finalSize = (newHeight * newWidth) * info.size();
 		RenderSystem.bufferStorage(GL43.GL_SHADER_STORAGE_BUFFER, finalSize, 0);
 		RenderSystem.clearBufferSubData(GL43.GL_SHADER_STORAGE_BUFFER, GL30.GL_R8, 0, finalSize, GL11.GL_RED, GL11.GL_BYTE, new int[]{0});
 		RenderSystem.bindBufferBase(GL43.GL_SHADER_STORAGE_BUFFER, index, newId);
 		id = newId;
 	}
 
-	public int getId() {
-		return id;
-	}
 }

--- a/src/main/java/net/coderbot/iris/gl/buffer/ShaderStorageBuffer.java
+++ b/src/main/java/net/coderbot/iris/gl/buffer/ShaderStorageBuffer.java
@@ -11,8 +11,7 @@ import org.lwjgl.opengl.GL43;
 public class ShaderStorageBuffer {
 	protected final int index;
 	protected final ShaderStorageInfo info;
-	@Getter
-    protected int id;
+	@Getter protected int id;
 
 	public ShaderStorageBuffer(int index, ShaderStorageInfo info) {
 		this.id = RenderSystem.createBuffers();

--- a/src/main/java/net/coderbot/iris/gl/buffer/ShaderStorageInfo.java
+++ b/src/main/java/net/coderbot/iris/gl/buffer/ShaderStorageInfo.java
@@ -1,4 +1,4 @@
 package net.coderbot.iris.gl.buffer;
 
-public record ShaderStorageInfo(int size, boolean relative, float scaleX, float scaleY) {
+public record ShaderStorageInfo(long size, boolean relative, float scaleX, float scaleY) {
 }

--- a/src/main/java/net/coderbot/iris/gl/program/Program.java
+++ b/src/main/java/net/coderbot/iris/gl/program/Program.java
@@ -4,15 +4,18 @@ import lombok.Getter;
 import net.coderbot.iris.gl.GlResource;
 import net.coderbot.iris.gl.blending.DepthColorStorage;
 import com.gtnewhorizons.angelica.glsm.GLStateManager;
+import com.gtnewhorizons.angelica.glsm.RenderSystem;
+import org.lwjgl.opengl.GL42;
+import org.lwjgl.opengl.GL43;
 
 public final class Program extends GlResource {
-	
+
 	@Getter
 	private final ProgramUniforms uniforms;
-	
+
 	@Getter
 	private final ProgramSamplers samplers;
-	
+
 	@Getter
 	private final ProgramImages images;
 
@@ -25,15 +28,16 @@ public final class Program extends GlResource {
 
 		DepthColorStorage.registerOwnedProgram(program);
 	}
-	
+
 	public void use() {
+		RenderSystem.memoryBarrier(GL42.GL_SHADER_IMAGE_ACCESS_BARRIER_BIT | GL42.GL_TEXTURE_FETCH_BARRIER_BIT | GL43.GL_SHADER_STORAGE_BARRIER_BIT);
 		GLStateManager.glUseProgram(getGlId());
-		
+
 		uniforms.update();
 		samplers.update();
 		images.update();
 	}
-	
+
 	public static void unbind() {
 		ProgramUniforms.clearActiveUniforms();
 		ProgramSamplers.clearActiveSamplers();
@@ -45,7 +49,7 @@ public final class Program extends GlResource {
 		DepthColorStorage.unregisterOwnedProgram(getGlId());
 		GLStateManager.glDeleteProgram(getGlId());
 	}
-	
+
 	public int getProgramId() {
 		return getGlId();
 	}

--- a/src/main/java/net/coderbot/iris/gl/shader/StandardMacros.java
+++ b/src/main/java/net/coderbot/iris/gl/shader/StandardMacros.java
@@ -81,6 +81,9 @@ public class StandardMacros {
 		define(standardDefines, "IS_ANGELICA");
 		if (AngelicaConfig.defineIsIris) {
 			define(standardDefines, "IS_IRIS");
+			define(standardDefines, "IRIS_VERSION", "10803");
+			define(standardDefines, "IRIS_HAS_TRANSLUCENCY_SORTING");
+			define(standardDefines, "MAX_COLOR_BUFFERS", String.valueOf(net.coderbot.iris.shaderpack.IrisLimits.MAX_COLOR_BUFFERS));
 		}
 
 		if (DHCompat.hasRenderingEnabled()) {

--- a/src/main/java/net/coderbot/iris/gl/shader/StandardMacros.java
+++ b/src/main/java/net/coderbot/iris/gl/shader/StandardMacros.java
@@ -8,6 +8,7 @@ import net.coderbot.iris.compat.dh.DHCompat;
 import net.coderbot.iris.parsing.BiomeCategories;
 import net.coderbot.iris.pipeline.HandRenderer;
 import net.coderbot.iris.pipeline.WorldRenderingPhase;
+import net.coderbot.iris.shaderpack.IrisLimits;
 import net.coderbot.iris.shaderpack.StringPair;
 import net.coderbot.iris.texture.format.TextureFormat;
 import net.coderbot.iris.texture.format.TextureFormatLoader;
@@ -83,7 +84,7 @@ public class StandardMacros {
 			define(standardDefines, "IS_IRIS");
 			define(standardDefines, "IRIS_VERSION", "10803");
 			define(standardDefines, "IRIS_HAS_TRANSLUCENCY_SORTING");
-			define(standardDefines, "MAX_COLOR_BUFFERS", String.valueOf(net.coderbot.iris.shaderpack.IrisLimits.MAX_COLOR_BUFFERS));
+			define(standardDefines, "MAX_COLOR_BUFFERS", String.valueOf(IrisLimits.MAX_COLOR_BUFFERS));
 		}
 
 		if (DHCompat.hasRenderingEnabled()) {

--- a/src/main/java/net/coderbot/iris/pipeline/DeferredWorldRenderingPipeline.java
+++ b/src/main/java/net/coderbot/iris/pipeline/DeferredWorldRenderingPipeline.java
@@ -90,6 +90,7 @@ import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.GL13;
 import org.lwjgl.opengl.GL30;
 import org.lwjgl.opengl.GL42;
+import org.lwjgl.opengl.GL43;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -517,7 +518,7 @@ public class DeferredWorldRenderingPipeline implements WorldRenderingPipeline, R
 		}
 		if (hasSetup) {
 			ComputeProgram.unbind();
-			RenderSystem.memoryBarrier(GL42.GL_SHADER_IMAGE_ACCESS_BARRIER_BIT | GL42.GL_TEXTURE_FETCH_BARRIER_BIT);
+			RenderSystem.memoryBarrier(GL42.GL_SHADER_IMAGE_ACCESS_BARRIER_BIT | GL42.GL_TEXTURE_FETCH_BARRIER_BIT | GL43.GL_SHADER_STORAGE_BARRIER_BIT);
 		}
 
 		// Terrain pipeline sampler/image factory setup follows.
@@ -771,11 +772,11 @@ public class DeferredWorldRenderingPipeline implements WorldRenderingPipeline, R
 	public boolean shouldOverrideShaders() {
 		return isRenderingWorld && !isRenderingFullScreenPass && !isPostChain && isMainBound;
 	}
-	
+
 	public Pass getActivePassProgram() {
 		return current;
 	}
-	
+
 	public int getActivePassProgramId() {
 		if (current == null) return -1;
 		final Program p = current.getProgram();
@@ -793,10 +794,10 @@ public class DeferredWorldRenderingPipeline implements WorldRenderingPipeline, R
 		if (!isRenderingWorld || isRenderingFullScreenPass || isPostChain || !isMainBound) {
 			return;
 		}
-		
+
 		final RenderCondition condition = getCondition(getPhase());
 		final Pass matched = table.match(condition, inputs);
-		
+
 		beginPass(matched);
 	}
 
@@ -1332,7 +1333,7 @@ public class DeferredWorldRenderingPipeline implements WorldRenderingPipeline, R
 			}
 			if (ranSetup) {
 				ComputeProgram.unbind();
-				RenderSystem.memoryBarrier(GL42.GL_SHADER_IMAGE_ACCESS_BARRIER_BIT | GL42.GL_TEXTURE_FETCH_BARRIER_BIT);
+				RenderSystem.memoryBarrier(GL42.GL_SHADER_IMAGE_ACCESS_BARRIER_BIT | GL42.GL_TEXTURE_FETCH_BARRIER_BIT | GL43.GL_SHADER_STORAGE_BARRIER_BIT);
 			}
 		}
 

--- a/src/main/java/net/coderbot/iris/pipeline/transform/CeleritasTransformer.java
+++ b/src/main/java/net/coderbot/iris/pipeline/transform/CeleritasTransformer.java
@@ -60,6 +60,7 @@ class CeleritasTransformer {
     }
 
     private static void transformShared(Transformer transformer, Parameters parameters) {
+        transformer.replaceExpression("gl_TextureMatrix[0]", "mat4(1.0)");
         CoreTransformHelper.injectMatrixUniforms(transformer);
     }
 }

--- a/src/main/java/net/coderbot/iris/postprocess/CompositeRenderer.java
+++ b/src/main/java/net/coderbot/iris/postprocess/CompositeRenderer.java
@@ -44,6 +44,7 @@ import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.GL13;
 import org.lwjgl.opengl.GL30;
 import org.lwjgl.opengl.GL42;
+import org.lwjgl.opengl.GL43;
 
 import java.util.Map;
 import java.util.Objects;
@@ -263,7 +264,7 @@ public class CompositeRenderer {
 			}
 
 			if (ranCompute) {
-				RenderSystem.memoryBarrier(GL42.GL_SHADER_IMAGE_ACCESS_BARRIER_BIT | GL42.GL_TEXTURE_FETCH_BARRIER_BIT);
+				RenderSystem.memoryBarrier(GL42.GL_SHADER_IMAGE_ACCESS_BARRIER_BIT | GL42.GL_TEXTURE_FETCH_BARRIER_BIT | GL43.GL_SHADER_STORAGE_BARRIER_BIT);
 			}
 
 			Program.unbind();

--- a/src/main/java/net/coderbot/iris/postprocess/FinalPassRenderer.java
+++ b/src/main/java/net/coderbot/iris/postprocess/FinalPassRenderer.java
@@ -42,6 +42,7 @@ import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.GL13;
 import org.lwjgl.opengl.GL30;
 import org.lwjgl.opengl.GL42;
+import org.lwjgl.opengl.GL43;
 
 import java.util.Map;
 import java.util.Objects;
@@ -229,7 +230,7 @@ public class FinalPassRenderer {
 				}
 			}
 
-			RenderSystem.memoryBarrier(GL42.GL_SHADER_IMAGE_ACCESS_BARRIER_BIT | GL42.GL_TEXTURE_FETCH_BARRIER_BIT);
+			RenderSystem.memoryBarrier(GL42.GL_SHADER_IMAGE_ACCESS_BARRIER_BIT | GL42.GL_TEXTURE_FETCH_BARRIER_BIT | GL43.GL_SHADER_STORAGE_BARRIER_BIT);
 
 			if (!finalPass.mipmappedBuffers.isEmpty()) {
 				GLStateManager.glActiveTexture(GL13.GL_TEXTURE0);

--- a/src/main/java/net/coderbot/iris/shaderpack/ShaderProperties.java
+++ b/src/main/java/net/coderbot/iris/shaderpack/ShaderProperties.java
@@ -771,7 +771,7 @@ public class ShaderProperties {
 				return;
 			}
 
-			final int size = Integer.parseInt(parts[0]);
+			final long size = Long.parseLong(parts[0]);
 
 			// Size < 1 means the shader dev intended to disable the buffer
 			if (size < 1) {

--- a/src/main/java/net/coderbot/iris/shadows/ShadowCompositeRenderer.java
+++ b/src/main/java/net/coderbot/iris/shadows/ShadowCompositeRenderer.java
@@ -43,6 +43,7 @@ import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.GL13;
 import org.lwjgl.opengl.GL30;
 import org.lwjgl.opengl.GL42;
+import org.lwjgl.opengl.GL43;
 
 import java.util.Map;
 import java.util.Objects;
@@ -208,7 +209,7 @@ public class ShadowCompositeRenderer {
 
             if (ranCompute) {
                 // Memory barrier for shader image access and texture fetch
-                RenderSystem.memoryBarrier(GL42.GL_SHADER_IMAGE_ACCESS_BARRIER_BIT | GL42.GL_TEXTURE_FETCH_BARRIER_BIT);
+                RenderSystem.memoryBarrier(GL42.GL_SHADER_IMAGE_ACCESS_BARRIER_BIT | GL42.GL_TEXTURE_FETCH_BARRIER_BIT | GL43.GL_SHADER_STORAGE_BARRIER_BIT);
             }
 
             Program.unbind();

--- a/src/main/java/net/coderbot/iris/uniforms/CameraUniforms.java
+++ b/src/main/java/net/coderbot/iris/uniforms/CameraUniforms.java
@@ -89,7 +89,7 @@ public class CameraUniforms {
 
 		private void update() {
 			previousCameraPosition.set(currentCameraPosition);
-			previousCameraPositionUnshifted = currentCameraPositionUnshifted;
+			previousCameraPositionUnshifted.set(currentCameraPositionUnshifted);
 			currentCameraPosition.set(getUnshiftedCameraPosition()).add(shift);
 			currentCameraPositionUnshifted.set(getUnshiftedCameraPosition());
 

--- a/src/main/java/net/coderbot/iris/uniforms/MatrixUniforms.java
+++ b/src/main/java/net/coderbot/iris/uniforms/MatrixUniforms.java
@@ -6,6 +6,8 @@ import net.coderbot.iris.gl.uniform.UniformHolder;
 import net.coderbot.iris.pipeline.ShadowRenderer;
 import net.coderbot.iris.shaderpack.PackDirectives;
 import net.coderbot.iris.shadow.ShadowMatrices;
+import net.minecraft.client.Minecraft;
+import net.minecraft.entity.Entity;
 import org.joml.Matrix4f;
 import org.joml.Matrix4fc;
 
@@ -17,8 +19,18 @@ public final class MatrixUniforms {
 	private MatrixUniforms() {
 	}
 
+	private static final Matrix4f GBUFFER_MODELVIEW_SCRATCH = new Matrix4f();
+	private static Matrix4fc getGbufferModelView() {
+		final Matrix4fc raw = RenderingState.INSTANCE.getModelViewMatrix();
+		final Entity view = Minecraft.getMinecraft().renderViewEntity;
+		if (view == null) {
+			return raw;
+		}
+		return GBUFFER_MODELVIEW_SCRATCH.set(raw).translate(0f, view.getEyeHeight(), 0f);
+	}
+
 	public static void addMatrixUniforms(UniformHolder uniforms, PackDirectives directives) {
-		addMatrix(uniforms, "ModelView", RenderingState.INSTANCE::getModelViewMatrix);
+		addMatrix(uniforms, "ModelView", MatrixUniforms::getGbufferModelView);
 		// TODO: In some cases, gbufferProjectionInverse takes on a value much different than OptiFine...
 		// We need to audit Mojang's linear algebra.
 		addMatrix(uniforms, "Projection", RenderingState.INSTANCE::getProjectionMatrix);

--- a/src/mixin/java/com/gtnewhorizons/angelica/mixins/early/celeritas/terrain/MixinRenderGlobal.java
+++ b/src/mixin/java/com/gtnewhorizons/angelica/mixins/early/celeritas/terrain/MixinRenderGlobal.java
@@ -148,7 +148,11 @@ public class MixinRenderGlobal implements IRenderGlobalExt {
         this.mc.entityRenderer.enableLightmap(partialTicks);
 
         final double camX = lerp(entity.lastTickPosX, entity.posX, partialTicks);
-        final double camY = lerp(entity.lastTickPosY, entity.posY, partialTicks);
+        // Minecraft's setupCameraTransform bakes -eyeHeight into the modelview, which would normally
+        // require feet here; CeleritasWorldRenderer.createChunkRenderMatrices compensates this by
+        // post-multiplying the chunk-shader modelview with translate(0, +eyeHeight, 0).
+        // Otherwise, we get issues with Iris shaders getting normals at a shifted y-position.
+        final double camY = lerp(entity.lastTickPosY, entity.posY, partialTicks) + entity.getEyeHeight();
         final double camZ = lerp(entity.lastTickPosZ, entity.posZ, partialTicks);
 
         try {


### PR DESCRIPTION
Fixes the issue of Nether Portal outline being shifted down and normals in general being read wrong. Which in this case, made the Ender Crystal Vortex from within the end think it was constantly being destroyed and playing the explosion animation over and over again. There's also a few Iris parity things in here like the memory protection and switching from int to longs.