### PR TITLE
Remove registerIcons call in MCPF MixinTextureMap

### DIFF
--- a/src/mixin/java/com/gtnewhorizons/angelica/mixins/early/mcpatcherforge/ctm_cc/MixinTextureMap.java
+++ b/src/mixin/java/com/gtnewhorizons/angelica/mixins/early/mcpatcherforge/ctm_cc/MixinTextureMap.java
@@ -29,14 +29,10 @@ public abstract class MixinTextureMap extends AbstractTexture {
     @Final
     private String basePath;
 
-    @Shadow
-    protected abstract void registerIcons();
-
     @Inject(
         method = "loadTextureAtlas(Lnet/minecraft/client/resources/IResourceManager;)V",
         at = @At(value = "INVOKE", target = "Ljava/util/List;clear()V", remap = false, shift = At.Shift.AFTER))
     private void modifyLoadTextureAtlas(IResourceManager manager, CallbackInfo ci) {
-        this.registerIcons();
         TileLoader.registerIcons((TextureMap) (Object) this, this.basePath, this.mapRegisteredSprites);
     }
 


### PR DESCRIPTION
Not sure what else it does other than make the load time longer. Saves 5-7 seconds on load on my machine and following the code, this call seems to be unnecessary. 

I checked chisel CTM and it was still working but i'm not sure if that uses this code or not.