### PR TITLE
More class loading order fun with java 8...

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -76,7 +76,7 @@ dependencies {
 
     // Iris Shaders
     compileOnly('org.jetbrains:annotations:26.0.2')
-    api("com.github.GTNewHorizons:GTNHLib:0.10.0:dev")
+    api("com.github.GTNewHorizons:GTNHLib:0.11.4:dev")
 
     shadowImplementation(project(":glsm")) { transitive = false }
     shadowImplementation(project(":lwjgl3-backend")) { transitive = false }

--- a/src/main/java/com/gtnewhorizons/angelica/loading/AngelicaClientTweaker.java
+++ b/src/main/java/com/gtnewhorizons/angelica/loading/AngelicaClientTweaker.java
@@ -53,8 +53,15 @@ public final class AngelicaClientTweaker implements IFMLLoadingPlugin, IEarlyMix
         Launch.classLoader.addTransformerExclusion("com.gtnewhorizons.angelica.loading");
         Launch.classLoader.addTransformerExclusion("com.gtnewhorizons.angelica.glsm.GLStateManager");
 
-        if (Launch.blackboard.getOrDefault("angelica.rfbPluginLoaded", Boolean.FALSE) == Boolean.TRUE) {
+        final boolean rfbLoaded = Launch.blackboard.getOrDefault("angelica.rfbPluginLoaded", Boolean.FALSE) == Boolean.TRUE;
+        if (rfbLoaded) {
             addLwjgl3ifyExclusions();
+        } else {
+            // Fucking java 8 and non RFB
+            try {
+                Class.forName("com.gtnewhorizon.gtnhlib.core.GTNHLibCore", true, Launch.classLoader);
+            } catch (ClassNotFoundException ignored) {
+            }
         }
 
         try {
@@ -84,7 +91,6 @@ public final class AngelicaClientTweaker implements IFMLLoadingPlugin, IEarlyMix
         // packages to avoid interfering with mixin delegation on game classes. AngelicaLateTweaker removes this registration once
         // mixins are setup.
         if (FMLLaunchHandler.side().isClient()) {
-            final boolean rfbLoaded = Launch.blackboard.getOrDefault("angelica.rfbPluginLoaded", Boolean.FALSE) == Boolean.TRUE;
             if (!rfbLoaded) {
                 final String transformer = "com.gtnewhorizons.angelica.loading.fml.transformers.EarlyRedirectorTransformer";
                 FMLRelaunchLog.finer("Registering transformer %s", transformer);


### PR DESCRIPTION
Nhlib used to shade fastutil/etc... but now Angelica loads too early now without(A vs N) so we forcibly load GTNHLibCore to bootstrap the deploader w/o RFB