### PR TITLE
Improve perf of EmissiveTextureAutoloader.resourceExists

### DIFF
--- a/src/main/java/com/gtnewhorizons/angelica/render/EmissiveTextureAutoloader.java
+++ b/src/main/java/com/gtnewhorizons/angelica/render/EmissiveTextureAutoloader.java
@@ -5,6 +5,10 @@ import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.texture.TextureMap;
+import net.minecraft.client.resources.FallbackResourceManager;
+import net.minecraft.client.resources.IResourceManager;
+import net.minecraft.client.resources.IResourcePack;
+import net.minecraft.client.resources.SimpleReloadableResourceManager;
 import net.minecraft.util.IIcon;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.client.event.TextureStitchEvent;
@@ -50,8 +54,23 @@ public class EmissiveTextureAutoloader {
             loc.getResourceDomain(),
             "textures/blocks/" + loc.getResourcePath() + ".png"
         );
+
+        final IResourceManager resMan = Minecraft.getMinecraft().getResourceManager();
+        if (resMan instanceof SimpleReloadableResourceManager simple) {
+            FallbackResourceManager fallback = simple.domainResourceManagers.get(full.getResourceDomain());
+            if (fallback != null) {
+                for (IResourcePack rp : fallback.resourcePacks) {
+                    if (rp != null && rp.resourceExists(full)) {
+                        return true;
+                    }
+                }
+                return false;
+            }
+        }
+
+        // Fallback
         try {
-            Minecraft.getMinecraft().getResourceManager().getResource(full);
+            resMan.getResource(full);
             return true;
         } catch (Exception ignored) {
             return false;


### PR DESCRIPTION
Checking directly with `ITexturePack.resourceExists` is a lot faster. Falls back to the original implementation in case a mod changes the behavior/fields of `SimpleReloadableResourceManager` and `FallbackResourceManager`

Saves ~400ms for GTNH launch