### PR TITLE
Add double_plant handling to match modern

### DIFF
--- a/src/main/java/com/gtnewhorizons/angelica/rendering/celeritas/AngelicaChunkBuilderMeshingTask.java
+++ b/src/main/java/com/gtnewhorizons/angelica/rendering/celeritas/AngelicaChunkBuilderMeshingTask.java
@@ -15,6 +15,7 @@ import net.coderbot.iris.block_rendering.BlockRenderingSettings;
 import net.coderbot.iris.block_rendering.NbtConditionalIdMap;
 import net.coderbot.iris.vertices.ExtendedDataHelper;
 import net.minecraft.block.Block;
+import net.minecraft.block.BlockDoublePlant;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.RenderBlocks;
@@ -275,6 +276,8 @@ public abstract class AngelicaChunkBuilderMeshingTask extends ChunkBuilderTask<C
                     && BlockRenderingSettings.INSTANCE.getSnowyBlocks().contains(block)
                     && RenderBlocksUtils.isSnowCovered(renderBlocks.blockAccess, x, y, z)) {
                     effectiveMeta |= BlockMaterialMapping.SNOWY_META_BIT;
+                } else if (block instanceof BlockDoublePlant doublePlant && BlockDoublePlant.func_149887_c(metadata)) {
+                    effectiveMeta = 0x8 | (doublePlant.func_149885_e(renderBlocks.blockAccess, x, y, z) & 7);
                 }
                 contextEncoder.prepareToRenderBlock(blockRenderContext, block, effectiveMeta,
                     ExtendedDataHelper.BLOCK_RENDER_TYPE, lightValue);

--- a/src/main/java/net/coderbot/iris/block_rendering/BlockMaterialMapping.java
+++ b/src/main/java/net/coderbot/iris/block_rendering/BlockMaterialMapping.java
@@ -14,6 +14,7 @@ import net.coderbot.iris.shaderpack.materialmap.BlockRenderType;
 import net.coderbot.iris.shaderpack.materialmap.FlatteningMap;
 import net.coderbot.iris.shaderpack.materialmap.NamespacedId;
 import net.minecraft.block.Block;
+import net.minecraft.block.BlockDoublePlant;
 import net.minecraft.init.Blocks;
 import net.minecraft.util.ResourceLocation;
 
@@ -25,8 +26,10 @@ public class BlockMaterialMapping {
 
 	public record BlockIdMaps(Reference2ObjectMap<Block, Int2IntMap> blockMetaMap, NbtConditionalIdMap<Block> tileEntityMap) {}
 
-	/** Meta-key bit OR'd in at runtime when a snowy-tagged block has snow above it. */
+	// Meta-key bits OR'd in at runtime
 	public static final int SNOWY_META_BIT = 0x10;
+
+	public static final int DOUBLE_PLANT_TOP_BIT = 0x8;
 
 	/**
 	 * Creates the standard block meta ID map, the TileEntity NBT-conditional map, and registers
@@ -129,6 +132,7 @@ public class BlockMaterialMapping {
 		final Map<String, String> stateProps = entry.stateProperties();
 		final String snowy = stateProps.get("snowy");
 		final int snowyBit = "true".equals(snowy) ? SNOWY_META_BIT : 0;
+		final boolean wantsDoublePlantTop = "upper".equals(stateProps.get("half"));
 
 		// Vanilla modern names go through FlatteningMap; legacy-section packs and modded blocks
 		// resolve directly from the registry.
@@ -145,12 +149,16 @@ public class BlockMaterialMapping {
 			}
 			final Block block = resolveBlockOrNull(target.id());
 			if (block == null) continue;
-			applyMetas(block, target.metas(), idMap, intId, snowyBit);
+			int extraBits = snowyBit;
+			if (wantsDoublePlantTop && block instanceof BlockDoublePlant) {
+				extraBits |= DOUBLE_PLANT_TOP_BIT;
+			}
+			applyMetas(block, target.metas(), idMap, intId, extraBits);
 			if (snowy != null) snowyBlocks.add(block);
 		}
 	}
 
-	private static void applyMetas(Block block, Set<Integer> metas, Reference2ObjectMap<Block, Int2IntMap> idMap, int intId, int snowyBit) {
+	private static void applyMetas(Block block, Set<Integer> metas, Reference2ObjectMap<Block, Int2IntMap> idMap, int intId, int extraBits) {
 		Int2IntMap metaMap = idMap.get(block);
 		if (metaMap == null) {
 			metaMap = new Int2IntOpenHashMap();
@@ -159,9 +167,9 @@ public class BlockMaterialMapping {
 		}
 
 		if (metas.isEmpty()) {
-			for (int meta = 0; meta < 16; meta++) metaMap.putIfAbsent(meta | snowyBit, intId);
+			for (int meta = 0; meta < 16; meta++) metaMap.putIfAbsent(meta | extraBits, intId);
 		} else {
-			for (int meta : metas) metaMap.putIfAbsent(meta | snowyBit, intId);
+			for (int meta : metas) metaMap.putIfAbsent(meta | extraBits, intId);
 		}
 	}
 

--- a/src/main/java/net/coderbot/iris/shaderpack/materialmap/FlatteningMap.java
+++ b/src/main/java/net/coderbot/iris/shaderpack/materialmap/FlatteningMap.java
@@ -373,13 +373,14 @@ public class FlatteningMap {
 		colorVariants("carpet", "carpet");
 
 		// === Double plant (ID 175) ===
-		// Bottom half has type in meta 0-5; top half is always meta 8 (shared by all types).
-		meta("sunflower",   "double_plant", 0);
-		meta("lilac",       "double_plant", 1);
-		meta("tall_grass",  "double_plant", 2);
-		meta("large_fern",  "double_plant", 3);
-		meta("rose_bush",   "double_plant", 4);
-		meta("peony",       "double_plant", 5);
+		// Bottom half carries the variant in meta 0-5; the top half's real meta is 8-11.
+        // We use a synthetic key to tie the variant the bottom is with the top half.
+		doublePlant("sunflower",  0);
+		doublePlant("lilac",      1);
+		doublePlant("tall_grass", 2);
+		doublePlant("large_fern", 3);
+		doublePlant("rose_bush",  4);
+		doublePlant("peony",      5);
 
 		// === Water / Lava (IDs 8-11) ===
 		// In 1.13+, water/lava are single blocks. In 1.7.10, flowing variants are separate.
@@ -861,21 +862,6 @@ public class FlatteningMap {
 			state(WOOD_TYPES[i] + "_sapling", "stage", "0", entryMetas("sapling", i));
 			state(WOOD_TYPES[i] + "_sapling", "stage", "1", entryMetas("sapling", i + 8));
 		}
-
-		// === Double plant half (ID 175) ===
-		// 1.7.10: bottom half has type in meta 0-5; top half is always meta 8
-		state("sunflower",  "half", "lower", entryMetas("double_plant", 0));
-		state("sunflower",  "half", "upper", entryMetas("double_plant", 8));
-		state("lilac",      "half", "lower", entryMetas("double_plant", 1));
-		state("lilac",      "half", "upper", entryMetas("double_plant", 8));
-		state("tall_grass", "half", "lower", entryMetas("double_plant", 2));
-		state("tall_grass", "half", "upper", entryMetas("double_plant", 8));
-		state("large_fern", "half", "lower", entryMetas("double_plant", 3));
-		state("large_fern", "half", "upper", entryMetas("double_plant", 8));
-		state("rose_bush",  "half", "lower", entryMetas("double_plant", 4));
-		state("rose_bush",  "half", "upper", entryMetas("double_plant", 8));
-		state("peony",      "half", "lower", entryMetas("double_plant", 5));
-		state("peony",      "half", "upper", entryMetas("double_plant", 8));
 	}
 
 	/**
@@ -1051,6 +1037,17 @@ public class FlatteningMap {
 		for (int i = 0; i < COLORS.length; i++) {
 			meta(COLORS[i] + "_" + modernSuffix, legacyName, i);
 		}
+	}
+
+	/**
+	 * Double plant: the bottom half stores the variant in meta 0-5; the top half stores facing
+     * direction, so Angelica's chunk mesher rebuilds a synthetic key 0x8|variant for top halves.
+	 */
+	private static void doublePlant(String modern, int variant) {
+		final int upper = 0x8 | variant;
+		metas(modern, "double_plant", variant, upper);
+		state(modern, "half", "lower", entryMetas("double_plant", variant));
+		state(modern, "half", "upper", entryMetas("double_plant", upper));
 	}
 
 	// ==========================================


### PR DESCRIPTION
Would have impossible to do before with the current iteration of Angelica.
<img width="2560" height="1368" alt="2026-06-05_02 25 18" src="https://github.com/user-attachments/assets/0210090a-ad32-4b7b-9a10-d0c20fb1d7e4" />
