### PR TITLE
Fix bottom-face being flipped for compact CTM

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -66,7 +66,7 @@ configurations.all {
 }
 
 dependencies {
-    compileOnly("com.github.GTNewHorizons:Hodgepodge:2.7.14:dev")
+    compileOnly("com.github.GTNewHorizons:Hodgepodge:2.7.158:dev")
 
     compileOnly("com.gtnewhorizons.retrofuturabootstrap:RetroFuturaBootstrap:1.1.0") { transitive = false }
 //    runtimeOnlyNonPublishable("com.github.GTNewHorizons:lwjgl3ify:3.0.99")

--- a/src/main/java/com/prupe/mcpatcher/ctm/BlockOrientation.java
+++ b/src/main/java/com/prupe/mcpatcher/ctm/BlockOrientation.java
@@ -20,11 +20,7 @@ final class BlockOrientation extends RenderBlockState {
     // 1 2 3
     // c: coordinate (x,y,z) 0-2
     private static final int[][][] NEIGHBOR_OFFSET = new int[][][] {
-        (
-            fixedBottomFaceUV
-                ? makeNeighborOffset(EAST_FACE, SOUTH_FACE, WEST_FACE, NORTH_FACE) // BOTTOM_FACE fixedBottomFaceUV
-                : makeNeighborOffset(WEST_FACE, SOUTH_FACE, EAST_FACE, NORTH_FACE) // BOTTOM_FACE not fixed
-        ),
+        makeNeighborOffset(EAST_FACE, SOUTH_FACE, WEST_FACE, NORTH_FACE), // BOTTOM_FACE
         makeNeighborOffset(WEST_FACE, SOUTH_FACE, EAST_FACE, NORTH_FACE), // TOP_FACE
         makeNeighborOffset(EAST_FACE, BOTTOM_FACE, WEST_FACE, TOP_FACE), // NORTH_FACE
         makeNeighborOffset(WEST_FACE, BOTTOM_FACE, EAST_FACE, TOP_FACE), // SOUTH_FACE
@@ -48,6 +44,7 @@ final class BlockOrientation extends RenderBlockState {
     private int textureFace;
     private int textureFaceOrig;
     private int rotateUV;
+    private boolean flipBottom;
 
     @Override
     public void clear() {
@@ -60,6 +57,7 @@ final class BlockOrientation extends RenderBlockState {
         offsetsComputed = false;
         haveOffsets = false;
         dx = dy = dz = 0;
+        flipBottom = !fixedBottomFaceUV;
     }
 
     @Override
@@ -104,7 +102,7 @@ final class BlockOrientation extends RenderBlockState {
 
     @Override
     public int[] getOffset(int blockFace, int relativeDirection) {
-        return NEIGHBOR_OFFSET[blockFace][rotateUV(relativeDirection)];
+        return NEIGHBOR_OFFSET[flipBottom && blockFace == 0 ? 1 : blockFace][rotateUV(relativeDirection)];
     }
 
     @Override
@@ -147,6 +145,11 @@ final class BlockOrientation extends RenderBlockState {
         return haveOffsets;
     }
 
+
+    public void setFlipBottom(){
+        flipBottom = true;
+    }
+
     @Override
     public boolean shouldConnectByBlock(Block neighbor, int neighborX, int neighborY, int neighborZ) {
         return block == neighbor
@@ -172,6 +175,7 @@ final class BlockOrientation extends RenderBlockState {
         copy.textureFace = textureFace;
         copy.textureFaceOrig = textureFaceOrig;
         copy.rotateUV = rotateUV;
+        copy.flipBottom = flipBottom;
 
         copy.blockAccess = blockAccess;
         copy.block = block;
@@ -204,6 +208,7 @@ final class BlockOrientation extends RenderBlockState {
         rotateUV = 0;
         textureFace = blockFaceToTextureFace(blockFace);
         metadataBits = (1 << metadata) | (1 << altMetadata);
+        flipBottom = !fixedBottomFaceUV;
     }
 
     void setBlockMetadata(Block block, int metadata, int face) {

--- a/src/main/java/com/prupe/mcpatcher/ctm/CompactCtmQuadProcessor.java
+++ b/src/main/java/com/prupe/mcpatcher/ctm/CompactCtmQuadProcessor.java
@@ -53,6 +53,9 @@ public final class CompactCtmQuadProcessor {
     }
 
     public boolean processFace(RenderBlocks rb, RenderBlockState renderBlockState, IIcon origIcon) {
+        if(renderBlockState instanceof BlockOrientation blockOrientation){
+            blockOrientation.setFlipBottom();
+        }
         int neighborBits = override.getNeighborBits(renderBlockState, origIcon);
 
         int ctmIndex = TileOverride.neighborMap[neighborBits & 0xFF];


### PR DESCRIPTION
Compact CTM cancels hodgepodge's fix for flipped bottom face so we need to make sure we fix it ourselves. 

Regular CTM will still only fix if hodgepodge's fix isn't present, just like before.