### PR TITLE
Fix beacon beams

### DIFF
--- a/src/main/java/com/gtnewhorizons/angelica/mixins/Mixins.java
+++ b/src/main/java/com/gtnewhorizons/angelica/mixins/Mixins.java
@@ -329,6 +329,15 @@ public enum Mixins implements IMixins {
         )
     ),
 
+    IRIS_SHADERS_CHISEL_BEACON(new MixinBuilder("Iris Chisel Beacon Beam")
+        .setPhase(Phase.LATE)
+        .setApplyIf(() -> AngelicaConfig.enableIris)
+        .addRequiredMod(TargetedMod.CHISEL)
+        .addClientMixins(
+            "chisel.MixinRenderCarvableBeacon"
+        )
+    ),
+
     ANGELICA_TEXTURE(new MixinBuilder()
         .setPhase(Phase.EARLY)
         .setApplyIf(() -> AngelicaConfig.enableIris || AngelicaConfig.enableCeleritas)

--- a/src/main/java/com/gtnewhorizons/angelica/mixins/TargetedMod.java
+++ b/src/main/java/com/gtnewhorizons/angelica/mixins/TargetedMod.java
@@ -10,6 +10,7 @@ public enum TargetedMod implements ITargetMod {
     ARCHAICFIX("org.embeddedt.archaicfix.ArchaicCore", "archaicfix"),
     BACKHAND("xonin.backhand.coremod.BackhandLoadingPlugin", "backhand"),
     CAMPFIRE_BACKPORT(null, "campfirebackport"),
+    CHISEL(null, "chisel"),
     COFHCORE( "cofh.asm.LoadingPlugin", "CoFHCore"),
     DYNAMIC_SURROUNDINGS_MIST("org.blockartistry.mod.DynSurround.mixinplugin.DynamicSurroundingsEarlyMixins", "dsurround"),
     DYNAMIC_SURROUNDINGS_ORIGINAL("org.blockartistry.mod.DynSurround.asm.TransformLoader", "dsurround"),

--- a/src/mixin/java/com/gtnewhorizons/angelica/mixins/early/shaders/MixinTileEntityBeaconRenderer.java
+++ b/src/mixin/java/com/gtnewhorizons/angelica/mixins/early/shaders/MixinTileEntityBeaconRenderer.java
@@ -2,11 +2,14 @@ package com.gtnewhorizons.angelica.mixins.early.shaders;
 
 import net.coderbot.iris.gbuffer_overrides.matching.SpecialCondition;
 import net.coderbot.iris.layer.GbufferPrograms;
+import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.client.renderer.tileentity.TileEntityBeaconRenderer;
 import net.minecraft.tileentity.TileEntityBeacon;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(TileEntityBeaconRenderer.class)
@@ -22,5 +25,30 @@ public class MixinTileEntityBeaconRenderer {
         GbufferPrograms.teardownSpecialRenderCondition();
     }
 
+    /**
+     * Whoever wrote this part of vanilla code sucks. Just change the alpha my guy.
+     */
+    @Redirect(
+        method = "Lnet/minecraft/client/renderer/tileentity/TileEntityBeaconRenderer;renderTileEntityAt(Lnet/minecraft/tileentity/TileEntityBeacon;DDDF)V",
+        at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/Tessellator;setColorRGBA(IIII)V", ordinal = 0))
+    private void angelica$innerBeamColor(Tessellator tessellator, int r, int g, int b, int a) {
+        angelica$beamColor(tessellator, r, g, b, 255);
+    }
+
+    @Redirect(
+        method = "Lnet/minecraft/client/renderer/tileentity/TileEntityBeaconRenderer;renderTileEntityAt(Lnet/minecraft/tileentity/TileEntityBeacon;DDDF)V",
+        at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/Tessellator;setColorRGBA(IIII)V", ordinal = 1))
+    private void angelica$outerBeamColor(Tessellator tessellator, int r, int g, int b, int a) {
+        angelica$beamColor(tessellator, r, g, b, a);
+    }
+
+    /**
+     * Make beam fullbright.
+     */
+    @Unique
+    private void angelica$beamColor(Tessellator tessellator, int r, int g, int b, int a) {
+        tessellator.setColorRGBA(r, g, b, a);
+        tessellator.setBrightness(0x00F000F0);
+    }
 
 }

--- a/src/mixin/java/com/gtnewhorizons/angelica/mixins/late/chisel/MixinRenderCarvableBeacon.java
+++ b/src/mixin/java/com/gtnewhorizons/angelica/mixins/late/chisel/MixinRenderCarvableBeacon.java
@@ -1,0 +1,52 @@
+package com.gtnewhorizons.angelica.mixins.late.chisel;
+
+import net.coderbot.iris.gbuffer_overrides.matching.SpecialCondition;
+import net.coderbot.iris.layer.GbufferPrograms;
+import net.minecraft.client.renderer.Tessellator;
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Pseudo;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+/**
+ * Chisel ships its own beacon beam renderer, we yoink a lot of the code from
+ * {@link com.gtnewhorizons.angelica.mixins.early.shaders.MixinTileEntityBeaconRenderer} to apply the same fixes here.
+ */
+@Pseudo
+@Mixin(targets = { "team.chisel.client.render.tile.RenderCarvableBeacon" }, remap = false)
+public class MixinRenderCarvableBeacon {
+
+    @Inject(method = "renderBeam(FLnet/minecraft/world/World;DDDIF)V", at = @At("HEAD"))
+    private void angelica$beginBeaconBeam(float f1, World world, double x, double y, double z, int meta, float partialTicks, CallbackInfo ci) {
+        GbufferPrograms.setupSpecialRenderCondition(SpecialCondition.BEACON_BEAM);
+    }
+
+    @Inject(method = "renderBeam(FLnet/minecraft/world/World;DDDIF)V", at = @At("RETURN"))
+    private void angelica$endBeaconBeam(float f1, World world, double x, double y, double z, int meta, float partialTicks, CallbackInfo ci) {
+        GbufferPrograms.teardownSpecialRenderCondition();
+    }
+
+    @Redirect(
+        method = "renderBeam(FLnet/minecraft/world/World;DDDIF)V",
+        at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/Tessellator;setColorRGBA(IIII)V", ordinal = 0, remap = true))
+    private void angelica$innerBeamColor(Tessellator tessellator, int r, int g, int b, int a) {
+        angelica$beamColor(tessellator, r, g, b, 255);
+    }
+
+    @Redirect(
+        method = "renderBeam(FLnet/minecraft/world/World;DDDIF)V",
+        at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/Tessellator;setColorRGBA(IIII)V", ordinal = 1, remap = true))
+    private void angelica$outerBeamColor(Tessellator tessellator, int r, int g, int b, int a) {
+        angelica$beamColor(tessellator, r, g, b, a);
+    }
+
+    @Unique
+    private void angelica$beamColor(Tessellator tessellator, int r, int g, int b, int a) {
+        tessellator.setColorRGBA(r, g, b, a);
+        tessellator.setBrightness(0x00F000F0);
+    }
+}


### PR DESCRIPTION
Had a few issues to fix regarding rendering with shaders. Also fixes and properly sets the render condition for chisel beacons since they use an entirely different renderer.

Before: 
<img width="2560" height="1368" alt="2026-06-05_19 00 34" src="https://github.com/user-attachments/assets/8e9017f3-b8a3-4dfa-8def-10c2d906d90a" />

After: 
<img width="2560" height="1368" alt="2026-06-05_18 59 35" src="https://github.com/user-attachments/assets/6797e371-a271-4f07-9fd5-1e0a96bae752" />
