### PR TITLE
Remove CTM adding .png to tile paths

### DIFF
--- a/src/main/java/com/prupe/mcpatcher/ctm/TileOverride.java
+++ b/src/main/java/com/prupe/mcpatcher/ctm/TileOverride.java
@@ -289,9 +289,6 @@ public abstract class TileOverride implements Comparable<TileOverride> {
             if (token.isEmpty()) {
                 // nothing
             } else if (token.contains("/")) {
-                if (!token.endsWith(".png")) {
-                    token += ".png";
-                }
                 ResourceLocation resource = TexturePackAPI.parseResourceLocation(properties.getResource(), token);
                 if (resource != null) {
                     list.add(resource.toString());


### PR DESCRIPTION
Icons do not end in .png yet CTM adds it to resourcelocation paths. This makes it so these paths could never be matched and thus never worked.