### PR TITLE
Make no-meta block.properties entries match any metadata

### DIFF
--- a/src/main/java/com/gtnewhorizons/angelica/rendering/celeritas/iris/IrisExtendedChunkVertexEncoder.java
+++ b/src/main/java/com/gtnewhorizons/angelica/rendering/celeritas/iris/IrisExtendedChunkVertexEncoder.java
@@ -7,6 +7,7 @@ import static com.gtnewhorizons.angelica.rendering.celeritas.iris.IrisExtendedCh
 import it.unimi.dsi.fastutil.ints.Int2IntMap;
 import it.unimi.dsi.fastutil.objects.Reference2ObjectMap;
 import lombok.Setter;
+import net.coderbot.iris.block_rendering.BlockMaterialMapping;
 import net.coderbot.iris.block_rendering.BlockRenderingSettings;
 import net.coderbot.iris.vertices.ExtendedDataHelper;
 import net.coderbot.iris.vertices.NormalHelper;
@@ -55,7 +56,7 @@ public class IrisExtendedChunkVertexEncoder implements ContextAwareChunkVertexEn
     public void prepareToRenderBlock(BlockRenderContext ctx, Block block, int metadata, short renderType, byte lightValue) {
         this.context = ctx;
         Int2IntMap metaMap = blockMetaMatches != null ? blockMetaMatches.get(block) : null;
-        ctx.blockId = (short) (metaMap != null ? metaMap.get(metadata) : -1);
+        ctx.blockId = (short) (metaMap != null ? BlockMaterialMapping.lookupBlockId(metaMap, metadata) : -1);
         ctx.renderType = renderType;
         ctx.lightValue = lightValue;
     }
@@ -84,7 +85,7 @@ public class IrisExtendedChunkVertexEncoder implements ContextAwareChunkVertexEn
 
     private int lookupFluidMeta(Block block, int metadata) {
         final Int2IntMap metaMap = blockMetaMatches.get(block);
-        return metaMap != null ? metaMap.get(metadata) : -1;
+        return metaMap != null ? BlockMaterialMapping.lookupBlockId(metaMap, metadata) : -1;
     }
 
     private static Block liquidCounterpart(Block block) {

--- a/src/main/java/net/coderbot/iris/Iris.java
+++ b/src/main/java/net/coderbot/iris/Iris.java
@@ -10,8 +10,6 @@ import com.gtnewhorizons.angelica.rendering.celeritas.api.IrisShaderProviderHold
 import cpw.mods.fml.client.registry.ClientRegistry;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import cpw.mods.fml.common.gameevent.InputEvent;
-import it.unimi.dsi.fastutil.ints.Int2IntMap;
-import it.unimi.dsi.fastutil.objects.Reference2ObjectMap;
 import lombok.Getter;
 import net.coderbot.iris.block_rendering.BlockRenderingSettings;
 import net.coderbot.iris.celeritas.IrisCeleritasShaderProvider;
@@ -943,12 +941,10 @@ public class Iris {
         if (!enabled)
             return;
 
-        final Reference2ObjectMap<Block, Int2IntMap> blockMetaMatches = BlockRenderingSettings.INSTANCE.getBlockMetaMatches();
-        if (blockMetaMatches == null)
+        if (BlockRenderingSettings.INSTANCE.getBlockMetaMatches() == null)
             return;
 
-        final Int2IntMap metaMap = blockMetaMatches.get(block);
-        final int blockId = metaMap != null ? metaMap.get(meta) : -1;
+        final int blockId = BlockRenderingSettings.INSTANCE.resolveBlockId(block, meta);
 
         if (TessellatorManager.get() instanceof StateAwareTessellator tess)
             tess.angelica$setShaderOverrideBlockId((short) blockId);

--- a/src/main/java/net/coderbot/iris/block_rendering/BlockMaterialMapping.java
+++ b/src/main/java/net/coderbot/iris/block_rendering/BlockMaterialMapping.java
@@ -31,6 +31,26 @@ public class BlockMaterialMapping {
 
 	public static final int DOUBLE_PLANT_TOP_BIT = 0x8;
 
+	// Sentinel meta key for no-meta entries: matches ANY metadata of the block.
+	// Real keys are non-negative (block metadata OR'd with low extra bits), so this never collides.
+	public static final int WILDCARD_META_KEY = Integer.MIN_VALUE;
+
+	/**
+	 * The ONLY sanctioned way to read a per-block meta map produced by {@link #createBlockIdMaps}.
+	 * Resolves a block's shader ID: exact metadata first, then the block-wide wildcard registered
+	 * by a no-meta entry. Returns -1 when neither matches (relies on the map's defaultReturnValue == -1).
+	 *
+	 * Do NOT call {@code metaMap.get(meta)} directly on these maps: no-meta entries live only under
+	 * {@link #WILDCARD_META_KEY}, so a raw get would miss them for every metadata value.
+	 */
+	public static int lookupBlockId(Int2IntMap metaMap, int metadata) {
+		int id = metaMap.get(metadata);
+		if (id == -1) {
+			id = metaMap.get(WILDCARD_META_KEY);
+		}
+		return id;
+	}
+
 	/**
 	 * Creates the standard block meta ID map, the TileEntity NBT-conditional map, and registers
 	 * snowy blocks on {@link BlockRenderingSettings}.
@@ -167,7 +187,14 @@ public class BlockMaterialMapping {
 		}
 
 		if (metas.isEmpty()) {
-			for (int meta = 0; meta < 16; meta++) metaMap.putIfAbsent(meta | extraBits, intId);
+			if (extraBits == 0) {
+				// no-meta -> matches ANY metadata of the block (incl. extended metas > 15)
+				metaMap.putIfAbsent(WILDCARD_META_KEY, intId);
+			} else {
+				// snowy / double-plant: those bits are runtime flags, so keep the 0..15 | bit
+				// keys and do NOT register a wildcard (it would match unconditionally).
+				for (int meta = 0; meta < 16; meta++) metaMap.putIfAbsent(meta | extraBits, intId);
+			}
 		} else {
 			for (int meta : metas) metaMap.putIfAbsent(meta | extraBits, intId);
 		}

--- a/src/main/java/net/coderbot/iris/block_rendering/BlockRenderingSettings.java
+++ b/src/main/java/net/coderbot/iris/block_rendering/BlockRenderingSettings.java
@@ -76,6 +76,8 @@ public class BlockRenderingSettings {
 
 	@Getter
     private boolean reloadRequired;
+	// No-meta entries are stored under BlockMaterialMapping.WILDCARD_META_KEY, not as keys 0..15.
+	// Read this map only via BlockMaterialMapping.lookupBlockId / resolveBlockId, never a raw .get.
 	private Reference2ObjectMap<Block, Int2IntMap> blockMetaMatches;
 	private NbtConditionalIdMap<Block> blockNbtMap;
 	private Map<Block, BlockRenderLayer> blockTypeIds;
@@ -127,6 +129,13 @@ public class BlockRenderingSettings {
     @Nullable
 	public Reference2ObjectMap<Block, Int2IntMap> getBlockMetaMatches() {
 		return blockMetaMatches;
+	}
+
+	/** Resolve a block+meta to its shader ID via the wildcard-aware contract, or -1 if unmapped. */
+	public int resolveBlockId(Block block, int metadata) {
+		if (blockMetaMatches == null) return -1;
+		final Int2IntMap metaMap = blockMetaMatches.get(block);
+		return metaMap != null ? BlockMaterialMapping.lookupBlockId(metaMap, metadata) : -1;
 	}
 
 	@Nullable

--- a/src/main/java/net/coderbot/iris/shaderpack/materialmap/PropertiesTokenizer.java
+++ b/src/main/java/net/coderbot/iris/shaderpack/materialmap/PropertiesTokenizer.java
@@ -240,8 +240,11 @@ public final class PropertiesTokenizer {
      * Splits the bracket-stripped portion of a block identifier (e.g. {@code minecraft:furnace:lit=true})
      * into its components.
      *
+     * A bare/no-meta form (no {@code :meta} suffix) matches ANY metadata of the block, including
+     * extended metadata > 15. Single and comma-list meta forms match only the listed values.
+     *
      * Accepted forms:
-     *   stone                                                  (vanilla block)
+     *   stone                                                  (vanilla block, any meta)
      *   stone:0                                                (vanilla block with meta)
      *   minecraft:stone                                        (block with namespaced id specified)
      *   minecraft:stone:0                                      (single meta)

--- a/src/main/java/net/coderbot/iris/uniforms/ItemMaterialHelper.java
+++ b/src/main/java/net/coderbot/iris/uniforms/ItemMaterialHelper.java
@@ -5,6 +5,7 @@ import it.unimi.dsi.fastutil.ints.Int2IntOpenHashMap;
 import it.unimi.dsi.fastutil.objects.Object2IntFunction;
 import it.unimi.dsi.fastutil.objects.Reference2ObjectMap;
 import it.unimi.dsi.fastutil.objects.Reference2ObjectOpenHashMap;
+import net.coderbot.iris.block_rendering.BlockMaterialMapping;
 import net.coderbot.iris.block_rendering.BlockRenderingSettings;
 import net.coderbot.iris.block_rendering.NbtConditionalIdMap;
 import net.coderbot.iris.shaderpack.materialmap.NamespacedId;
@@ -96,7 +97,7 @@ public class ItemMaterialHelper {
                 if (blockMetaMatches != null) {
                     Int2IntMap metaMap = blockMetaMatches.get(block);
                     if (metaMap != null) {
-                        int id = metaMap.get(itemBlock.getMetadata(metadata));
+                        int id = BlockMaterialMapping.lookupBlockId(metaMap, itemBlock.getMetadata(metadata));
                         if (id != -1) {
                             return id;
                         }

--- a/src/mixin/java/com/gtnewhorizons/angelica/mixins/early/shaders/MixinTileEntityRendererDispatcher.java
+++ b/src/mixin/java/com/gtnewhorizons/angelica/mixins/early/shaders/MixinTileEntityRendererDispatcher.java
@@ -1,8 +1,6 @@
 package com.gtnewhorizons.angelica.mixins.early.shaders;
 
 import com.prupe.mcpatcher.ctm.CTMUtils;
-import it.unimi.dsi.fastutil.ints.Int2IntMap;
-import it.unimi.dsi.fastutil.objects.Reference2ObjectMap;
 import net.coderbot.iris.block_rendering.BlockRenderingSettings;
 import net.coderbot.iris.uniforms.CapturedRenderingState;
 import net.minecraft.block.Block;
@@ -29,20 +27,7 @@ public class MixinTileEntityRendererDispatcher {
             return;
         }
 
-        Reference2ObjectMap<Block, Int2IntMap> blockMetaMatches = BlockRenderingSettings.INSTANCE.getBlockMetaMatches();
-        if (blockMetaMatches == null) {
-            CapturedRenderingState.INSTANCE.setCurrentBlockEntity(0);
-            return;
-        }
-
-        Int2IntMap metaMap = blockMetaMatches.get(block);
-        if (metaMap == null) {
-            CapturedRenderingState.INSTANCE.setCurrentBlockEntity(0);
-            return;
-        }
-
-        int meta = te.getBlockMetadata();
-        int id = metaMap.get(meta);
+        final int id = BlockRenderingSettings.INSTANCE.resolveBlockId(block, te.getBlockMetadata());
         CapturedRenderingState.INSTANCE.setCurrentBlockEntity(Math.max(0, id));
     }
 

--- a/src/test/java/net/coderbot/iris/block_rendering/BlockMaterialMappingTest.java
+++ b/src/test/java/net/coderbot/iris/block_rendering/BlockMaterialMappingTest.java
@@ -1,0 +1,70 @@
+package net.coderbot.iris.block_rendering;
+
+import it.unimi.dsi.fastutil.ints.Int2IntMap;
+import it.unimi.dsi.fastutil.ints.Int2IntOpenHashMap;
+import org.junit.jupiter.api.Test;
+
+import static net.coderbot.iris.block_rendering.BlockMaterialMapping.WILDCARD_META_KEY;
+import static net.coderbot.iris.block_rendering.BlockMaterialMapping.lookupBlockId;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/**
+ * Pins the wildcard-aware lookup contract of {@link BlockMaterialMapping#lookupBlockId} independent
+ * of any render path. The per-block maps are plain {@link Int2IntMap}s (default return value -1),
+ * so the contract can be exercised without the Minecraft registry.
+ */
+class BlockMaterialMappingTest {
+
+    private static Int2IntMap map() {
+        final Int2IntMap m = new Int2IntOpenHashMap();
+        m.defaultReturnValue(-1);
+        return m;
+    }
+
+    @Test
+    void noMetaEntryMatchesAnyMetadata() {
+        // A no-meta entry registers only the wildcard key (mirrors applyMetas with extraBits == 0).
+        final Int2IntMap m = map();
+        m.put(WILDCARD_META_KEY, 10030);
+
+        assertEquals(10030, lookupBlockId(m, 0), "meta 0 should match the no-meta entry");
+        assertEquals(10030, lookupBlockId(m, 5), "meta 5 should match the no-meta entry");
+        assertEquals(10030, lookupBlockId(m, 8855), "extended meta 8855 should match the no-meta entry");
+    }
+
+    @Test
+    void exactEntryWinsOverWildcardForItsMeta() {
+        // Both a no-meta entry (wildcard -> 100) and an exact :5 entry (key 5 -> 200) for one block.
+        final Int2IntMap m = map();
+        m.put(WILDCARD_META_KEY, 100);
+        m.put(5, 200);
+
+        assertEquals(200, lookupBlockId(m, 5), "exact meta should win over the wildcard");
+        assertEquals(100, lookupBlockId(m, 3), "other low metas fall back to the wildcard");
+        assertEquals(100, lookupBlockId(m, 8855), "extended metas fall back to the wildcard");
+    }
+
+    @Test
+    void exactOnlyEntryDoesNotMatchUnlistedMeta() {
+        final Int2IntMap m = map();
+        m.put(5, 200);
+
+        assertEquals(200, lookupBlockId(m, 5), "listed meta matches");
+        assertEquals(-1, lookupBlockId(m, 8855), "unlisted meta returns -1 (no wildcard present)");
+        assertEquals(-1, lookupBlockId(m, 0), "unlisted meta returns -1 (no wildcard present)");
+    }
+
+    @Test
+    void snowyStyleNoMetaEntryRegistersNoWildcard() {
+        // Mirrors applyMetas with extraBits != 0 (snowy / double-plant): 0..15 | bit keys, no wildcard.
+        final int bit = BlockMaterialMapping.SNOWY_META_BIT;
+        final Int2IntMap m = map();
+        for (int meta = 0; meta < 16; meta++) m.put(meta | bit, 42);
+
+        assertFalse(m.containsKey(WILDCARD_META_KEY), "extra-bits entries must not register a wildcard");
+        assertEquals(42, lookupBlockId(m, 5 | bit), "snow-covered meta (with bit set) matches");
+        assertEquals(-1, lookupBlockId(m, 5), "raw meta without the bit does not match");
+        assertEquals(-1, lookupBlockId(m, 8855), "extended meta does not match an extra-bits entry");
+    }
+}


### PR DESCRIPTION
Fixes #1846.

## Behavior

- A no-meta entry now matches **any** metadata of the block (including extended metadata > 15), instead of only `0..15`.
- Exact (`name:5`) and comma-list (`name:0,1,2`) forms unchanged.
- A no-meta entry and an exact entry on the same block: exact metadata wins for its value, wildcard covers the rest — now independent of registration order (previously order-dependent via `putIfAbsent`).
- Snowy / double-plant entries (`extraBits != 0`) unchanged.

## Changes

### `BlockMaterialMapping.java`

- Add `public static final int WILDCARD_META_KEY = Integer.MIN_VALUE` (negative sentinel; real keys are non-negative metadata OR'd with low bits, so no collision).
- Add `public static int lookupBlockId(Int2IntMap, int)`: exact metadata first, then `WILDCARD_META_KEY`; returns `-1` otherwise.
- `applyMetas`: for a no-meta entry with `extraBits == 0`, register `WILDCARD_META_KEY` instead of keys `0..15`. With `extraBits != 0` (snowy / double-plant), keep the `0..15 | bit` loop and register no wildcard.

### `BlockRenderingSettings.java`

- Add `int resolveBlockId(Block, int)` (null-guards + `lookupBlockId`).
- Comment on the `blockMetaMatches` field: no-meta entries live under `WILDCARD_META_KEY`; read only via `lookupBlockId` / `resolveBlockId`.

### Meta lookup sites affected by this change (required: the `0..15` expansion was removed)

- `IrisExtendedChunkVertexEncoder.java:58,87` — terrain and fluid → `lookupBlockId`.
- `ItemMaterialHelper.java:99` — item/ItemBlock → `lookupBlockId`.
- `MixinTileEntityRendererDispatcher.java:45` — tile-entity → `resolveBlockId`.
- `Iris.java:951` — immediate-mode override → `resolveBlockId`.

### `PropertiesTokenizer.java`

- Doc: bare/no-meta form matches any metadata.

### Tests

- New `BlockMaterialMappingTest` (4 cases): no-meta resolves `0`/`5`/`8855`; exact wins over wildcard; exact-only returns `-1` for unlisted meta; `extraBits != 0` registers no wildcard and matches only `meta | bit`.

## Verification

- In-game: `block.10030 = gregtech:gt.blockores2` (no meta) tags GT ore (world meta 8855) as `mat == 10030` in base and fleck-overlay passes; controls (explicit metas, no-meta meta-0 blocks, snowy, double plants) unchanged.
