### PR TITLE
Reload DH pipeline on framebuffer resize (fix DH + shaders corruption after fullscreen toggle)

### DIFF
--- a/src/main/java/net/coderbot/iris/compat/dh/DHCompatInternal.java
+++ b/src/main/java/net/coderbot/iris/compat/dh/DHCompatInternal.java
@@ -26,6 +26,17 @@ public class DHCompatInternal {
     public static final DHCompatInternal SHADERLESS = new DHCompatInternal(null, false);
     static boolean dhEnabled;
     private static int guiScale = -1;
+    // Debounced framebuffer-size tracking for checkFrame(). The pipeline is reloaded (rebuilding the
+    // DH framebuffers against the resized render targets) when the window/resolution changes, but only
+    // once the new size has been stable for a few frames. This avoids reacting to the transient sizes
+    // GLFW reports during fullscreen toggles and alt-tab focus changes, which would otherwise fire
+    // spurious reloads and disrupt the mouse grab (cursor position mismatch when tabbing back in).
+    private static int lastReloadFramebufferWidth = -1;
+    private static int lastReloadFramebufferHeight = -1;
+    private static int pendingFramebufferWidth = -1;
+    private static int pendingFramebufferHeight = -1;
+    private static int framebufferStableFrameCount = 0;
+    private static final int FRAMEBUFFER_STABLE_FRAMES_REQUIRED = 10;
     private final DeferredWorldRenderingPipeline pipeline;
     public boolean shouldOverrideShadow;
     public boolean shouldOverride;
@@ -133,15 +144,48 @@ public class DHCompatInternal {
     }
 
     public static boolean checkFrame() {
+        final int fbWidth = Minecraft.getMinecraft().getFramebuffer().framebufferWidth;
+        final int fbHeight = Minecraft.getMinecraft().getFramebuffer().framebufferHeight;
+
         if (guiScale == -1) {
             guiScale = Minecraft.getMinecraft().gameSettings.guiScale;
+        }
+        if (lastReloadFramebufferWidth == -1) {
+            lastReloadFramebufferWidth = fbWidth;
+            lastReloadFramebufferHeight = fbHeight;
         }
 
         if (DhApi.Delayed.configs == null) return dhEnabled;
 
-        if ((dhEnabled != DhApi.Delayed.configs.graphics().renderingEnabled().getValue() || guiScale != Minecraft.getMinecraft().gameSettings.guiScale)
+        // Detect a settled framebuffer size change (eg toggling fullscreen): a resize recreates Iris's
+        // render targets, but the DH framebuffers keep pointing at the old ones until the pipeline is
+        // reloaded. Only act once the new size has been stable for several frames and differs from the
+        // size we last reloaded at, and ignore zero/minimized sizes - otherwise the transient sizes
+        // reported during a fullscreen toggle or alt-tab focus change fire spurious reloads that
+        // disrupt the mouse grab.
+        boolean sizeChanged = false;
+        if (fbWidth > 0 && fbHeight > 0) {
+            if (fbWidth == pendingFramebufferWidth && fbHeight == pendingFramebufferHeight) {
+                if (framebufferStableFrameCount < FRAMEBUFFER_STABLE_FRAMES_REQUIRED) {
+                    framebufferStableFrameCount++;
+                }
+            } else {
+                pendingFramebufferWidth = fbWidth;
+                pendingFramebufferHeight = fbHeight;
+                framebufferStableFrameCount = 1;
+            }
+            sizeChanged = framebufferStableFrameCount >= FRAMEBUFFER_STABLE_FRAMES_REQUIRED
+                && (fbWidth != lastReloadFramebufferWidth || fbHeight != lastReloadFramebufferHeight);
+        }
+
+        if ((dhEnabled != DhApi.Delayed.configs.graphics().renderingEnabled().getValue()
+                || guiScale != Minecraft.getMinecraft().gameSettings.guiScale
+                || sizeChanged)
             && IrisApi.getInstance().isShaderPackInUse()) {
             guiScale = Minecraft.getMinecraft().gameSettings.guiScale;
+            lastReloadFramebufferWidth = fbWidth;
+            lastReloadFramebufferHeight = fbHeight;
+            framebufferStableFrameCount = 0;
             dhEnabled = DhApi.Delayed.configs.graphics().renderingEnabled().getValue();
             try {
                 Iris.reload();


### PR DESCRIPTION
# Rebuild the DH pipeline on framebuffer resize (fixes Distant Horizons + shaders corruption after fullscreen toggle)

## Problem
With a shaderpack active, toggling fullscreen (or otherwise changing the framebuffer
size) mid-session corrupts rendering when Distant Horizons is installed: distant LODs
keep rendering, but **local/vanilla terrain renders smeared and semi-transparent**. A
manual shaderpack reload fixes it until the next resize.

Reproduced on GTNH 2.8.4 with Angelica 2.1.16, Distant Horizons (alpha20 backport),
and Complementary Reimagined r5.x, on an ultrawide (5120×1440) display.

## Root cause
`DHCompatInternal.checkFrame()` already reloads the pipeline when **guiScale** changes
(via `Iris.reload()`), which rebuilds the DH framebuffers (`dhTerrainFramebuffer`, etc.)
against the current render targets. It did **not** react to a **framebuffer size change**.

So on a window/fullscreen resize, Iris's render targets are recreated at the new size,
but the DH framebuffers keep pointing at the old (pre-resize) render targets — producing
the corruption. A manual shader reload runs the same rebuild, which is why it fixes it.

(`reconnectDHTextures()` handles the depth attachment via its depth-buffer-version check,
but the DH framebuffers' colour attachments are only rebuilt on a full pipeline reload.)

## Fix
Track the framebuffer size in `checkFrame()` and trigger the same `Iris.reload()` on a
change, mirroring the existing guiScale handling.

To avoid the transient sizes GLFW reports during fullscreen toggles and alt-tab focus
changes — which would otherwise fire spurious reloads and add latency — the detection is
**debounced**: it only fires once the new size has been stable for a few frames and
differs from the size last reloaded at, and zero/minimized sizes are ignored.

## Testing
- Verified on the setup above: after a fullscreen toggle, local terrain now renders
  correctly (LODs already survived) without needing a manual shader reload.
- Without Distant Horizons / without shaders this path is unaffected (the reload is gated
  by `IrisApi.getInstance().isShaderPackInUse()`).

## Notes
- Built from tag `2.1.16`.
- The reload reuses the existing, cached shader pipeline, so post-first-load reloads are
  fast (~130–220 ms in testing).
