### PR TITLE
Separate out entity overlay render mixins

### DIFF
--- a/src/main/java/com/gtnewhorizons/angelica/config/AngelicaConfig.java
+++ b/src/main/java/com/gtnewhorizons/angelica/config/AngelicaConfig.java
@@ -350,4 +350,8 @@ public class AngelicaConfig {
     @Config.RequiresMcRestart
     public static boolean disableErrorChecks;
 
+    @Config.Comment("Fixes various issues with entity overlays, such as z-fighting, damage animations and eyes.")
+    @Config.DefaultBoolean(true)
+    @Config.RequiresMcRestart
+    public static boolean entityOverlayFixes;
 }

--- a/src/main/java/com/gtnewhorizons/angelica/mixins/Mixins.java
+++ b/src/main/java/com/gtnewhorizons/angelica/mixins/Mixins.java
@@ -47,9 +47,7 @@ public enum Mixins implements IMixins {
             , "angelica.bugfixes.MixinRenderGlobal_DestroyBlock"
             , "angelica.bugfixes.MixinRenderMooshroom_MushroomTint"
             , "angelica.bugfixes.MixinRendererLivingEntity_DeferredEntityOverlay"
-            , "angelica.bugfixes.MixinRendererLivingEntity_OverlayTint"
             , "angelica.bugfixes.MixinRenderWither_ArmorCentering"
-            , "angelica.bugfixes.MixinRendererLivingEntity_EyeDepth"
             , "angelica.debug.MixinMinecraft_FPSCap"
             , "angelica.ffp.MixinTessellator_CoreProfile"
             , "angelica.glsm.MixinSplashProgressCaching"
@@ -57,6 +55,16 @@ public enum Mixins implements IMixins {
             , "angelica.optimizations.MixinRendererLivingEntity"
             , "angelica.rendering.MixinRenderGlobal_SelectionBox"
             , "angelica.gui.MixinGuiIngameForge_ModernF3"
+        )
+    ),
+
+    ANGELICA_ENTITY_OVERLAYS(new MixinBuilder()
+        .setPhase(Phase.EARLY)
+        .setApplyIf(() -> AngelicaConfig.entityOverlayFixes)
+        .addExcludedMod(TargetedMod.CUSTOM_PLAYER_MODELS)
+        .addClientMixins(
+            "angelica.bugfixes.MixinRendererLivingEntity_EyeDepth"
+            , "angelica.bugfixes.MixinRendererLivingEntity_OverlayTint"
         )
     ),
 

--- a/src/main/java/com/gtnewhorizons/angelica/mixins/TargetedMod.java
+++ b/src/main/java/com/gtnewhorizons/angelica/mixins/TargetedMod.java
@@ -28,6 +28,7 @@ public enum TargetedMod implements ITargetMod {
     TINKERS_CONSTRUCT(null, "TConstruct"),
     TWILIGHT_FOREST(null, "TwilightForest"),
     BIOMES_O_PLENTY(null, "BiomesOPlenty"),
+    CUSTOM_PLAYER_MODELS("com.tom.cpmcore.CPMLoadingPlugin", "customplayermodels"),
     WITCHERY(null, "witchery");
 
     private final TargetModBuilder builder;


### PR DESCRIPTION
# Description or your *PR* and other info
This PR separates out the RendererLivingEntity overlay mixins and disables them if customplayermodels transformer is present

Fixes https://github.com/GTNewHorizons/Angelica/issues/1869 

<details open><summary>Template</summary> <!-- OPEN is intentional -->

### Before submitting a *pull request* make sure you have:
- [x] Read the [AI Contribution Policy](https://github.com/GTNewHorizons/Angelica/blob/master/AI_POLICY.md)
- [x] At least [skimmed](https://github.com/GTNewHorizons/Angelica/search?q=is%3Apr&type=Issues) the tracker for similar pull requests

</details>
