### PR TITLE
Fix map rendering issue in xaero's map mods

### DIFF
--- a/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/GLStateManager.java
+++ b/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/GLStateManager.java
@@ -187,6 +187,14 @@ public class GLStateManager {
     private static boolean dirtyTexCoordAttrib;
     private static boolean dirtyLightmapAttrib = true;
 
+    private static boolean unit23TexCoordSetDuringDraw = false;
+
+    public static boolean consumeUnit23TexCoordSetDuringDraw() {
+        boolean v = unit23TexCoordSetDuringDraw;
+        unit23TexCoordSetDuringDraw = false;
+        return v;
+    }
+
     // vertexFlags bits mark attribs the VBO already supplies; FFP supplies the rest via u_Current* uniforms.
     // Skip the backend vertexAttrib call in either case.
     public static void flushDeferredVertexAttribs(boolean hasColor, boolean hasNormal, boolean hasTexCoord, boolean hasLightmap) {
@@ -2158,6 +2166,7 @@ public class GLStateManager {
     }
 
     public static void glBegin(int mode) {
+        unit23TexCoordSetDuringDraw = false;
         if (DisplayListManager.isRecording()) {
             ImmediateModeRecorder.begin(mode);
             return;
@@ -5325,6 +5334,9 @@ public class GLStateManager {
         } else {
             final int unit = target - GL13.GL_TEXTURE0;
             if (unit >= 2 && unit < 4) {
+                if (DisplayListManager.isRecording() || ImmediateModeRecorder.isDrawing()) {
+                    unit23TexCoordSetDuringDraw = true;
+                }
                 ShaderManager.setCurrentTexCoord(unit, s, t, 0.0f, 1.0f);
             }
         }

--- a/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/ffp/VertexKey.java
+++ b/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/ffp/VertexKey.java
@@ -49,6 +49,7 @@ public final class VertexKey {
     private static final int BIT_WIDE_LINE           = 36;
     // Per-unit texmat enable: bits 37-40 (unit 0..3). Unit 1 is the lightmap matrix.
     private static final int BIT_UNIT_TEXMAT_BASE    = 37;
+    private static final int BIT_UNIT23_UV_FROM_UNIT0 = 41;
 
     public static final int TG_NONE                  = 0;
     public static final int TG_OBJ_LINEAR            = 1;
@@ -85,6 +86,7 @@ public final class VertexKey {
     public boolean hasVertexNormal()       { return bit(BIT_HAS_VERTEX_NORMAL); }
     public boolean hasVertexTexCoord()     { return bit(BIT_HAS_VERTEX_TEX); }
     public boolean hasVertexLightmap()    { return bit(BIT_HAS_VERTEX_LIGHTMAP); }
+    public boolean unit23UvFromUnit0()     { return bit(BIT_UNIT23_UV_FROM_UNIT0); }
     /** Color material mode (CM_AMBIENT, CM_DIFFUSE, CM_SPECULAR, CM_EMISSION, CM_AMBIENT_AND_DIFFUSE). Only meaningful when colorMaterialEnabled(). */
     public int colorMaterialMode()        { return (int)((packed >> BIT_COLOR_MAT_MODE) & 0x7); }
 
@@ -212,6 +214,10 @@ public final class VertexKey {
         if (hasNormal) bits |= (1L << BIT_HAS_VERTEX_NORMAL);
         if (hasTexCoord) bits |= (1L << BIT_HAS_VERTEX_TEX);
         if (hasLightmap) bits |= (1L << BIT_HAS_VERTEX_LIGHTMAP);
+
+        if (GLStateManager.consumeUnit23TexCoordSetDuringDraw() && hasTexCoord) {
+            bits |= (1L << BIT_UNIT23_UV_FROM_UNIT0);
+        }
 
         if (GLStateManager.anyClipPlaneEnabled()) {
             bits |= (1L << BIT_CLIP_PLANES);

--- a/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/ffp/VertexShaderGenerator.java
+++ b/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/ffp/VertexShaderGenerator.java
@@ -106,8 +106,8 @@ public final class VertexShaderGenerator {
         if (key.unitTexCoordEnabled(0) && !key.hasVertexTexCoord()) {
             sb.append("uniform vec4 u_CurrentTexCoord0;\n");
         }
-        if (key.unitTexCoordEnabled(2)) sb.append("uniform vec4 u_CurrentTexCoord2;\n");
-        if (key.unitTexCoordEnabled(3)) sb.append("uniform vec4 u_CurrentTexCoord3;\n");
+        if (key.unitTexCoordEnabled(2) && !key.unit23UvFromUnit0()) sb.append("uniform vec4 u_CurrentTexCoord2;\n");
+        if (key.unitTexCoordEnabled(3) && !key.unit23UvFromUnit0()) sb.append("uniform vec4 u_CurrentTexCoord3;\n");
 
         if (key.lightmapEnabled() && !key.hasVertexLightmap()) {
             sb.append("uniform vec2 u_CurrentLightmapCoord;\n");
@@ -363,8 +363,10 @@ public final class VertexShaderGenerator {
 
         for (int i = 2; i < VertexKey.MAX_UNITS; i++) {
             if (!key.unitTexCoordEnabled(i)) continue;
-            final String src = "u_CurrentTexCoord" + i;
-            if (key.unitTexMatEnabled(i)) {
+            final String src = key.unit23UvFromUnit0()
+                ? "vec4(a_TexCoord0, 0.0, 1.0)"
+                : "u_CurrentTexCoord" + i;
+            if (!key.unit23UvFromUnit0() && key.unitTexMatEnabled(i)) {
                 sb.append("  v_TexCoord").append(i).append(" = u_TextureMatrix").append(i).append(" * ").append(src).append(";\n");
             } else {
                 sb.append("  v_TexCoord").append(i).append(" = ").append(src).append(";\n");


### PR DESCRIPTION
Attempts to fix #1784

This PR fixes two bugs:
- Streaming VAOs did not set vertex flags:
  `format.setupBufferState()` calls `glEnableVertexAttribArray()` which updates `VAOManager.Attrib.enabled` but not `currentVertexFlags`.
  `ShaderManager.preDraw()` reads `getCurrentVertexFlags()` to determine hasVertexTexCoord/Color/etc. so streaming VAOs always got `flags=0`, causing the shader to use `u_CurrentTexCoord0` instead of `a_TexCoord0`.
- Extend support for `glMultiTexCoord2d` to texture units 2 and 3:
  These calls should go to `ImmediateModeRecorder`. This is something already fixed for texture units 0/1, I just extended it to the other units. Xaero's map rendering uses those in `bindMapTextureWithLighting3` for tiles with `textureHasLight=true` (which is true for blocks like lava). The PR could be extended to support units 2 and 3 seperately if needed.
  
The rendering should now behave normally, this is how it looked before with Angelica 2.1.42 for reference:
<img width="984" height="638" alt="image" src="https://github.com/user-attachments/assets/deb16f95-94c1-46f9-8942-9a8fab3b4788" />
