### PR TITLE
Use vanilla AO metric when shading custom rendered blocks

### DIFF
--- a/src/mixin/java/com/gtnewhorizons/angelica/mixins/early/rendering/MixinRenderBlocks.java
+++ b/src/mixin/java/com/gtnewhorizons/angelica/mixins/early/rendering/MixinRenderBlocks.java
@@ -50,6 +50,7 @@ public abstract class MixinRenderBlocks {
     @Unique
     private boolean isRenderingByType = false;
 
+    @Unique
     private boolean applyingCeleritasAO = false;
 
     @Inject(method = "renderBlockByRenderType", at = @At("HEAD"))
@@ -105,11 +106,14 @@ public abstract class MixinRenderBlocks {
     /**
      * @author embeddedt
      * @reason When vanilla would render with AO, hijack the rendering logic and render using flat lighting instead.
+     *         Skip the separateAo redirect when called on a RenderBlocks subclass (e.g. BetterFoliage's
+     *         ExtendedRenderBlocks) so that the per-vertex brightness/color fields get populated by vanilla AO
+     *         for custom geometry shading.
      */
     @Inject(method = { "renderStandardBlockWithAmbientOcclusion", "renderStandardBlockWithAmbientOcclusionPartial" }, at = @At("HEAD"), cancellable = true)
     private void handleCeleritasAo(Block block, int x, int y, int z, float r, float g, float b, CallbackInfoReturnable<Boolean> cir) {
         if ((this.isRenderingByType && Minecraft.isAmbientOcclusionEnabled() && ClientProxy.options().quality.useCeleritasSmoothLighting) ||
-            (Iris.enabled && BlockRenderingSettings.INSTANCE.shouldUseSeparateAo())) {
+            (((Object)this).getClass() == RenderBlocks.class && Iris.enabled && BlockRenderingSettings.INSTANCE.shouldUseSeparateAo())) {
             this.applyingCeleritasAO = true;
             try {
                 cir.setReturnValue(this.renderStandardBlockWithColorMultiplier(block, x, y, z, r, g, b));


### PR DESCRIPTION
The change forces blocks rendered with RenderBlocks to be shaded with the vanilla AO.
This should fix some mods which rely on this data to shade their blocks, namely BetterFoliage.

The PR fixes the following issues:
- #1351
- #1290
- https://github.com/Kynake/BetterFoliage/issues/28
- #1357

This issue *might* also be solved by using a different branch of BetterFoliage (from https://github.com/Kynake/BetterFoliage) according to #1339 (untested).

Its possible that this could break rendering in some mods. I didn't find any where it did in my testing, but that does not rule it out. On option could be added to disable this behaviour if needed.