### PR TITLE
CTM: Fix "flipped" value not set to false in setFace()

### DIFF
--- a/src/main/java/com/prupe/mcpatcher/ctm/BlockOrientation.java
+++ b/src/main/java/com/prupe/mcpatcher/ctm/BlockOrientation.java
@@ -212,7 +212,7 @@ final class BlockOrientation extends RenderBlockState {
         rotateUV = 0;
         textureFace = blockFaceToTextureFace(blockFace);
         metadataBits = (1 << metadata) | (1 << altMetadata);
-        if(!fixedBottomFaceUV && blockFace == ForgeDirection.DOWN.ordinal()) flipped = true;
+        flipped = !fixedBottomFaceUV && blockFace == ForgeDirection.DOWN.ordinal();
     }
 
     void setBlockMetadata(Block block, int metadata, int face) {


### PR DESCRIPTION
`flipped` was only ever set to true, and wasn't set to false if the method was called on a new face. This fixes that.

<details open><summary>Template</summary> <!-- OPEN is intentional -->

### Before submitting a *pull request* make sure you have:
- [X] Read the [AI Contribution Policy](https://github.com/GTNewHorizons/Angelica/blob/master/AI_POLICY.md)
- [X] At least [skimmed](https://github.com/GTNewHorizons/Angelica/search?q=is%3Apr&type=Issues) the tracker for similar pull requests

</details>
