### PR TITLE
Add API for allowing other mods to have celeritas support

### DIFF
--- a/src/main/java/com/gtnewhorizons/angelica/api/ExtCeleritasRenderBlocks.java
+++ b/src/main/java/com/gtnewhorizons/angelica/api/ExtCeleritasRenderBlocks.java
@@ -1,0 +1,9 @@
+package com.gtnewhorizons.angelica.api;
+
+public interface ExtCeleritasRenderBlocks {
+
+    boolean angelica$shouldApplyCeleritasAO();
+
+    void angelica$setApplyingCeleritasAO(boolean val);
+
+}

--- a/src/mixin/java/com/gtnewhorizons/angelica/mixins/early/rendering/MixinRenderBlocks.java
+++ b/src/mixin/java/com/gtnewhorizons/angelica/mixins/early/rendering/MixinRenderBlocks.java
@@ -1,5 +1,6 @@
 package com.gtnewhorizons.angelica.mixins.early.rendering;
 
+import com.gtnewhorizons.angelica.api.ExtCeleritasRenderBlocks;
 import com.gtnewhorizons.angelica.common.BlockError;
 import com.gtnewhorizons.angelica.loading.AngelicaClientTweaker;
 import com.gtnewhorizons.angelica.proxy.ClientProxy;
@@ -33,7 +34,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(RenderBlocks.class)
-public abstract class MixinRenderBlocks {
+public abstract class MixinRenderBlocks implements ExtCeleritasRenderBlocks {
     @Shadow
     public abstract boolean renderStandardBlockWithColorMultiplier(Block p_147736_1_, int p_147736_2_, int p_147736_3_, int p_147736_4_, float p_147736_5_, float p_147736_6_, float p_147736_7_);
 
@@ -109,8 +110,7 @@ public abstract class MixinRenderBlocks {
      */
     @Inject(method = { "renderStandardBlockWithAmbientOcclusion", "renderStandardBlockWithAmbientOcclusionPartial" }, at = @At("HEAD"), cancellable = true)
     private void handleCeleritasAo(Block block, int x, int y, int z, float r, float g, float b, CallbackInfoReturnable<Boolean> cir) {
-        if ((this.isRenderingByType && Minecraft.isAmbientOcclusionEnabled() && ClientProxy.options().quality.useCeleritasSmoothLighting) ||
-            (Iris.enabled && BlockRenderingSettings.INSTANCE.shouldUseSeparateAo())) {
+        if (angelica$shouldApplyCeleritasAO()) {
             this.applyingCeleritasAO = true;
             try {
                 cir.setReturnValue(this.renderStandardBlockWithColorMultiplier(block, x, y, z, r, g, b));
@@ -118,6 +118,17 @@ public abstract class MixinRenderBlocks {
                 this.applyingCeleritasAO = false;
             }
         }
+    }
+
+    @Override
+    public boolean angelica$shouldApplyCeleritasAO() {
+        return (this.isRenderingByType && Minecraft.isAmbientOcclusionEnabled() && ClientProxy.options().quality.useCeleritasSmoothLighting) ||
+            (Iris.enabled && BlockRenderingSettings.INSTANCE.shouldUseSeparateAo());
+    }
+
+    @Override
+    public void angelica$setApplyingCeleritasAO(boolean val) {
+        this.applyingCeleritasAO = val;
     }
 
     /**


### PR DESCRIPTION
# Description or your *PR* and other info
Allows mods which work with mods which call RenderBlocks.renderFace/the tessellator directly to still work with the celeritas AO impl. Will be used in GT's SBRWorldContext to skip its own lighting calculations.

<details open><summary>Template</summary> <!-- OPEN is intentional -->

### Before submitting a *pull request* make sure you have:
- [X] Read the [AI Contribution Policy](https://github.com/GTNewHorizons/Angelica/blob/master/AI_POLICY.md)
- [X] At least [skimmed](https://github.com/GTNewHorizons/Angelica/search?q=is%3Apr&type=Issues) the tracker for similar pull requests

</details>
