### PR TITLE
Fix at_midBlock at high coordinates

### DIFF
--- a/src/main/java/net/coderbot/iris/vertices/ExtendedDataHelper.java
+++ b/src/main/java/net/coderbot/iris/vertices/ExtendedDataHelper.java
@@ -12,9 +12,9 @@ public final class ExtendedDataHelper {
 
 	public static int computeMidBlock(float x, float y, float z, int localPosX, int localPosY, int localPosZ) {
 		return packMidBlock(
-				localPosX + 0.5f - x,
-				localPosY + 0.5f - y,
-				localPosZ + 0.5f - z
+            (localPosX & 0xFFFF) + 0.5f - x,
+			(localPosY & 0xFFFF) + 0.5f - y,
+			(localPosZ & 0xFFFF) + 0.5f - z
 		);
 	}
 }


### PR DESCRIPTION
# Description of your *PR* and other info
Backports this PR https://github.com/IrisShaders/Iris/pull/3246 which fixes midBlock breaking at high coords.
Noticeable with colored lights being broken.

Tested only on modern mc versions but the fix should work here 1:1 the same.

<details><summary>Before</summary>

<img width="2560" height="1417" alt="2026-07-19_14 42 04" src="https://github.com/user-attachments/assets/1299c102-f29f-4899-9924-b6d86342cc7d" />

</details>

<details><summary>After</summary>

<img width="2560" height="1417" alt="2026-07-19_14 40 51" src="https://github.com/user-attachments/assets/7a87d89b-490b-48f7-b148-090ef43d0cb9" />

</details>

<details open><summary>Template</summary> <!-- OPEN is intentional -->

### Before submitting a *pull request* make sure you have:
- [x] Read the [AI Contribution Policy](https://github.com/GTNewHorizons/Angelica/blob/master/AI_POLICY.md)
- [x] At least [skimmed](https://github.com/GTNewHorizons/Angelica/search?q=is%3Apr&type=Issues) the tracker for similar pull requests

</details>
