### PR TITLE
Optimize item frame rendering

### DIFF
--- a/src/main/java/com/gtnewhorizons/angelica/mixins/Mixins.java
+++ b/src/main/java/com/gtnewhorizons/angelica/mixins/Mixins.java
@@ -157,6 +157,7 @@ public enum Mixins implements IMixins {
         .setPhase(Phase.EARLY)
         .addClientMixins(
             "angelica.itemrenderer.MixinItemRenderer",
+            "angelica.itemrenderer.MixinRenderItemFrame",
             "angelica.itemrenderer.MixinRenderBlocks"
         )
         .setApplyIf(() -> AngelicaConfig.optimizeInWorldItemRendering)),

--- a/src/main/java/com/gtnewhorizons/angelica/rendering/items/BlockRenderListManager.java
+++ b/src/main/java/com/gtnewhorizons/angelica/rendering/items/BlockRenderListManager.java
@@ -12,6 +12,7 @@ public class BlockRenderListManager {
     private static final BlockMeta key = new BlockMeta();
 
     private static final Object2IntOpenHashMap<BlockMeta> displayListMap = new Object2IntOpenHashMap<>();
+    private static final int[] itemFrameDisplayLists = new int[8];
 
 
     private static final int ISBRH_CUTOFF = 40;
@@ -36,6 +37,10 @@ public class BlockRenderListManager {
         return displayListMap.getInt(key);
     }
 
+    public static int getItemFrameDisplayList(int variant) {
+        return itemFrameDisplayLists[variant];
+    }
+
     public static int startCompiling() {
         final int list = GLStateManager.glGenLists(1);
         GLStateManager.glNewList(list, GL11.GL_COMPILE);
@@ -43,9 +48,18 @@ public class BlockRenderListManager {
     }
 
     public static void endCompiling(int list, Block block, int meta) {
+        finishCompiling();
+        displayListMap.put(new BlockMeta(block, meta), list);
+    }
+
+    public static void endItemFrameCompiling(int list, int variant) {
+        finishCompiling();
+        itemFrameDisplayLists[variant] = list;
+    }
+
+    private static void finishCompiling() {
         DisplayListManager.discardMatrixTransforms();
         GLStateManager.glEndList();
-        displayListMap.put(new BlockMeta(block, meta), list);
     }
 
     public static void registerReloadListener(){
@@ -56,6 +70,12 @@ public class BlockRenderListManager {
                 GLStateManager.glDeleteLists(list, 1);
             }
             displayListMap.clear();
+            for (int i = 0; i < itemFrameDisplayLists.length; i++) {
+                if (itemFrameDisplayLists[i] != 0) {
+                    GLStateManager.glDeleteLists(itemFrameDisplayLists[i], 1);
+                    itemFrameDisplayLists[i] = 0;
+                }
+            }
         });
     }
 

--- a/src/mixin/java/com/gtnewhorizons/angelica/mixins/early/angelica/itemrenderer/MixinRenderItemFrame.java
+++ b/src/mixin/java/com/gtnewhorizons/angelica/mixins/early/angelica/itemrenderer/MixinRenderItemFrame.java
@@ -1,0 +1,49 @@
+package com.gtnewhorizons.angelica.mixins.early.angelica.itemrenderer;
+
+import com.gtnewhorizons.angelica.glsm.GLStateManager;
+import com.gtnewhorizons.angelica.rendering.items.BlockRenderListManager;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import net.minecraft.client.renderer.tileentity.RenderItemFrame;
+import net.minecraft.entity.item.EntityItemFrame;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+
+@Mixin(RenderItemFrame.class)
+public class MixinRenderItemFrame {
+
+    @WrapOperation(
+        method = "doRender(Lnet/minecraft/entity/item/EntityItemFrame;DDDFF)V",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/client/renderer/tileentity/RenderItemFrame;renderFrameItemAsBlock(Lnet/minecraft/entity/item/EntityItemFrame;)V"
+        )
+    )
+    private void angelica$cacheFrame(RenderItemFrame renderer, EntityItemFrame frame, Operation<Void> original) {
+        angelica$renderCached(renderer, frame, original, frame.hangingDirection);
+    }
+
+    @WrapOperation(
+        method = "doRender(Lnet/minecraft/entity/item/EntityItemFrame;DDDFF)V",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/client/renderer/tileentity/RenderItemFrame;func_147915_b(Lnet/minecraft/entity/item/EntityItemFrame;)V"
+        )
+    )
+    private void angelica$cacheMapFrame(RenderItemFrame renderer, EntityItemFrame frame, Operation<Void> original) {
+        angelica$renderCached(renderer, frame, original, 4 + frame.hangingDirection);
+    }
+
+    @Unique
+    private static void angelica$renderCached(RenderItemFrame renderer, EntityItemFrame frame,
+                                              Operation<Void> original, int keyIndex) {
+        int list = BlockRenderListManager.getItemFrameDisplayList(keyIndex);
+        if (list == 0) {
+            list = BlockRenderListManager.startCompiling();
+            original.call(renderer, frame);
+            BlockRenderListManager.endItemFrameCompiling(list, keyIndex);
+        }
+        GLStateManager.glCallList(list);
+    }
+}

--- a/src/mixin/java/com/gtnewhorizons/angelica/mixins/early/angelica/itemrenderer/MixinRenderItemFrame.java
+++ b/src/mixin/java/com/gtnewhorizons/angelica/mixins/early/angelica/itemrenderer/MixinRenderItemFrame.java
@@ -1,9 +1,11 @@
 package com.gtnewhorizons.angelica.mixins.early.angelica.itemrenderer;
 
+import com.gtnewhorizon.gtnhlib.client.renderer.TessellatorManager;
 import com.gtnewhorizons.angelica.glsm.GLStateManager;
 import com.gtnewhorizons.angelica.rendering.items.BlockRenderListManager;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.client.renderer.tileentity.RenderItemFrame;
 import net.minecraft.entity.item.EntityItemFrame;
 import org.spongepowered.asm.mixin.Mixin;
@@ -38,6 +40,11 @@ public class MixinRenderItemFrame {
     @Unique
     private static void angelica$renderCached(RenderItemFrame renderer, EntityItemFrame frame,
                                               Operation<Void> original, int keyIndex) {
+        if (GLStateManager.isRecordingDisplayList() || TessellatorManager.isCurrentlyCapturing()
+            || TessellatorManager.shouldInterceptDraw(Tessellator.instance)) {
+            original.call(renderer, frame);
+            return;
+        }
         int list = BlockRenderListManager.getItemFrameDisplayList(keyIndex);
         if (list == 0) {
             list = BlockRenderListManager.startCompiling();


### PR DESCRIPTION
# Description of your *PR* and other info

Improve performances when many item frames are rendered at same time by caching it's geometry.

Not fully sure this is the right way but was encouraged by admin to try to PR and see what you think of it.

Issue spotted while working https://github.com/GTNewHorizons/GT5-Unofficial/pull/7464
Partially mitigated with https://github.com/GTNewHorizons/Hodgepodge/pull/949


In nightmare scenario (spawned two ore show room on top of each other so it's twice as bad)
before:
<img width="2560" height="1369" alt="2026-07-26_16 49 32" src="https://github.com/user-attachments/assets/50e52abb-42fb-4e27-86d1-ae588720b8db" />

After:
<img width="2560" height="1369" alt="2026-07-26_16 47 32" src="https://github.com/user-attachments/assets/018a8af4-b01d-48c3-a7a3-892c7af9da54" />


<details open><summary>Template</summary> <!-- OPEN is intentional -->

### Before submitting a *pull request* make sure you have:
- [x] Read the [AI Contribution Policy](https://github.com/GTNewHorizons/Angelica/blob/master/AI_POLICY.md)
- [x] At least [skimmed](https://github.com/GTNewHorizons/Angelica/search?q=is%3Apr&type=Issues) the tracker for similar pull requests

</details>
