### PR TITLE
Properly handle flags removed in core

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -97,6 +97,10 @@ dependencies {
     devOnlyNonPublishable('com.github.GTNewHorizons:NotEnoughItems:2.8.35-GTNH:dev')
     devOnlyNonPublishable('com.github.GTNewHorizons:CodeChickenCore:1.4.7:dev')
 
+    // BQ Testing
+//    devOnlyNonPublishable("com.github.GTNewHorizons:BetterQuesting:3.8.74-GTNH:dev")
+
+
     // Display List Testing
     /*
     runtimeOnlyNonPublishable("com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-749-GTNH:dev")

--- a/glsm/build.gradle.kts
+++ b/glsm/build.gradle.kts
@@ -146,9 +146,13 @@ val downgradeTestClasses by tasks.registering(DowngradeFiles::class) {
     dependsOn(tasks.named("testClasses"))
 }
 
-tasks.test {
-    useJUnitPlatform()
+val GL_TASK_TAGS = mapOf(
+    "glCompatTest" to "gl-compat",
+    "glCoreTest" to "gl-core",
+    "glSharedTest" to "gl-shared",
+)
 
+fun Test.configureGlsmJava8() {
     javaLauncher = javaToolchains.launcherFor {
         languageVersion = JavaLanguageVersion.of(8)
         if (System.getProperty("os.name").lowercase().contains("mac")
@@ -171,23 +175,53 @@ tasks.test {
     classpath = downgradedTest
         .plus(downgradedMain)
         .plus(downgradedDeps)
-        .plus(classpath.minus(mainClassesDirs).minus(testClassesDirs).minus(depsToDowngrade))
+        .plus(sourceSets["test"].runtimeClasspath.minus(mainClassesDirs).minus(testClassesDirs).minus(depsToDowngrade))
 
     val extractNatives = rootProject.tasks.named("extractNatives2")
     dependsOn(extractNatives)
     jvmArgs("-Djava.library.path=${extractNatives.get().property("destinationFolder").let { (it as DirectoryProperty).asFile.get().path }}")
 }
 
+tasks.test {
+    useJUnitPlatform {
+        excludeTags = GL_TASK_TAGS.values.toSet()
+    }
+    configureGlsmJava8()
+}
+
+val glTestTasks = GL_TASK_TAGS.map { (taskName, tag) ->
+    tasks.register<Test>(taskName) {
+        description = "Runs the $tag GL tests in their own JVM, so they get their own Display and GL profile."
+        group = "verification"
+        useJUnitPlatform {
+            includeTags = setOf(tag)
+        }
+        configureGlsmJava8()
+    }
+}
+
+(listOf(tasks.test) + glTestTasks).zipWithNext { earlier, later ->
+    later.configure { mustRunAfter(earlier) }
+}
+tasks.test { finalizedBy(glTestTasks) }
+
 val verifyTestsRan by tasks.registering {
-    val resultsDir = layout.buildDirectory.dir("test-results/test")
-    dependsOn(tasks.test)
-    doLast {
-        val dir = resultsDir.get().asFile
-        val xmls = dir.listFiles { f -> f.name.startsWith("TEST-") && f.name.endsWith(".xml") } ?: emptyArray()
-        check(xmls.isNotEmpty()) {
-            ":glsm:test produced no TEST-*.xml in $dir - test task likely went NO-SOURCE"
+    dependsOn(tasks.test, glTestTasks)
+}
+(listOf(tasks.test) + glTestTasks).forEach { testTask ->
+    val name = testTask.name
+    val verify = tasks.register("verify${name.replaceFirstChar { it.uppercase() }}Ran") {
+        val resultsDir = layout.buildDirectory.dir("test-results/$name")
+        dependsOn(testTask)
+        doLast {
+            val dir = resultsDir.get().asFile
+            val xmls = dir.listFiles { f -> f.name.startsWith("TEST-") && f.name.endsWith(".xml") } ?: emptyArray()
+            check(xmls.isNotEmpty()) {
+                ":glsm:$name produced no TEST-*.xml in $dir - test task likely went NO-SOURCE"
+            }
         }
     }
+    verifyTestsRan.configure { dependsOn(verify) }
 }
 tasks.check { dependsOn(verifyTestsRan) }
 

--- a/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/GLStateManager.java
+++ b/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/GLStateManager.java
@@ -57,8 +57,8 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.joml.Matrix4d;
 import org.joml.Matrix4f;
-import org.joml.Matrix4fc;
 import org.joml.Matrix4fStack;
+import org.joml.Matrix4fc;
 import org.joml.Vector3d;
 import org.joml.Vector3f;
 import org.joml.Vector4f;
@@ -381,16 +381,16 @@ public class GLStateManager {
     @Getter protected static final BooleanStateStack ditherState = new BooleanStateStack(GL11.GL_DITHER, true); // Defaults to true per OpenGL spec
     @Getter protected static final BooleanStateStack stencilTest = new BooleanStateStack(GL11.GL_STENCIL_TEST);
     @Getter protected static final BooleanStateStack lineSmoothState = new BooleanStateStack(GL11.GL_LINE_SMOOTH);
-    @Getter protected static final BooleanStateStack lineStippleState = new BooleanStateStack(GL11.GL_LINE_STIPPLE);
-    @Getter protected static final BooleanStateStack pointSmoothState = new BooleanStateStack(GL11.GL_POINT_SMOOTH);
+    @Getter protected static final BooleanStateStack lineStippleState = new BooleanStateStack(GL11.GL_LINE_STIPPLE, false, true);
+    @Getter protected static final BooleanStateStack pointSmoothState = new BooleanStateStack(GL11.GL_POINT_SMOOTH, false, true);
     @Getter protected static final BooleanStateStack polygonSmoothState = new BooleanStateStack(GL11.GL_POLYGON_SMOOTH);
-    @Getter protected static final BooleanStateStack polygonStippleState = new BooleanStateStack(GL11.GL_POLYGON_STIPPLE);
+    @Getter protected static final BooleanStateStack polygonStippleState = new BooleanStateStack(GL11.GL_POLYGON_STIPPLE, false, true);
     @Getter protected static final BooleanStateStack multisampleState = new BooleanStateStack(GL13.GL_MULTISAMPLE, true); // Defaults to true per OpenGL spec
     @Getter protected static final BooleanStateStack sampleAlphaToCoverageState = new BooleanStateStack(GL13.GL_SAMPLE_ALPHA_TO_COVERAGE);
     @Getter protected static final BooleanStateStack sampleAlphaToOneState = new BooleanStateStack(GL13.GL_SAMPLE_ALPHA_TO_ONE);
     @Getter protected static final BooleanStateStack sampleCoverageState = new BooleanStateStack(GL13.GL_SAMPLE_COVERAGE);
     @Getter protected static final BooleanStateStack colorLogicOpState = new BooleanStateStack(GL11.GL_COLOR_LOGIC_OP);
-    @Getter protected static final BooleanStateStack indexLogicOpState = new BooleanStateStack(GL11.GL_INDEX_LOGIC_OP);
+    @Getter protected static final BooleanStateStack indexLogicOpState = new BooleanStateStack(GL11.GL_INDEX_LOGIC_OP, false, true);
 
     // Polygon offset states (enable bits)
     @Getter protected static final BooleanStateStack polygonOffsetPointState = new BooleanStateStack(GL11.GL_POLYGON_OFFSET_POINT);
@@ -410,6 +410,7 @@ public class GLStateManager {
      * {@link com.gtnewhorizons.angelica.glsm.ffp.VertexKey}.
      */
     public static boolean wideLineEmulationActive = false;
+    public static boolean lineStippleActive = false;
 
     // Point state (GL_POINT_BIT)
     @Getter protected static final PointStateStack pointState = new PointStateStack();
@@ -421,25 +422,25 @@ public class GLStateManager {
     @Getter protected static final StencilStateStack stencilState = new StencilStateStack();
     private static int stencilBitMask = 0xFFFFFFFF;
 
-    @Getter protected static final BooleanStateStack autoNormalState = new BooleanStateStack(GL11.GL_AUTO_NORMAL);
-    @Getter protected static final BooleanStateStack map1Color4State = new BooleanStateStack(GL11.GL_MAP1_COLOR_4);
-    @Getter protected static final BooleanStateStack map1IndexState = new BooleanStateStack(GL11.GL_MAP1_INDEX);
-    @Getter protected static final BooleanStateStack map1NormalState = new BooleanStateStack(GL11.GL_MAP1_NORMAL);
-    @Getter protected static final BooleanStateStack map1TextureCoord1State = new BooleanStateStack(GL11.GL_MAP1_TEXTURE_COORD_1);
-    @Getter protected static final BooleanStateStack map1TextureCoord2State = new BooleanStateStack(GL11.GL_MAP1_TEXTURE_COORD_2);
-    @Getter protected static final BooleanStateStack map1TextureCoord3State = new BooleanStateStack(GL11.GL_MAP1_TEXTURE_COORD_3);
-    @Getter protected static final BooleanStateStack map1TextureCoord4State = new BooleanStateStack(GL11.GL_MAP1_TEXTURE_COORD_4);
-    @Getter protected static final BooleanStateStack map1Vertex3State = new BooleanStateStack(GL11.GL_MAP1_VERTEX_3);
-    @Getter protected static final BooleanStateStack map1Vertex4State = new BooleanStateStack(GL11.GL_MAP1_VERTEX_4);
-    @Getter protected static final BooleanStateStack map2Color4State = new BooleanStateStack(GL11.GL_MAP2_COLOR_4);
-    @Getter protected static final BooleanStateStack map2IndexState = new BooleanStateStack(GL11.GL_MAP2_INDEX);
-    @Getter protected static final BooleanStateStack map2NormalState = new BooleanStateStack(GL11.GL_MAP2_NORMAL);
-    @Getter protected static final BooleanStateStack map2TextureCoord1State = new BooleanStateStack(GL11.GL_MAP2_TEXTURE_COORD_1);
-    @Getter protected static final BooleanStateStack map2TextureCoord2State = new BooleanStateStack(GL11.GL_MAP2_TEXTURE_COORD_2);
-    @Getter protected static final BooleanStateStack map2TextureCoord3State = new BooleanStateStack(GL11.GL_MAP2_TEXTURE_COORD_3);
-    @Getter protected static final BooleanStateStack map2TextureCoord4State = new BooleanStateStack(GL11.GL_MAP2_TEXTURE_COORD_4);
-    @Getter protected static final BooleanStateStack map2Vertex3State = new BooleanStateStack(GL11.GL_MAP2_VERTEX_3);
-    @Getter protected static final BooleanStateStack map2Vertex4State = new BooleanStateStack(GL11.GL_MAP2_VERTEX_4);
+    @Getter protected static final BooleanStateStack autoNormalState = new BooleanStateStack(GL11.GL_AUTO_NORMAL, false, true);
+    @Getter protected static final BooleanStateStack map1Color4State = new BooleanStateStack(GL11.GL_MAP1_COLOR_4, false, true);
+    @Getter protected static final BooleanStateStack map1IndexState = new BooleanStateStack(GL11.GL_MAP1_INDEX, false, true);
+    @Getter protected static final BooleanStateStack map1NormalState = new BooleanStateStack(GL11.GL_MAP1_NORMAL, false, true);
+    @Getter protected static final BooleanStateStack map1TextureCoord1State = new BooleanStateStack(GL11.GL_MAP1_TEXTURE_COORD_1, false, true);
+    @Getter protected static final BooleanStateStack map1TextureCoord2State = new BooleanStateStack(GL11.GL_MAP1_TEXTURE_COORD_2, false, true);
+    @Getter protected static final BooleanStateStack map1TextureCoord3State = new BooleanStateStack(GL11.GL_MAP1_TEXTURE_COORD_3, false, true);
+    @Getter protected static final BooleanStateStack map1TextureCoord4State = new BooleanStateStack(GL11.GL_MAP1_TEXTURE_COORD_4, false, true);
+    @Getter protected static final BooleanStateStack map1Vertex3State = new BooleanStateStack(GL11.GL_MAP1_VERTEX_3, false, true);
+    @Getter protected static final BooleanStateStack map1Vertex4State = new BooleanStateStack(GL11.GL_MAP1_VERTEX_4, false, true);
+    @Getter protected static final BooleanStateStack map2Color4State = new BooleanStateStack(GL11.GL_MAP2_COLOR_4, false, true);
+    @Getter protected static final BooleanStateStack map2IndexState = new BooleanStateStack(GL11.GL_MAP2_INDEX, false, true);
+    @Getter protected static final BooleanStateStack map2NormalState = new BooleanStateStack(GL11.GL_MAP2_NORMAL, false, true);
+    @Getter protected static final BooleanStateStack map2TextureCoord1State = new BooleanStateStack(GL11.GL_MAP2_TEXTURE_COORD_1, false, true);
+    @Getter protected static final BooleanStateStack map2TextureCoord2State = new BooleanStateStack(GL11.GL_MAP2_TEXTURE_COORD_2, false, true);
+    @Getter protected static final BooleanStateStack map2TextureCoord3State = new BooleanStateStack(GL11.GL_MAP2_TEXTURE_COORD_3, false, true);
+    @Getter protected static final BooleanStateStack map2TextureCoord4State = new BooleanStateStack(GL11.GL_MAP2_TEXTURE_COORD_4, false, true);
+    @Getter protected static final BooleanStateStack map2Vertex3State = new BooleanStateStack(GL11.GL_MAP2_VERTEX_3, false, true);
+    @Getter protected static final BooleanStateStack map2Vertex4State = new BooleanStateStack(GL11.GL_MAP2_VERTEX_4, false, true);
 
     // Clip plane states
     @Getter protected static final BooleanStateStack[] clipPlaneStates = new BooleanStateStack[MAX_CLIP_PLANES];
@@ -2259,7 +2260,7 @@ public class GLStateManager {
     public static void preDraw(int drawMode) {
         final boolean locked = acquireDrawLock();
         try {
-            prepareWideLineEmulation(drawMode);
+            prepareLineEmulation(drawMode);
             ShaderManager.getInstance().preDraw();
             prepareClientArrays();
         } finally {
@@ -2270,7 +2271,7 @@ public class GLStateManager {
     public static void preDraw() {
         final boolean locked = acquireDrawLock();
         try {
-            disableWideLineEmulation();
+            disableLineEmulation();
             ShaderManager.getInstance().preDraw();
             prepareClientArrays();
         } finally {
@@ -4606,15 +4607,21 @@ public class GLStateManager {
         }
     }
 
-    public static void prepareWideLineEmulation(int drawMode) {
-        wideLineEmulationActive =
-            (drawMode == GL11.GL_LINES || drawMode == GL11.GL_LINE_STRIP || drawMode == GL11.GL_LINE_LOOP)
-                && lineState.getWidth() > 1.0f
-                && wideLineEmulationEnabled;
+    public static void prepareLineEmulation(int drawMode) {
+        final boolean isLine = drawMode == GL11.GL_LINES || drawMode == GL11.GL_LINE_STRIP || drawMode == GL11.GL_LINE_LOOP;
+        wideLineEmulationActive = isLine && lineState.getWidth() > 1.0f && wideLineEmulationEnabled;
+        setLineStippleActive(isLine && lineStippleState.isEnabled());
     }
 
-    public static void disableWideLineEmulation() {
+    public static void disableLineEmulation() {
         wideLineEmulationActive = false;
+        setLineStippleActive(false);
+    }
+
+    private static void setLineStippleActive(boolean active) {
+        if (lineStippleActive == active) return;
+        lineStippleActive = active;
+        RENDER_BACKEND.provokingVertex(active ? GL32.GL_FIRST_VERTEX_CONVENTION : GL32.GL_LAST_VERTEX_CONVENTION);
     }
 
     public static void glFlush() {
@@ -5207,10 +5214,10 @@ public class GLStateManager {
 
     private static void invalidateDeletedBuffer(int buffer) {
         if (buffer == 0) return;
-        if (boundVBO == buffer) boundVBO = 0;
-        if (VAOManager.boundEBO == buffer) VAOManager.boundEBO = 0;
-        if (boundPixelUnpackBuffer == buffer) boundPixelUnpackBuffer = 0;
-        if (boundPixelPackBuffer == buffer) boundPixelPackBuffer = 0;
+        if (boundVBO == buffer) glBindBuffer(GL15.GL_ARRAY_BUFFER, 0);
+        if (VAOManager.boundEBO == buffer) glBindBuffer(GL15.GL_ELEMENT_ARRAY_BUFFER, 0);
+        if (boundPixelUnpackBuffer == buffer) glBindBuffer(GL21.GL_PIXEL_UNPACK_BUFFER, 0);
+        if (boundPixelPackBuffer == buffer) glBindBuffer(GL21.GL_PIXEL_PACK_BUFFER, 0);
 
         // Sweep all VAOs: an unbound VAO may later rebind with a dangling EBO id.
         for (VAOManager.VAOData data : VAOManager.vaoMap.values()) {
@@ -5241,9 +5248,21 @@ public class GLStateManager {
         PixelUnpackState.applyDiff(applied, pixelUnpackState);
     }
 
+    private static boolean warnedUntrackedPixelBuffer;
+
+    private static void warnUntrackedPixelBuffer(int binding, String name) {
+        if (warnedUntrackedPixelBuffer || initConfig == null || !initConfig.isLwjglDebug()) return;
+        final int actual = RENDER_BACKEND.getInteger(binding);
+        if (actual == 0) return;
+        warnedUntrackedPixelBuffer = true;
+        LOGGER.warn("{} is bound to {} but GLSM's cache says 0; a call site bypassed GLStateManager.glBindBuffer", name, actual, new Throwable());
+    }
+
     static void suspendPixelUnpackBuffer() {
         if (boundPixelUnpackBuffer != 0) {
             RENDER_BACKEND.bindBuffer(GL21.GL_PIXEL_UNPACK_BUFFER, 0);
+        } else {
+            warnUntrackedPixelBuffer(GL21.GL_PIXEL_UNPACK_BUFFER_BINDING, "GL_PIXEL_UNPACK_BUFFER");
         }
     }
 
@@ -5256,6 +5275,8 @@ public class GLStateManager {
     static void suspendPixelPackBuffer() {
         if (boundPixelPackBuffer != 0) {
             RENDER_BACKEND.bindBuffer(GL21.GL_PIXEL_PACK_BUFFER, 0);
+        } else {
+            warnUntrackedPixelBuffer(GL21.GL_PIXEL_PACK_BUFFER_BINDING, "GL_PIXEL_PACK_BUFFER");
         }
     }
 

--- a/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/ffp/FragmentKey.java
+++ b/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/ffp/FragmentKey.java
@@ -12,7 +12,7 @@ import org.lwjgl.opengl.GL13;
  * Packed-long fragment shader permutation key for FFP emulation.
  *
  * Layout:
- *   long[0]: global bits (11) + unit 0 (47 bits at offset 11)
+ *   long[0]: global bits (12) + unit 0 (47 bits at offset 12)
  *   long[1..3]: unit 1..3 (47 bits each, low-aligned)
  * Only max(1, nrEnabledUnits) longs are significant.
  *
@@ -63,13 +63,14 @@ public final class FragmentKey {
     public static final int FOG_EXP    = 2;
     public static final int FOG_EXP2   = 3;
 
-    private static final int GLOBAL_BITS = 11;
+    private static final int GLOBAL_BITS = 12;
     private static final int BIT_FOG_MODE          = 0;  // 2 bits
     private static final int BIT_ALPHA_TEST        = 2;  // 1 bit
     private static final int BIT_ALPHA_FUNC        = 3;  // 3 bits
     private static final int BIT_SEPARATE_SPECULAR = 6;  // 1 bit
     private static final int BIT_NR_ENABLED_UNITS  = 7;  // 3 bits
     private static final int BIT_OVERLAY_ENABLED   = 10; // 1 bit
+    private static final int BIT_LINE_STIPPLE      = 11; // 1 bit
 
     private static final int U_ENABLED         = 0;
     private static final int U_MODE            = 1;   // 3 bits
@@ -123,6 +124,10 @@ public final class FragmentKey {
         // Damage overlay
         if (GLStateManager.getOverlayA() != 0.0f) {
             global |= (1L << BIT_OVERLAY_ENABLED);
+        }
+
+        if (GLStateManager.lineStippleActive) {
+            global |= (1L << BIT_LINE_STIPPLE);
         }
 
         // Separate specular
@@ -233,6 +238,7 @@ public final class FragmentKey {
     public boolean alphaTestEnabled() { return ((packed[0] >> BIT_ALPHA_TEST) & 1) != 0; }
     public int alphaTestFunc()        { return (int) ((packed[0] >> BIT_ALPHA_FUNC) & 0x7); }
     public boolean separateSpecular() { return ((packed[0] >> BIT_SEPARATE_SPECULAR) & 1) != 0; }
+    public boolean lineStipple()      { return ((packed[0] >> BIT_LINE_STIPPLE) & 1) != 0; }
     public int nrEnabledUnits()       { return (int) ((packed[0] >> BIT_NR_ENABLED_UNITS) & 0x7); }
     public boolean overlayEnabled()   { return ((packed[0] >> BIT_OVERLAY_ENABLED) & 1) != 0; }
 

--- a/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/ffp/FragmentShaderGenerator.java
+++ b/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/ffp/FragmentShaderGenerator.java
@@ -20,6 +20,7 @@ public final class FragmentShaderGenerator {
         sb.append("out vec4 fragColor;\n\n");
 
         sb.append("void main() {\n");
+        emitLineStipple(sb, key);
         emitTextureSampling(sb, key);
         emitTexEnvChain(sb, key);
         emitSpecularAdd(sb, key);
@@ -46,7 +47,17 @@ public final class FragmentShaderGenerator {
         if (key.fogMode() != FragmentKey.FOG_NONE) {
             sb.append("in float v_FogCoord;\n");
         }
+        if (key.lineStipple()) {
+            sb.append("flat in vec2 v_LineStart;\n");
+        }
         sb.append('\n');
+    }
+
+    private static void emitLineStipple(StringBuilder sb, FragmentKey key) {
+        if (!key.lineStipple()) return;
+        sb.append("  vec2 stippleDelta = abs(gl_FragCoord.xy - v_LineStart);\n");
+        sb.append("  int stippleBit = int(floor(max(stippleDelta.x, stippleDelta.y) / float(u_LineStipple >> 16))) & 15;\n");
+        sb.append("  if (((u_LineStipple >> stippleBit) & 1) == 0) discard;\n\n");
     }
 
     private static void emitUniforms(StringBuilder sb, FragmentKey key) {
@@ -58,6 +69,9 @@ public final class FragmentShaderGenerator {
         }
         if (key.alphaTestEnabled()) {
             sb.append("uniform float u_AlphaRef;\n");
+        }
+        if (key.lineStipple()) {
+            sb.append("uniform int u_LineStipple;\n");
         }
         // Per-unit texEnvColor uniforms
         for (int i = 0; i < key.nrEnabledUnits(); i++) {

--- a/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/ffp/GeometryShaderGenerator.java
+++ b/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/ffp/GeometryShaderGenerator.java
@@ -29,6 +29,9 @@ public final class GeometryShaderGenerator {
         if (key.fogEnabled()) {
             sb.append("in float v_FogCoord_gs[];\n");
         }
+        if (key.lineStipple()) {
+            sb.append("flat in vec2 v_LineStart_gs[];\n");
+        }
         sb.append('\n');
 
         sb.append("out vec4 v_Color;\n");
@@ -41,6 +44,9 @@ public final class GeometryShaderGenerator {
         if (key.unitTexCoordEnabled(3))       sb.append("out vec4 v_TexCoord3;\n");
         if (key.fogEnabled()) {
             sb.append("out float v_FogCoord;\n");
+        }
+        if (key.lineStipple()) {
+            sb.append("flat out vec2 v_LineStart;\n");
         }
         sb.append('\n');
 
@@ -84,6 +90,9 @@ public final class GeometryShaderGenerator {
         if (key.unitTexCoordEnabled(3))       sb.append("    v_TexCoord3 = v_TexCoord3_gs").append(idx).append(";\n");
         if (key.fogEnabled()) {
             sb.append("    v_FogCoord = v_FogCoord_gs").append(idx).append(";\n");
+        }
+        if (key.lineStipple()) {
+            sb.append("    v_LineStart = v_LineStart_gs[0];\n");
         }
 
         if (key.clipPlanesEnabled()) {

--- a/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/ffp/Program.java
+++ b/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/ffp/Program.java
@@ -33,6 +33,9 @@ public class Program {
         int texGenGen = -1, clipPlaneGen = -1;
         float lightmapX = Float.NaN, lightmapY = Float.NaN, lineWidth = Float.NaN;
         int viewportWidth = -1, viewportHeight = -1;
+        int stippleViewportX = Integer.MIN_VALUE, stippleViewportY = Integer.MIN_VALUE;
+        int stippleViewportW = -1, stippleViewportH = -1;
+        int lineStipple = -1;
     }
     final UploadState uploadState = new UploadState();
 
@@ -97,6 +100,10 @@ public class Program {
     // Wide line emulation (geometry shader)
     public int locViewportSize = -1;
     public int locLineWidth = -1;
+
+    // Line stipple emulation
+    public int locViewport = -1;
+    public int locLineStipple = -1;
 
     // Fragment uniforms
     public final int[] locSampler = { -1, -1, -1, -1 };
@@ -173,6 +180,10 @@ public class Program {
         // Wide line emulation
         locViewportSize = loc("u_ViewportSize");
         locLineWidth = loc("u_LineWidth");
+
+        // Line stipple emulation
+        locViewport = loc("u_Viewport");
+        locLineStipple = loc("u_LineStipple");
 
         // Fragment
         for (int i = 0; i < 4; i++) {

--- a/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/ffp/Uniforms.java
+++ b/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/ffp/Uniforms.java
@@ -4,8 +4,10 @@ import com.gtnewhorizons.angelica.glsm.GLStateManager;
 import com.gtnewhorizons.angelica.glsm.states.ClipPlaneState;
 import com.gtnewhorizons.angelica.glsm.states.FogState;
 import com.gtnewhorizons.angelica.glsm.states.LightState;
+import com.gtnewhorizons.angelica.glsm.states.LineState;
 import com.gtnewhorizons.angelica.glsm.states.MaterialState;
 import com.gtnewhorizons.angelica.glsm.states.TexGenState;
+import com.gtnewhorizons.angelica.glsm.states.ViewportState;
 import com.gtnewhorizons.angelica.glsm.hooks.GLSMConfig;
 import org.joml.Math;
 import org.joml.Matrix3f;
@@ -135,6 +137,31 @@ public class Uniforms {
         // Wide line emulation uniforms
         if (program.locLineWidth != -1 && program.locViewportSize != -1) {
             uploadWideLineUniforms(program);
+        }
+
+        if (program.locLineStipple != -1) {
+            uploadLineStippleUniforms(program);
+        }
+    }
+
+    private void uploadLineStippleUniforms(Program program) {
+        final Program.UploadState st = program.uploadState;
+        final LineState line = GLStateManager.getLineState();
+
+        final int factor = line.getStippleFactor() < 1 ? 1 : line.getStippleFactor();
+        final int packed = (line.getStipplePattern() & 0xFFFF) | (factor << 16);
+        if (packed != st.lineStipple) {
+            RENDER_BACKEND.uniform1i(program.locLineStipple, packed);
+            st.lineStipple = packed;
+        }
+
+        final ViewportState vp = GLStateManager.getViewportState();
+        if (vp.x != st.stippleViewportX || vp.y != st.stippleViewportY || vp.width != st.stippleViewportW || vp.height != st.stippleViewportH) {
+            RENDER_BACKEND.uniform4f(program.locViewport, vp.x, vp.y, vp.width, vp.height);
+            st.stippleViewportX = vp.x;
+            st.stippleViewportY = vp.y;
+            st.stippleViewportW = vp.width;
+            st.stippleViewportH = vp.height;
         }
     }
 

--- a/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/ffp/VertexKey.java
+++ b/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/ffp/VertexKey.java
@@ -50,6 +50,7 @@ public final class VertexKey {
     // Per-unit texmat enable: bits 37-40 (unit 0..3). Unit 1 is the lightmap matrix.
     private static final int BIT_UNIT_TEXMAT_BASE    = 37;
     private static final int BIT_UNIT23_UV_FROM_UNIT0 = 41;
+    private static final int BIT_LINE_STIPPLE        = 42;
 
     public static final int TG_NONE                  = 0;
     public static final int TG_OBJ_LINEAR            = 1;
@@ -98,6 +99,7 @@ public final class VertexKey {
     public boolean texGenEnabled()        { return texGenModeS() != TG_NONE || texGenModeT() != TG_NONE || texGenModeR() != TG_NONE || texGenModeQ() != TG_NONE; }
     public boolean clipPlanesEnabled()    { return bit(BIT_CLIP_PLANES); }
     public boolean wideLineEmulation()   { return bit(BIT_WIDE_LINE); }
+    public boolean lineStipple()          { return bit(BIT_LINE_STIPPLE); }
 
     public boolean cmReplacesAmbient()    { final int m = colorMaterialMode(); return m == CM_AMBIENT || m == CM_AMBIENT_AND_DIFFUSE; }
     public boolean cmReplacesDiffuse()    { final int m = colorMaterialMode(); return m == CM_DIFFUSE || m == CM_AMBIENT_AND_DIFFUSE; }
@@ -225,6 +227,10 @@ public final class VertexKey {
 
         if (GLStateManager.wideLineEmulationActive) {
             bits |= (1L << BIT_WIDE_LINE);
+        }
+
+        if (GLStateManager.lineStippleActive) {
+            bits |= (1L << BIT_LINE_STIPPLE);
         }
 
         return bits;

--- a/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/ffp/VertexShaderGenerator.java
+++ b/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/ffp/VertexShaderGenerator.java
@@ -29,6 +29,9 @@ public final class VertexShaderGenerator {
             emitColorPassthrough(sb, key);
         }
         emitTexCoordPassthrough(sb, key);
+        if (key.lineStipple()) {
+            emitLineStart(sb);
+        }
         if (key.fogEnabled()) {
             emitFogDistance(sb, key);
         }
@@ -45,6 +48,7 @@ public final class VertexShaderGenerator {
                            .replace("v_TexCoord2", "v_TexCoord2_gs")
                            .replace("v_TexCoord3", "v_TexCoord3_gs")
                            .replace("v_FogCoord", "v_FogCoord_gs")
+                           .replace("v_LineStart", "v_LineStart_gs")
                            .replace("v_Color", "v_Color_gs");
         }
         return source;
@@ -68,6 +72,11 @@ public final class VertexShaderGenerator {
         sb.append('\n');
     }
 
+    private static void emitLineStart(StringBuilder sb) {
+        sb.append("  vec2 ndc = gl_Position.xy / gl_Position.w;\n");
+        sb.append("  v_LineStart = u_Viewport.xy + (ndc * 0.5 + 0.5) * u_Viewport.zw;\n\n");
+    }
+
     private static void emitUniforms(StringBuilder sb, VertexKey key) {
         sb.append("// Matrices\n");
         sb.append("uniform mat4 u_ModelViewMatrix;\n");
@@ -76,6 +85,9 @@ public final class VertexShaderGenerator {
 
         if (key.lightingEnabled()) {
             sb.append("uniform mat3 u_NormalMatrix;\n");
+        }
+        if (key.lineStipple()) {
+            sb.append("uniform vec4 u_Viewport;\n");
         }
 
         for (int i = 0; i < VertexKey.MAX_UNITS; i++) {
@@ -182,6 +194,9 @@ public final class VertexShaderGenerator {
     private static void emitOutputs(StringBuilder sb, VertexKey key) {
         sb.append("// Outputs\n");
         sb.append("out vec4 v_Color;\n");
+        if (key.lineStipple()) {
+            sb.append("flat out vec2 v_LineStart;\n");
+        }
         if (key.separateSpecular()) {
             sb.append("out vec3 v_SpecularColor;\n");
         }

--- a/glsm/src/test/java/com/gtnewhorizons/angelica/glsm/ArrayUniformUploadGLTest.java
+++ b/glsm/src/test/java/com/gtnewhorizons/angelica/glsm/ArrayUniformUploadGLTest.java
@@ -1,7 +1,6 @@
 package com.gtnewhorizons.angelica.glsm;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.lwjgl.BufferUtils;
 import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.GL20;
@@ -12,7 +11,7 @@ import java.nio.IntBuffer;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@ExtendWith(GLSMCoreExtension.class)
+@GLCoreTest
 class ArrayUniformUploadGLTest {
 
     private static int compile(int type, String src) {

--- a/glsm/src/test/java/com/gtnewhorizons/angelica/glsm/CompatUniformManagerTest.java
+++ b/glsm/src/test/java/com/gtnewhorizons/angelica/glsm/CompatUniformManagerTest.java
@@ -2,7 +2,6 @@ package com.gtnewhorizons.angelica.glsm;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.lwjgl.opengl.GL20;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -12,7 +11,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-@ExtendWith(GLSMExtension.class)
+@GLCompatTest
 class CompatUniformManagerTest {
 
     private int program = 0;

--- a/glsm/src/test/java/com/gtnewhorizons/angelica/glsm/DisplayListCompilationGLSMTest.java
+++ b/glsm/src/test/java/com/gtnewhorizons/angelica/glsm/DisplayListCompilationGLSMTest.java
@@ -3,7 +3,6 @@ package com.gtnewhorizons.angelica.glsm;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.lwjgl.BufferUtils;
 import org.lwjgl.opengl.GL11;
 
@@ -17,7 +16,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /** Tests GLSM display list behavior matches OpenGL spec. */
-@ExtendWith(GLSMExtension.class)
+@GLCompatTest
 class DisplayListCompilationGLSMTest {
 
     private int testList = -1;

--- a/glsm/src/test/java/com/gtnewhorizons/angelica/glsm/DisplayListCompilationRawGLTest.java
+++ b/glsm/src/test/java/com/gtnewhorizons/angelica/glsm/DisplayListCompilationRawGLTest.java
@@ -3,16 +3,17 @@ package com.gtnewhorizons.angelica.glsm;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.lwjgl.BufferUtils;
 import org.lwjgl.opengl.GL11;
 
 import java.nio.FloatBuffer;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /** Tests raw GL11 display list behavior (reference for GLSM). */
-@ExtendWith(GLSMExtension.class)
+@GLCompatTest
 class DisplayListCompilationRawGLTest {
 
     private int testList = -1;

--- a/glsm/src/test/java/com/gtnewhorizons/angelica/glsm/FeedbackManagerTest.java
+++ b/glsm/src/test/java/com/gtnewhorizons/angelica/glsm/FeedbackManagerTest.java
@@ -3,7 +3,6 @@ package com.gtnewhorizons.angelica.glsm;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.lwjgl.BufferUtils;
 import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.GL15;
@@ -11,9 +10,11 @@ import org.lwjgl.opengl.GL30;
 
 import java.nio.FloatBuffer;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@ExtendWith(GLSMExtension.class)
+@GLCompatTest
 class FeedbackManagerTest {
 
     @BeforeEach

--- a/glsm/src/test/java/com/gtnewhorizons/angelica/glsm/GLCompatTest.java
+++ b/glsm/src/test/java/com/gtnewhorizons/angelica/glsm/GLCompatTest.java
@@ -1,0 +1,18 @@
+package com.gtnewhorizons.angelica.glsm;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Tag(GLTestTags.COMPAT)
+@ExtendWith(GLSMExtension.class)
+public @interface GLCompatTest {
+}

--- a/glsm/src/test/java/com/gtnewhorizons/angelica/glsm/GLCoreTest.java
+++ b/glsm/src/test/java/com/gtnewhorizons/angelica/glsm/GLCoreTest.java
@@ -1,0 +1,18 @@
+package com.gtnewhorizons.angelica.glsm;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Tag(GLTestTags.CORE)
+@ExtendWith(GLSMCoreExtension.class)
+public @interface GLCoreTest {
+}

--- a/glsm/src/test/java/com/gtnewhorizons/angelica/glsm/GLSMCoreExtension.java
+++ b/glsm/src/test/java/com/gtnewhorizons/angelica/glsm/GLSMCoreExtension.java
@@ -1,40 +1,73 @@
 package com.gtnewhorizons.angelica.glsm;
 
 import com.gtnewhorizons.angelica.glsm.hooks.GLSMInitConfig;
-import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.lwjgl.LWJGLException;
 import org.lwjgl.opengl.ContextAttribs;
 import org.lwjgl.opengl.Display;
 import org.lwjgl.opengl.DisplayMode;
+import org.lwjgl.opengl.GL11;
+import org.lwjgl.opengl.GL32;
 import org.lwjgl.opengl.PixelFormat;
+
+import static org.junit.jupiter.api.extension.ExtensionContext.Namespace.GLOBAL;
 
 /**
  * 3.3 core-profile context extension
  */
-public class GLSMCoreExtension implements BeforeAllCallback, AfterAllCallback {
-    private boolean ownsDisplay = false;
+public class GLSMCoreExtension implements BeforeAllCallback, BeforeEachCallback, ExtensionContext.Store.CloseableResource {
+
+    private static boolean started = false;
+    private static Throwable startFailure;
 
     @Override
     public void beforeAll(ExtensionContext context) throws LWJGLException {
-        if (Display.isCreated()) return;
-        Display.setDisplayModeAndFullscreen(new DisplayMode(800, 600));
-        Display.setResizable(false);
-        Display.setFullscreen(false);
-        Display.create(
-            new PixelFormat().withDepthBits(24).withStencilBits(8),
-            new ContextAttribs(3, 3).withProfileCore(true).withForwardCompatible(true));
-        ownsDisplay = true;
-        GLStateManager.initialize(GLSMInitConfig.builder().displaySize(800, 600).build());
-        GLStateManager.setRunningSplash(false);
-        GLStateManager.markSplashComplete();
-        GLStateManager.BYPASS_CACHE = false;
+        if (startFailure != null) {
+            throw new IllegalStateException("GLSMCoreExtension context setup failed earlier in this JVM", startFailure);
+        }
+        if (started) return;
+        try {
+            Display.setDisplayModeAndFullscreen(new DisplayMode(800, 600));
+            Display.setResizable(false);
+            Display.setFullscreen(false);
+            Display.create(
+                new PixelFormat().withDepthBits(24).withStencilBits(8),
+                new ContextAttribs(3, 3).withProfileCore(true).withForwardCompatible(true));
+
+            GLSMExtension.setMainThread(Thread.currentThread());
+            GLStateManager.initialize(GLSMInitConfig.builder().displaySize(800, 600).build());
+            GLStateManager.setRunningSplash(false);
+            GLStateManager.markSplashComplete();
+            GLStateManager.BYPASS_CACHE = false;
+
+            GLSMExtension.glVendor = GL11.glGetString(GL11.GL_VENDOR);
+            GLSMExtension.glRenderer = GL11.glGetString(GL11.GL_RENDERER);
+            GLSMExtension.glVersion = GL11.glGetString(GL11.GL_VERSION);
+            System.out.println("OpenGL Vendor: " + GLSMExtension.glVendor);
+            System.out.println("OpenGL Renderer: " + GLSMExtension.glRenderer);
+            System.out.println("OpenGL Version: " + GLSMExtension.glVersion);
+
+            final int profileMask = GL11.glGetInteger(GL32.GL_CONTEXT_PROFILE_MASK);
+            if ((profileMask & GL32.GL_CONTEXT_CORE_PROFILE_BIT) == 0) {
+                throw new IllegalStateException("Expected a GL core context, got profile mask 0x" + Integer.toHexString(profileMask) + " (" + GLSMExtension.glVersion + ")");
+            }
+            context.getRoot().getStore(GLOBAL).put("GLSMCoreExtension", this);
+            started = true;
+        } catch (LWJGLException | RuntimeException | Error e) {
+            startFailure = e;
+            throw e;
+        }
     }
 
     @Override
-    public void afterAll(ExtensionContext context) {
-        if (ownsDisplay && Display.isCreated()) Display.destroy();
-        ownsDisplay = false;
+    public void beforeEach(ExtensionContext context) {
+        while (GL11.glGetError() != GL11.GL_NO_ERROR) {}
+    }
+
+    @Override
+    public void close() {
+        if (Display.isCreated()) Display.destroy();
     }
 }

--- a/glsm/src/test/java/com/gtnewhorizons/angelica/glsm/GLSMExtension.java
+++ b/glsm/src/test/java/com/gtnewhorizons/angelica/glsm/GLSMExtension.java
@@ -8,9 +8,11 @@ import org.junit.jupiter.api.extension.ConditionEvaluationResult;
 import org.junit.jupiter.api.extension.ExecutionCondition;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.lwjgl.LWJGLException;
+import org.lwjgl.opengl.ContextAttribs;
 import org.lwjgl.opengl.Display;
 import org.lwjgl.opengl.DisplayMode;
 import org.lwjgl.opengl.GL11;
+import org.lwjgl.opengl.GL32;
 import org.lwjgl.opengl.PixelFormat;
 import sun.misc.Unsafe;
 
@@ -45,6 +47,7 @@ public class GLSMExtension implements BeforeAllCallback, BeforeEachCallback, Aft
     }
 
     private static boolean started = false;
+    private static Throwable startFailure;
     private static DisplayMode displayMode;
     public static String glVendor;
     public static String glRenderer;
@@ -55,21 +58,23 @@ public class GLSMExtension implements BeforeAllCallback, BeforeEachCallback, Aft
 
     @Override
     public void beforeAll(ExtensionContext context) throws LWJGLException {
-        if (!started) {
-            started = true;
-
+        if (startFailure != null) {
+            throw new IllegalStateException("GLSMExtension context setup failed earlier in this JVM", startFailure);
+        }
+        if (started) return;
+        try {
             displayMode = new DisplayMode(800, 600);
+            final GLSMInitConfig config = GLSMInitConfig.builder().displaySize(displayMode.getWidth(), displayMode.getHeight()).build();
+            setMainThread(Thread.currentThread());
+
+            latchRenderSystemOnCoreContext(config);
+
             Display.setDisplayModeAndFullscreen(displayMode);
             Display.setResizable(false);
             Display.setFullscreen(false);
-            final PixelFormat format = new PixelFormat().withDepthBits(24).withStencilBits(8);
-            Display.create(format);
+            Display.create(new PixelFormat().withDepthBits(24).withStencilBits(8));
 
-            setMainThread(Thread.currentThread());
-
-            GLStateManager.initialize(GLSMInitConfig.builder()
-                .displaySize(displayMode.getWidth(), displayMode.getHeight())
-                .build());
+            GLStateManager.initialize(config);
             GLStateManager.setRunningSplash(false);
             GLStateManager.markSplashComplete();
             GLStateManager.BYPASS_CACHE = false;
@@ -81,6 +86,30 @@ public class GLSMExtension implements BeforeAllCallback, BeforeEachCallback, Aft
             System.out.println("OpenGL Vendor: " + glVendor);
             System.out.println("OpenGL Renderer: " + glRenderer);
             System.out.println("OpenGL Version: " + glVersion);
+
+            final int profileMask = GL11.glGetInteger(GL32.GL_CONTEXT_PROFILE_MASK);
+            if ((profileMask & GL32.GL_CONTEXT_COMPATIBILITY_PROFILE_BIT) == 0) {
+                throw new IllegalStateException("Expected a GL compatibility context, got profile mask 0x" + Integer.toHexString(profileMask) + " (" + glVersion + ")");
+            }
+            started = true;
+        } catch (LWJGLException | RuntimeException | Error e) {
+            startFailure = e;
+            throw e;
+        }
+    }
+
+
+    private static void latchRenderSystemOnCoreContext(GLSMInitConfig config) throws LWJGLException {
+        Display.setDisplayModeAndFullscreen(displayMode);
+        Display.setResizable(false);
+        Display.setFullscreen(false);
+        Display.create(
+            new PixelFormat().withDepthBits(24).withStencilBits(8),
+            new ContextAttribs(3, 3).withProfileCore(true).withForwardCompatible(true));
+        try {
+            GLStateManager.initialize(config);
+        } finally {
+            Display.destroy();
         }
     }
 
@@ -95,7 +124,7 @@ public class GLSMExtension implements BeforeAllCallback, BeforeEachCallback, Aft
         }
     }
 
-    private static void setMainThread(Thread thread) {
+    static void setMainThread(Thread thread) {
         try {
             final Field f = GLStateManager.class.getDeclaredField("MainThread");
             final Object base = theUnsafe.staticFieldBase(f);

--- a/glsm/src/test/java/com/gtnewhorizons/angelica/glsm/GLSM_BlendUnknownState_UnitTest.java
+++ b/glsm/src/test/java/com/gtnewhorizons/angelica/glsm/GLSM_BlendUnknownState_UnitTest.java
@@ -3,7 +3,6 @@ package com.gtnewhorizons.angelica.glsm;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.GL30;
 
@@ -16,7 +15,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * Verifies that per-buffer blend operations (glEnablei/glDisablei) properly invalidate
  * the GLSM blend cache so subsequent global blend enable/disable calls are not skipped.
  */
-@ExtendWith(GLSMExtension.class)
+@GLCompatTest
 class GLSM_BlendUnknownState_UnitTest {
 
     @BeforeEach

--- a/glsm/src/test/java/com/gtnewhorizons/angelica/glsm/GLSM_CoreRemovedCaps_GLTest.java
+++ b/glsm/src/test/java/com/gtnewhorizons/angelica/glsm/GLSM_CoreRemovedCaps_GLTest.java
@@ -1,0 +1,105 @@
+package com.gtnewhorizons.angelica.glsm;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.lwjgl.opengl.GL11;
+
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@GLCoreTest
+public class GLSM_CoreRemovedCaps_GLTest {
+
+    static Stream<Arguments> removedCaps() {
+        return Stream.of(
+            cap("GL_LINE_STIPPLE", GL11.GL_LINE_STIPPLE),
+            cap("GL_POINT_SMOOTH", GL11.GL_POINT_SMOOTH),
+            cap("GL_POLYGON_STIPPLE", GL11.GL_POLYGON_STIPPLE),
+            cap("GL_INDEX_LOGIC_OP", GL11.GL_INDEX_LOGIC_OP),
+            cap("GL_AUTO_NORMAL", GL11.GL_AUTO_NORMAL),
+            cap("GL_MAP1_COLOR_4", GL11.GL_MAP1_COLOR_4),
+            cap("GL_MAP1_INDEX", GL11.GL_MAP1_INDEX),
+            cap("GL_MAP1_NORMAL", GL11.GL_MAP1_NORMAL),
+            cap("GL_MAP1_TEXTURE_COORD_1", GL11.GL_MAP1_TEXTURE_COORD_1),
+            cap("GL_MAP1_TEXTURE_COORD_2", GL11.GL_MAP1_TEXTURE_COORD_2),
+            cap("GL_MAP1_TEXTURE_COORD_3", GL11.GL_MAP1_TEXTURE_COORD_3),
+            cap("GL_MAP1_TEXTURE_COORD_4", GL11.GL_MAP1_TEXTURE_COORD_4),
+            cap("GL_MAP1_VERTEX_3", GL11.GL_MAP1_VERTEX_3),
+            cap("GL_MAP1_VERTEX_4", GL11.GL_MAP1_VERTEX_4),
+            cap("GL_MAP2_COLOR_4", GL11.GL_MAP2_COLOR_4),
+            cap("GL_MAP2_INDEX", GL11.GL_MAP2_INDEX),
+            cap("GL_MAP2_NORMAL", GL11.GL_MAP2_NORMAL),
+            cap("GL_MAP2_TEXTURE_COORD_1", GL11.GL_MAP2_TEXTURE_COORD_1),
+            cap("GL_MAP2_TEXTURE_COORD_2", GL11.GL_MAP2_TEXTURE_COORD_2),
+            cap("GL_MAP2_TEXTURE_COORD_3", GL11.GL_MAP2_TEXTURE_COORD_3),
+            cap("GL_MAP2_TEXTURE_COORD_4", GL11.GL_MAP2_TEXTURE_COORD_4),
+            cap("GL_MAP2_VERTEX_3", GL11.GL_MAP2_VERTEX_3),
+            cap("GL_MAP2_VERTEX_4", GL11.GL_MAP2_VERTEX_4));
+    }
+
+    private static Arguments cap(String name, int value) {
+        return Arguments.of(name, value);
+    }
+
+    private static void assertNoGlError(String what) {
+        final int error = GL11.glGetError();
+        assertEquals(GL11.GL_NO_ERROR, error, () -> what + " raised 0x" + Integer.toHexString(error));
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("removedCaps")
+    void enableDisableIsCacheOnly(String name, int cap) {
+        try {
+            GLStateManager.glEnable(cap);
+            assertNoGlError("glEnable(" + name + ")");
+            assertTrue(GLStateManager.glIsEnabled(cap), name + " must still round-trip through the cache");
+
+            GLStateManager.glDisable(cap);
+            assertNoGlError("glDisable(" + name + ")");
+            assertFalse(GLStateManager.glIsEnabled(cap));
+        } finally {
+            GLStateManager.glDisable(cap);
+            while (GL11.glGetError() != GL11.GL_NO_ERROR) {}
+        }
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("removedCaps")
+    void pushPopAttribIsCacheOnly(String name, int cap) {
+        try {
+            GLStateManager.glPushAttrib(GL11.GL_ENABLE_BIT);
+            GLStateManager.glEnable(cap);
+            GLStateManager.glPopAttrib();
+            assertNoGlError("glPushAttrib/glEnable(" + name + ")/glPopAttrib");
+            assertFalse(GLStateManager.glIsEnabled(cap));
+        } finally {
+            GLStateManager.glDisable(cap);
+            while (GL11.glGetError() != GL11.GL_NO_ERROR) {}
+        }
+    }
+
+    @Test
+    void displayListReplayIsCacheOnly() {
+        final int list = GLStateManager.glGenLists(1);
+        try {
+            GLStateManager.glNewList(list, GL11.GL_COMPILE);
+            GLStateManager.glEnable(GL11.GL_LINE_STIPPLE);
+            GLStateManager.glLineStipple(2, (short) 0xF0F0);
+            GLStateManager.glDisable(GL11.GL_LINE_STIPPLE);
+            GLStateManager.glEndList();
+            assertNoGlError("display list compile");
+
+            GLStateManager.glCallList(list);
+            assertNoGlError("display list replay");
+        } finally {
+            GLStateManager.glDeleteLists(list, 1);
+            GLStateManager.glDisable(GL11.GL_LINE_STIPPLE);
+            while (GL11.glGetError() != GL11.GL_NO_ERROR) {}
+        }
+    }
+}

--- a/glsm/src/test/java/com/gtnewhorizons/angelica/glsm/GLSM_DeletedBufferBinding_GLTest.java
+++ b/glsm/src/test/java/com/gtnewhorizons/angelica/glsm/GLSM_DeletedBufferBinding_GLTest.java
@@ -1,0 +1,71 @@
+package com.gtnewhorizons.angelica.glsm;
+
+import org.junit.jupiter.api.Test;
+import org.lwjgl.BufferUtils;
+import org.lwjgl.opengl.GL11;
+import org.lwjgl.opengl.GL15;
+import org.lwjgl.opengl.GL21;
+import org.lwjgl.opengl.GL30;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/** Deleting a bound buffer must not strand an id in LWJGL2's StateTracker */
+@GLCompatTest
+public class GLSM_DeletedBufferBinding_GLTest {
+
+    private static int makeBoundBuffer(int target) {
+        final int buffer = GLStateManager.glGenBuffers();
+        GLStateManager.glBindBuffer(target, buffer);
+        GLStateManager.glBufferData(target, 64L, GL15.GL_STREAM_DRAW);
+        return buffer;
+    }
+
+    private static void assertUnboundAfterDelete(int target, int binding, int buffer) {
+        GLStateManager.glDeleteBuffers(buffer);
+        assertEquals(0, GL11.glGetInteger(binding), "GL unbinds a deleted buffer; the cache must not be the only place that knows");
+    }
+
+    @Test
+    void deletedPixelUnpackBufferDoesNotBlockTexImage2D() {
+        final int pbo = makeBoundBuffer(GL21.GL_PIXEL_UNPACK_BUFFER);
+        assertUnboundAfterDelete(GL21.GL_PIXEL_UNPACK_BUFFER, GL21.GL_PIXEL_UNPACK_BUFFER_BINDING, pbo);
+
+        final int tex = GLStateManager.glGenTextures();
+        try {
+            GLStateManager.glBindTexture(GL11.GL_TEXTURE_2D, tex);
+            GLStateManager.glTexImage2D(GL11.GL_TEXTURE_2D, 0, GL11.GL_RGBA8, 1, 1, 0, GL11.GL_RGBA, GL11.GL_UNSIGNED_BYTE, BufferUtils.createByteBuffer(4));
+        } finally {
+            GLStateManager.glDeleteTextures(tex);
+        }
+    }
+
+    @Test
+    void deletedPixelPackBufferDoesNotBlockReadPixels() {
+        final int pbo = makeBoundBuffer(GL21.GL_PIXEL_PACK_BUFFER);
+        assertUnboundAfterDelete(GL21.GL_PIXEL_PACK_BUFFER, GL21.GL_PIXEL_PACK_BUFFER_BINDING, pbo);
+
+        GL11.glReadPixels(0, 0, 1, 1, GL11.GL_RGBA, GL11.GL_UNSIGNED_BYTE, BufferUtils.createByteBuffer(4));
+    }
+
+    @Test
+    void deletedArrayBufferDoesNotBlockClientVertexPointer() {
+        final int vbo = makeBoundBuffer(GL15.GL_ARRAY_BUFFER);
+        assertUnboundAfterDelete(GL15.GL_ARRAY_BUFFER, GL15.GL_ARRAY_BUFFER_BINDING, vbo);
+
+        final int prevVao = GL11.glGetInteger(GL30.GL_VERTEX_ARRAY_BINDING);
+        GL30.glBindVertexArray(0);
+        try {
+            GL11.glVertexPointer(3, 0, BufferUtils.createFloatBuffer(9));
+        } finally {
+            GL30.glBindVertexArray(prevVao);
+        }
+    }
+
+    @Test
+    void deletedElementArrayBufferDoesNotBlockClientDrawElements() {
+        final int ebo = makeBoundBuffer(GL15.GL_ELEMENT_ARRAY_BUFFER);
+        assertUnboundAfterDelete(GL15.GL_ELEMENT_ARRAY_BUFFER, GL15.GL_ELEMENT_ARRAY_BUFFER_BINDING, ebo);
+
+        GL11.glDrawElements(GL11.GL_TRIANGLES, BufferUtils.createIntBuffer(3));
+    }
+}

--- a/glsm/src/test/java/com/gtnewhorizons/angelica/glsm/GLSM_DirtyTracking_UnitTest.java
+++ b/glsm/src/test/java/com/gtnewhorizons/angelica/glsm/GLSM_DirtyTracking_UnitTest.java
@@ -4,7 +4,6 @@ import org.joml.Vector4f;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.lwjgl.opengl.GL11;
 
 import java.nio.ByteBuffer;
@@ -13,7 +12,7 @@ import java.nio.FloatBuffer;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@ExtendWith(GLSMCoreExtension.class)
+@GLCoreTest
 public class GLSM_DirtyTracking_UnitTest {
 
     static final FloatBuffer f4b = ByteBuffer.allocateDirect(4 << 2).order(ByteOrder.nativeOrder()).asFloatBuffer();

--- a/glsm/src/test/java/com/gtnewhorizons/angelica/glsm/GLSM_DisplayList_Batching_Test.java
+++ b/glsm/src/test/java/com/gtnewhorizons/angelica/glsm/GLSM_DisplayList_Batching_Test.java
@@ -6,13 +6,15 @@ import com.gtnewhorizons.angelica.glsm.recording.DisplayListVBO;
 import com.gtnewhorizons.angelica.glsm.recording.GLCommand;
 import it.unimi.dsi.fastutil.ints.Int2IntMap;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.HashSet;
 import java.util.Set;
 
-import static com.gtnewhorizons.angelica.glsm.DisplayListTestHelper.*;
-import static org.junit.jupiter.api.Assertions.*;
+import static com.gtnewhorizons.angelica.glsm.DisplayListTestHelper.createColorDraw;
+import static com.gtnewhorizons.angelica.glsm.DisplayListTestHelper.createDisplayList;
+import static com.gtnewhorizons.angelica.glsm.DisplayListTestHelper.createSimpleDraw;
+import static com.gtnewhorizons.angelica.glsm.DisplayListTestHelper.createTextureDraw;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Tests for display list format-based batching behavior.
@@ -24,7 +26,7 @@ import static org.junit.jupiter.api.Assertions.*;
  *   <li>Different formats produce separate VBOs</li>
  * </ul>
  */
-@ExtendWith(GLSMExtension.class)
+@GLCompatTest
 class GLSM_DisplayList_Batching_Test {
 
     private static int getVBOCount(CompiledDisplayList compiledDisplayList) {

--- a/glsm/src/test/java/com/gtnewhorizons/angelica/glsm/GLSM_DisplayList_FormatOptimization_Test.java
+++ b/glsm/src/test/java/com/gtnewhorizons/angelica/glsm/GLSM_DisplayList_FormatOptimization_Test.java
@@ -2,7 +2,6 @@ package com.gtnewhorizons.angelica.glsm;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.lwjgl.opengl.GL11;
 
 import static com.gtnewhorizons.angelica.util.GLSMUtil.verifyState;
@@ -12,7 +11,7 @@ import static com.gtnewhorizons.angelica.util.GLSMUtil.verifyState;
  * Verifies that display lists work correctly with different vertex attribute combinations
  * and that optimal formats are selected.
  */
-@ExtendWith(GLSMExtension.class)
+@GLCompatTest
 class GLSM_DisplayList_FormatOptimization_Test {
 
     private int displayList = -1;

--- a/glsm/src/test/java/com/gtnewhorizons/angelica/glsm/GLSM_DisplayList_Nesting_Test.java
+++ b/glsm/src/test/java/com/gtnewhorizons/angelica/glsm/GLSM_DisplayList_Nesting_Test.java
@@ -3,7 +3,6 @@ package com.gtnewhorizons.angelica.glsm;
 import org.joml.Matrix4f;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.lwjgl.BufferUtils;
 import org.lwjgl.opengl.GL11;
 
@@ -15,7 +14,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * Tests for nested display list execution.
  * Verifies that child display lists compose correctly with parent transforms.
  */
-@ExtendWith(GLSMExtension.class)
+@GLCompatTest
 class GLSM_DisplayList_Nesting_Test {
 
     private int parentList = -1;

--- a/glsm/src/test/java/com/gtnewhorizons/angelica/glsm/GLSM_DisplayList_PixelStore_Test.java
+++ b/glsm/src/test/java/com/gtnewhorizons/angelica/glsm/GLSM_DisplayList_PixelStore_Test.java
@@ -2,7 +2,6 @@ package com.gtnewhorizons.angelica.glsm;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.lwjgl.opengl.GL11;
 
 import java.nio.ByteBuffer;
@@ -10,7 +9,7 @@ import java.nio.ByteOrder;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@ExtendWith(GLSMCoreExtension.class)
+@GLCoreTest
 public class GLSM_DisplayList_PixelStore_Test {
 
     private static final int SRC = 8;

--- a/glsm/src/test/java/com/gtnewhorizons/angelica/glsm/GLSM_DisplayList_Stress_Test.java
+++ b/glsm/src/test/java/com/gtnewhorizons/angelica/glsm/GLSM_DisplayList_Stress_Test.java
@@ -3,7 +3,6 @@ package com.gtnewhorizons.angelica.glsm;
 import org.joml.Matrix4f;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.lwjgl.BufferUtils;
 import org.lwjgl.opengl.GL11;
 
@@ -23,7 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * need the full Minecraft environment. These tests focus on matrix
  * operations and display list lifecycle which work with raw GL calls.</p>
  */
-@ExtendWith(GLSMExtension.class)
+@GLCompatTest
 class GLSM_DisplayList_Stress_Test {
 
     private final List<Integer> testLists = new ArrayList<>();

--- a/glsm/src/test/java/com/gtnewhorizons/angelica/glsm/GLSM_DisplayList_TransformCollapsing_Test.java
+++ b/glsm/src/test/java/com/gtnewhorizons/angelica/glsm/GLSM_DisplayList_TransformCollapsing_Test.java
@@ -7,7 +7,6 @@ import it.unimi.dsi.fastutil.ints.IntList;
 import org.joml.Matrix4f;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.lwjgl.BufferUtils;
 import org.lwjgl.opengl.GL11;
 
@@ -18,7 +17,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /** Tests for transform collapsing optimization in display lists. */
-@ExtendWith(GLSMExtension.class)
+@GLCompatTest
 class GLSM_DisplayList_TransformCollapsing_Test {
 
     private int testList = -1;

--- a/glsm/src/test/java/com/gtnewhorizons/angelica/glsm/GLSM_DisplayList_UnitTest.java
+++ b/glsm/src/test/java/com/gtnewhorizons/angelica/glsm/GLSM_DisplayList_UnitTest.java
@@ -1,14 +1,12 @@
 package com.gtnewhorizons.angelica.glsm;
 
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.lwjgl.opengl.GL11;
 
 import static com.gtnewhorizons.angelica.util.GLSMUtil.verifyState;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@ExtendWith(GLSMExtension.class)
+@GLCompatTest
 class GLSM_DisplayList_UnitTest {
 
     @Test

--- a/glsm/src/test/java/com/gtnewhorizons/angelica/glsm/GLSM_GLU_UnitTest.java
+++ b/glsm/src/test/java/com/gtnewhorizons/angelica/glsm/GLSM_GLU_UnitTest.java
@@ -2,7 +2,6 @@ package com.gtnewhorizons.angelica.glsm;
 
 import org.joml.Matrix4f;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.lwjgl.BufferUtils;
 import org.lwjgl.opengl.GL11;
 
@@ -14,7 +13,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * Tests that GLStateManager's GLU implementations produce the same matrices as the equivalent JOML operations.
  */
-@ExtendWith(GLSMExtension.class)
+@GLCompatTest
 public class GLSM_GLU_UnitTest {
 
     private static final FloatBuffer buffer = BufferUtils.createFloatBuffer(16);

--- a/glsm/src/test/java/com/gtnewhorizons/angelica/glsm/GLSM_Lighting_UnitTest.java
+++ b/glsm/src/test/java/com/gtnewhorizons/angelica/glsm/GLSM_Lighting_UnitTest.java
@@ -1,7 +1,6 @@
 package com.gtnewhorizons.angelica.glsm;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.GL12;
 
@@ -10,10 +9,10 @@ import java.nio.ByteOrder;
 import java.nio.FloatBuffer;
 
 import static com.gtnewhorizons.angelica.util.GLSMUtil.verifyLightState;
-import static com.gtnewhorizons.angelica.util.GLSMUtil.verifyState;
 import static com.gtnewhorizons.angelica.util.GLSMUtil.verifyMaterialState;
+import static com.gtnewhorizons.angelica.util.GLSMUtil.verifyState;
 
-@ExtendWith(GLSMExtension.class)
+@GLCompatTest
 public class GLSM_Lighting_UnitTest {
 
     static final FloatBuffer f4b = ByteBuffer.allocateDirect(4 << 2).order(ByteOrder.nativeOrder()).asFloatBuffer();

--- a/glsm/src/test/java/com/gtnewhorizons/angelica/glsm/GLSM_LineStipple_GLTest.java
+++ b/glsm/src/test/java/com/gtnewhorizons/angelica/glsm/GLSM_LineStipple_GLTest.java
@@ -1,0 +1,184 @@
+package com.gtnewhorizons.angelica.glsm;
+
+import com.gtnewhorizon.gtnhlib.client.renderer.vertex.VertexFormatElement;
+import com.gtnewhorizons.angelica.glsm.states.ViewportState;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.lwjgl.BufferUtils;
+import org.lwjgl.opengl.GL11;
+import org.lwjgl.opengl.GL15;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.function.IntPredicate;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@GLCoreTest
+public class GLSM_LineStipple_GLTest {
+
+    private static final int W = 32;
+
+    private static final int POSITION_LOC = VertexFormatElement.Usage.POSITION.getAttributeLocation();
+
+    private final ByteBuffer pixels = BufferUtils.createByteBuffer(W * 4);
+    private final ByteBuffer verts = ByteBuffer.allocateDirect(3 * 12).order(ByteOrder.nativeOrder());
+    private int savedX, savedY, savedW, savedH;
+    private int vao, vbo;
+
+    @BeforeEach
+    void setUp() {
+        final ViewportState vp = GLStateManager.getViewportState();
+        savedX = vp.x;
+        savedY = vp.y;
+        savedW = vp.width;
+        savedH = vp.height;
+
+        GLStateManager.glUseProgram(0);
+
+        vao = GLStateManager.glGenVertexArrays();
+        GLStateManager.glBindVertexArray(vao);
+        vbo = GLStateManager.glGenBuffers();
+        GLStateManager.glBindBuffer(GL15.GL_ARRAY_BUFFER, vbo);
+        GLStateManager.glVertexAttribPointer(POSITION_LOC, 3, GL11.GL_FLOAT, false, 12, 0L);
+        GLStateManager.glEnableVertexAttribArray(POSITION_LOC);
+
+        GLStateManager.glViewport(0, 0, W, 1);
+        GLStateManager.glMatrixMode(GL11.GL_PROJECTION);
+        GLStateManager.glPushMatrix();
+        GLStateManager.glLoadIdentity();
+        GLStateManager.glOrtho(0, W, 0, 1, -1, 1);
+        GLStateManager.glMatrixMode(GL11.GL_MODELVIEW);
+        GLStateManager.glPushMatrix();
+        GLStateManager.glLoadIdentity();
+        GLStateManager.glDisable(GL11.GL_DEPTH_TEST);
+        GLStateManager.glDisable(GL11.GL_BLEND);
+        GLStateManager.glDisable(GL11.GL_TEXTURE_2D);
+        GLStateManager.glColor4f(1f, 1f, 1f, 1f);
+    }
+
+    @AfterEach
+    void tearDown() {
+        GLStateManager.glDisable(GL11.GL_LINE_STIPPLE);
+        GLStateManager.glLineStipple(1, (short) 0xFFFF);
+        GLStateManager.glMatrixMode(GL11.GL_PROJECTION);
+        GLStateManager.glPopMatrix();
+        GLStateManager.glMatrixMode(GL11.GL_MODELVIEW);
+        GLStateManager.glPopMatrix();
+        GLStateManager.glViewport(savedX, savedY, savedW, savedH);
+        GLStateManager.glBindVertexArray(0);
+        GLStateManager.glBindBuffer(GL15.GL_ARRAY_BUFFER, 0);
+        if (vbo != 0) GLStateManager.glDeleteBuffers(vbo);
+        if (vao != 0) GLStateManager.glDeleteVertexArrays(vao);
+        while (GL11.glGetError() != GL11.GL_NO_ERROR) {}
+    }
+
+    private boolean[] renderLine(float x0, float x1) {
+        clear();
+        drawLines(x0, x1);
+        return readCoverage();
+    }
+
+    private void drawLines(float... xs) {
+        verts.clear();
+        for (float x : xs) verts.putFloat(x).putFloat(0.5f).putFloat(0f);
+        verts.flip();
+        GLStateManager.glBufferData(GL15.GL_ARRAY_BUFFER, verts, GL15.GL_STREAM_DRAW);
+        GLStateManager.glDrawArrays(xs.length == 2 ? GL11.GL_LINES : GL11.GL_LINE_STRIP, 0, xs.length);
+    }
+
+    private void clear() {
+        GLStateManager.glClearColor(0f, 0f, 0f, 1f);
+        GLStateManager.glClear(GL11.GL_COLOR_BUFFER_BIT);
+    }
+
+    private boolean[] readCoverage() {
+        pixels.clear();
+        GLStateManager.glReadPixels(0, 0, W, 1, GL11.GL_RGBA, GL11.GL_UNSIGNED_BYTE, pixels);
+        assertEquals(GL11.GL_NO_ERROR, GL11.glGetError(), "GL error during readback");
+
+        final boolean[] covered = new boolean[W];
+        for (int i = 0; i < W; i++) {
+            covered[i] = (pixels.get(i * 4) & 0xFF) > 127;
+        }
+        return covered;
+    }
+
+    private static boolean[] expected(IntPredicate on) {
+        final boolean[] e = new boolean[W];
+        for (int i = 0; i < W; i++) e[i] = on.test(i);
+        return e;
+    }
+
+    private static void stipple(int factor, int pattern) {
+        GLStateManager.glEnable(GL11.GL_LINE_STIPPLE);
+        GLStateManager.glLineStipple(factor, (short) pattern);
+    }
+
+    @Test
+    void solidPatternCoversEveryPixel() {
+        stipple(1, 0xFFFF);
+        assertArrayEquals(expected(i -> true), renderLine(0f, W));
+    }
+
+    @Test
+    void emptyPatternCoversNothing() {
+        stipple(1, 0x0000);
+        assertArrayEquals(expected(i -> false), renderLine(0f, W));
+    }
+
+    @Test
+    void alternatingPatternDashesEveryOtherPixel() {
+        stipple(1, 0xAAAA);
+        assertArrayEquals(expected(i -> (i & 1) == 1), renderLine(0f, W));
+    }
+
+    @Test
+    void factorStretchesEachBitAcrossThatManyPixels() {
+        stipple(2, 0xAAAA);
+        assertArrayEquals(expected(i -> ((i / 2) & 1) == 1), renderLine(0f, W));
+    }
+
+    @Test
+    void disabledStippleCoversEveryPixel() {
+        GLStateManager.glLineStipple(1, (short) 0xAAAA);
+        GLStateManager.glDisable(GL11.GL_LINE_STIPPLE);
+        assertArrayEquals(expected(i -> true), renderLine(0f, W));
+    }
+
+    @Test
+    void patternIsAnchoredAtTheSegmentStart() {
+        stipple(1, 0xAAAA);
+        final boolean[] covered = renderLine(8f, W);
+        for (int i = 8; i < W; i++) {
+            assertEquals(((i - 8) & 1) == 1, covered[i], "pixel " + i + " must be phased from x=8, not x=0");
+        }
+    }
+
+    @Test
+    void lineStripRestartsThePatternPerSegment() {
+        stipple(1, 0xAAAA);
+
+        clear();
+        drawLines(0f, 9f, W);
+
+        final boolean[] covered = readCoverage();
+        for (int i = 0; i < 9; i++) {
+            assertEquals((i & 1) == 1, covered[i], "segment 1 pixel " + i);
+        }
+        for (int i = 10; i < W; i++) {
+            assertEquals(((i - 9) & 1) == 1, covered[i], "segment 2 pixel " + i + " must restart the phase at x=9");
+        }
+    }
+
+    @Test
+    void nonStippleDrawAfterStippleIsUnaffected() {
+        stipple(1, 0xAAAA);
+        renderLine(0f, W);
+
+        GLStateManager.glDisable(GL11.GL_LINE_STIPPLE);
+        assertArrayEquals(expected(i -> true), renderLine(0f, W));
+    }
+}

--- a/glsm/src/test/java/com/gtnewhorizons/angelica/glsm/GLSM_MatrixStack_UnitTest.java
+++ b/glsm/src/test/java/com/gtnewhorizons/angelica/glsm/GLSM_MatrixStack_UnitTest.java
@@ -2,7 +2,6 @@ package com.gtnewhorizons.angelica.glsm;
 
 import org.joml.Matrix4f;
 import org.joml.Matrix4fStack;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.lwjgl.BufferUtils;
@@ -12,7 +11,7 @@ import java.nio.FloatBuffer;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@ExtendWith(GLSMExtension.class)
+@GLCompatTest
 public class GLSM_MatrixStack_UnitTest {
 
     final static FloatBuffer buffer = BufferUtils.createFloatBuffer(16);

--- a/glsm/src/test/java/com/gtnewhorizons/angelica/glsm/GLSM_PushPop_UnitTest.java
+++ b/glsm/src/test/java/com/gtnewhorizons/angelica/glsm/GLSM_PushPop_UnitTest.java
@@ -4,7 +4,6 @@ import com.gtnewhorizons.angelica.util.GLBit;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.lwjgl.BufferUtils;
 import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.GL12;
@@ -21,7 +20,7 @@ import static com.gtnewhorizons.angelica.util.GLSMUtil.verifyLightState;
 import static com.gtnewhorizons.angelica.util.GLSMUtil.verifyState;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@ExtendWith(GLSMExtension.class)
+@GLCompatTest
 class GLSM_PushPop_UnitTest {
 
     @BeforeEach

--- a/glsm/src/test/java/com/gtnewhorizons/angelica/glsm/GLSM_ServerSideState_UnitTest.java
+++ b/glsm/src/test/java/com/gtnewhorizons/angelica/glsm/GLSM_ServerSideState_UnitTest.java
@@ -3,7 +3,6 @@ package com.gtnewhorizons.angelica.glsm;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.lwjgl.LWJGLException;
 import org.lwjgl.opengl.Display;
 import org.lwjgl.opengl.GL11;
@@ -15,7 +14,10 @@ import java.nio.ByteBuffer;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Tests for server-side GL state synchronization between SharedDrawable and DrawableGL contexts.
@@ -24,7 +26,7 @@ import static org.junit.jupiter.api.Assertions.*;
  * be properly synchronized in the GLSM cache. Client-side state (texture bindings, active unit)
  * is per-context and should NOT be shared.
  */
-@ExtendWith(GLSMExtension.class)
+@GLCompatTest
 public class GLSM_ServerSideState_UnitTest {
 
     private SharedDrawable sharedDrawable;

--- a/glsm/src/test/java/com/gtnewhorizons/angelica/glsm/GLSM_TextureInfoCache_UnitTest.java
+++ b/glsm/src/test/java/com/gtnewhorizons/angelica/glsm/GLSM_TextureInfoCache_UnitTest.java
@@ -3,20 +3,24 @@ package com.gtnewhorizons.angelica.glsm;
 import com.gtnewhorizons.angelica.glsm.texture.TextureInfo;
 import com.gtnewhorizons.angelica.glsm.texture.TextureInfoCache;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.lwjgl.BufferUtils;
+import org.lwjgl.opengl.EXTTextureCompressionS3TC;
 import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.GL13;
 import org.lwjgl.opengl.GL21;
 import org.lwjgl.opengl.GL30;
-import org.lwjgl.opengl.EXTTextureCompressionS3TC;
 
 import java.lang.reflect.Field;
 import java.nio.ByteBuffer;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@ExtendWith(GLSMExtension.class)
+@GLCompatTest
 public class GLSM_TextureInfoCache_UnitTest {
 
     @Test

--- a/glsm/src/test/java/com/gtnewhorizons/angelica/glsm/GLSM_VAO_UnitTest.java
+++ b/glsm/src/test/java/com/gtnewhorizons/angelica/glsm/GLSM_VAO_UnitTest.java
@@ -5,7 +5,6 @@ import com.gtnewhorizons.angelica.glsm.ffp.VAOManager;
 import com.gtnewhorizons.angelica.util.GLSMUtil;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.GL13;
 import org.lwjgl.opengl.GL15;
@@ -13,7 +12,7 @@ import org.lwjgl.opengl.GL30;
 
 import static com.gtnewhorizons.angelica.util.GLSMUtil.verifyState;
 
-@ExtendWith(GLSMExtension.class)
+@GLCompatTest
 public class GLSM_VAO_UnitTest {
 
     @Test

--- a/glsm/src/test/java/com/gtnewhorizons/angelica/glsm/GLTestTags.java
+++ b/glsm/src/test/java/com/gtnewhorizons/angelica/glsm/GLTestTags.java
@@ -1,0 +1,9 @@
+package com.gtnewhorizons.angelica.glsm;
+
+public final class GLTestTags {
+    public static final String COMPAT = "gl-compat";
+    public static final String CORE = "gl-core";
+    public static final String SHARED = "gl-shared";
+
+    private GLTestTags() {}
+}

--- a/glsm/src/test/java/com/gtnewhorizons/angelica/glsm/ImmediateModeThreadIsolationTest.java
+++ b/glsm/src/test/java/com/gtnewhorizons/angelica/glsm/ImmediateModeThreadIsolationTest.java
@@ -5,7 +5,6 @@ import com.gtnewhorizons.angelica.glsm.recording.CompiledDisplayList;
 import com.gtnewhorizons.angelica.glsm.recording.GLCommand;
 import com.gtnewhorizons.angelica.glsm.recording.ImmediateModeRecorder;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.lwjgl.opengl.GL11;
 
 import java.lang.reflect.Field;
@@ -22,7 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@ExtendWith(GLSMCoreExtension.class)
+@GLCoreTest
 class ImmediateModeThreadIsolationTest {
 
     @Test

--- a/glsm/src/test/java/com/gtnewhorizons/angelica/glsm/InstancedQuadDrawGLTest.java
+++ b/glsm/src/test/java/com/gtnewhorizons/angelica/glsm/InstancedQuadDrawGLTest.java
@@ -3,7 +3,6 @@ package com.gtnewhorizons.angelica.glsm;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.lwjgl.BufferUtils;
 import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.GL15;
@@ -15,7 +14,7 @@ import java.nio.IntBuffer;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
-@ExtendWith(GLSMCoreExtension.class)
+@GLCoreTest
 class InstancedQuadDrawGLTest {
 
     private static final String VS = "#version 330 core\nlayout(location=0) in vec2 aPos;\nvoid main(){ gl_Position = vec4(aPos, 0.0, 1.0); }\n";

--- a/glsm/src/test/java/com/gtnewhorizons/angelica/glsm/SharedDrawableVaoTest.java
+++ b/glsm/src/test/java/com/gtnewhorizons/angelica/glsm/SharedDrawableVaoTest.java
@@ -2,6 +2,7 @@ package com.gtnewhorizons.angelica.glsm;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.lwjgl.LWJGLException;
 import org.lwjgl.opengl.ContextAttribs;
@@ -16,6 +17,7 @@ import org.lwjgl.opengl.SharedDrawable;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
+@Tag(GLTestTags.SHARED)
 class SharedDrawableVaoTest {
 
     private static final String VERT_330 = "#version 330 core\nvoid main() { gl_Position = vec4(0.0); }\n";

--- a/glsm/src/test/java/com/gtnewhorizons/angelica/glsm/VertexAttribDefaultBridgeTest.java
+++ b/glsm/src/test/java/com/gtnewhorizons/angelica/glsm/VertexAttribDefaultBridgeTest.java
@@ -1,7 +1,6 @@
 package com.gtnewhorizons.angelica.glsm;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.lwjgl.BufferUtils;
 import org.lwjgl.opengl.GL13;
 import org.lwjgl.opengl.GL20;
@@ -10,7 +9,7 @@ import java.nio.FloatBuffer;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@ExtendWith(GLSMExtension.class)
+@GLCompatTest
 class VertexAttribDefaultBridgeTest {
 
     private static final int COLOR_ATTRIB = 1;        // VertexFormatElement.Usage.COLOR

--- a/glsm/src/test/java/com/gtnewhorizons/angelica/glsm/ffp/FFPCombineShaderTest.java
+++ b/glsm/src/test/java/com/gtnewhorizons/angelica/glsm/ffp/FFPCombineShaderTest.java
@@ -1,11 +1,10 @@
 package com.gtnewhorizons.angelica.glsm.ffp;
 
-import com.gtnewhorizons.angelica.glsm.GLSMExtension;
+import com.gtnewhorizons.angelica.glsm.GLCompatTest;
 import com.gtnewhorizons.angelica.glsm.GLStateManager;
 import com.gtnewhorizons.angelica.glsm.states.TexEnvState;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -17,13 +16,16 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Stream;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Tests for FFP TexEnv COMBINE / multi-unit features:
  * TexEnvState tracking, FragmentKey packing, FragmentShaderGenerator COMBINE codegen, and glMultiTexCoord routing.
  */
-@ExtendWith(GLSMExtension.class)
+@GLCompatTest
 class FFPCombineShaderTest {
 
     private final List<Integer> shadersToDelete = new ArrayList<>();

--- a/glsm/src/test/java/com/gtnewhorizons/angelica/glsm/ffp/FFPUnboundTextureUnitTest.java
+++ b/glsm/src/test/java/com/gtnewhorizons/angelica/glsm/ffp/FFPUnboundTextureUnitTest.java
@@ -1,10 +1,9 @@
 package com.gtnewhorizons.angelica.glsm.ffp;
 
-import com.gtnewhorizons.angelica.glsm.GLSMCoreExtension;
+import com.gtnewhorizons.angelica.glsm.GLCoreTest;
 import com.gtnewhorizons.angelica.glsm.GLStateManager;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.GL13;
 
@@ -14,7 +13,7 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@ExtendWith(GLSMCoreExtension.class)
+@GLCoreTest
 class FFPUnboundTextureUnitTest {
 
     private final List<Integer> texturesToDelete = new ArrayList<>();

--- a/glsm/src/test/java/com/gtnewhorizons/angelica/glsm/ffp/ProgramUniformTrackingTest.java
+++ b/glsm/src/test/java/com/gtnewhorizons/angelica/glsm/ffp/ProgramUniformTrackingTest.java
@@ -1,16 +1,15 @@
 package com.gtnewhorizons.angelica.glsm.ffp;
 
-import com.gtnewhorizons.angelica.glsm.GLSMCoreExtension;
+import com.gtnewhorizons.angelica.glsm.GLCoreTest;
 import com.gtnewhorizons.angelica.glsm.GLStateManager;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.GL20;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
-@ExtendWith(GLSMCoreExtension.class)
+@GLCoreTest
 class ProgramUniformTrackingTest {
 
     private static Program buildProgram(boolean hasColor) {

--- a/glsm/src/test/java/com/gtnewhorizons/angelica/glsm/recording/RecordingDataStructuresTest.java
+++ b/glsm/src/test/java/com/gtnewhorizons/angelica/glsm/recording/RecordingDataStructuresTest.java
@@ -2,26 +2,24 @@ package com.gtnewhorizons.angelica.glsm.recording;
 
 import com.gtnewhorizon.gtnhlib.client.renderer.DirectTessellator;
 import com.gtnewhorizon.gtnhlib.client.renderer.vertex.DefaultVertexFormat;
-import com.gtnewhorizons.angelica.glsm.GLSMExtension;
 import com.gtnewhorizons.angelica.glsm.DisplayListManager;
+import com.gtnewhorizons.angelica.glsm.GLCompatTest;
 import com.gtnewhorizons.angelica.glsm.GLStateManager;
+import it.unimi.dsi.fastutil.ints.Int2IntMap;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.lwjgl.opengl.GL11;
 
-import it.unimi.dsi.fastutil.ints.Int2IntMap;
-
-import java.nio.ByteBuffer;
-import java.util.Arrays;
-import java.util.List;
-
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Unit tests for display list recording data structures.
  */
-@ExtendWith(GLSMExtension.class)
+@GLCompatTest
 class RecordingDataStructuresTest {
 
     private int testList = -1;

--- a/glsm/src/test/java/com/gtnewhorizons/angelica/glsm/recording/support/DisplayListTestFixture.java
+++ b/glsm/src/test/java/com/gtnewhorizons/angelica/glsm/recording/support/DisplayListTestFixture.java
@@ -2,13 +2,12 @@ package com.gtnewhorizons.angelica.glsm.recording.support;
 
 import com.gtnewhorizon.gtnhlib.bytebuf.MemoryUtilities;
 import com.gtnewhorizons.angelica.glsm.DisplayListManager;
-import com.gtnewhorizons.angelica.glsm.GLSMExtension;
+import com.gtnewhorizons.angelica.glsm.GLCompatTest;
 import com.gtnewhorizons.angelica.glsm.GLStateManager;
 import com.gtnewhorizons.angelica.glsm.recording.CompiledDisplayList;
 import com.gtnewhorizons.angelica.glsm.recording.commands.BatchedIndexedDrawCmd;
 import com.gtnewhorizons.angelica.glsm.recording.commands.IndexedDrawBatch;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.GL15;
 import org.lwjgl.opengl.GL30;
@@ -20,7 +19,7 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-@ExtendWith(GLSMExtension.class)
+@GLCompatTest
 public abstract class DisplayListTestFixture {
 
     public static final float[] DEFAULT_QUAD_POSITIONS = {0f, 0f, 1f, 0f, 1f, 1f, 0f, 1f};

--- a/glsm/src/test/java/com/gtnewhorizons/angelica/glsm/streaming/StreamingBufferTest.java
+++ b/glsm/src/test/java/com/gtnewhorizons/angelica/glsm/streaming/StreamingBufferTest.java
@@ -1,13 +1,12 @@
 package com.gtnewhorizons.angelica.glsm.streaming;
 
-import com.gtnewhorizons.angelica.glsm.GLSMExtension;
+import com.gtnewhorizons.angelica.glsm.GLCompatTest;
 import com.gtnewhorizons.angelica.glsm.RenderSystem;
+import com.gtnewhorizons.angelica.glsm.streaming.StreamingUploader.UploadStrategy;
 import org.junit.jupiter.api.Assumptions;
-import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
-import com.gtnewhorizons.angelica.glsm.streaming.StreamingUploader.UploadStrategy;
-import org.junit.jupiter.api.Test;
 import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.GL15;
 
@@ -15,9 +14,10 @@ import java.nio.ByteBuffer;
 
 import static com.gtnewhorizon.gtnhlib.bytebuf.MemoryUtilities.memAlloc;
 import static com.gtnewhorizon.gtnhlib.bytebuf.MemoryUtilities.memFree;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@ExtendWith(GLSMExtension.class)
+@GLCompatTest
 class StreamingBufferTest {
 
     @ParameterizedTest

--- a/glsm/src/test/java/com/gtnewhorizons/angelica/util/GLSMUtil.java
+++ b/glsm/src/test/java/com/gtnewhorizons/angelica/util/GLSMUtil.java
@@ -9,11 +9,13 @@ import org.lwjgl.opengl.GL13;
 import java.nio.ByteBuffer;
 import java.nio.FloatBuffer;
 import java.nio.IntBuffer;
+import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.IntStream;
 
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 public class GLSMUtil {
@@ -39,7 +41,10 @@ public class GLSMUtil {
         GL11.GL_MAP2_VERTEX_3, GL11.GL_MAP2_VERTEX_4
     };
 
-    private static final Set<Integer> FFP_ONLY_CAPS = Set.of(
+    private static final Set<Integer> FFP_ONLY_CAPS = ffpOnlyCaps();
+
+    private static Set<Integer> ffpOnlyCaps() {
+        final Set<Integer> caps = new HashSet<>(Set.of(
         // Enable/disable caps (BooleanState ffpStateOnly=true)
         GL11.GL_FOG, GL11.GL_ALPHA_TEST, GL11.GL_LIGHTING,
         GL12.GL_RESCALE_NORMAL, GL11.GL_NORMALIZE, GL11.GL_COLOR_MATERIAL,
@@ -68,8 +73,15 @@ public class GLSMUtil {
         // Fog params
         GL11.GL_FOG_COLOR, GL11.GL_FOG_DENSITY,
         GL11.GL_FOG_START, GL11.GL_FOG_END,
-        GL11.GL_FOG_MODE, GL11.GL_FOG_INDEX
-    );
+        GL11.GL_FOG_MODE, GL11.GL_FOG_INDEX,
+        // Also removed from core profile
+        GL11.GL_POINT_SMOOTH, GL11.GL_POLYGON_STIPPLE,
+        GL11.GL_INDEX_LOGIC_OP, GL11.GL_AUTO_NORMAL));
+
+        for (int cap : MAP1_STATES) caps.add(cap);
+        for (int cap : MAP2_STATES) caps.add(cap);
+        return caps;
+    }
 
     private static boolean isFFPOnly(int glCap) {
         return FFP_ONLY_CAPS.contains(glCap);
@@ -81,7 +93,10 @@ public class GLSMUtil {
 
     public static void verifyIsEnabled(int glCap, boolean expected, String message) {
         if (isFFPOnly(glCap)) {
-            assertEquals(expected, GLStateManager.glIsEnabled(glCap), message + " - GLSM State Mismatch");
+            assertAll(message,
+                () -> assertFalse(GL11.glIsEnabled(glCap), "GL State Mismatch - cache-only cap reached the driver"),
+                () -> assertEquals(expected, GLStateManager.glIsEnabled(glCap), "GLSM State Mismatch")
+            );
         } else {
             assertAll(message,
                 () -> assertEquals(expected, GL11.glIsEnabled(glCap), "GL State Mismatch"),
@@ -96,7 +111,10 @@ public class GLSMUtil {
 
     public static void verifyState(int glCap, boolean expected, String message) {
         if (isFFPOnly(glCap)) {
-            assertEquals(expected, GLStateManager.glGetBoolean(glCap), message + " - GLSM State Mismatch");
+            assertAll(message,
+                () -> assertFalse(GL11.glGetBoolean(glCap), "GL State Mismatch - cache-only cap reached the driver"),
+                () -> assertEquals(expected, GLStateManager.glGetBoolean(glCap), "GLSM State Mismatch")
+            );
         } else {
             assertAll(message,
                 () -> assertEquals(expected, GL11.glGetBoolean(glCap), "GL State Mismatch"),


### PR DESCRIPTION
Properly handle flags removed in core
* Better Compat vs Core test identification
* Guard against lwjgl2 buffer checks
* Emulate LINE STRIPPLE while we're at it

Xaeros was calling check GL Error and crashing due to an invalid enum.  BetterQuesting was setting GL_LINE_STRIPPLE which isn't valid in core.

(probably) Fixes https://github.com/GTNewHorizons/Angelica/issues/1755

