### PR TITLE
fix(DisplayListVBO): guard against null VAO and zero-count draw during display list replay

### DIFF
--- a/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/recording/DisplayListVBO.java
+++ b/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/recording/DisplayListVBO.java
@@ -62,10 +62,13 @@ public final class DisplayListVBO {
         }
 
         public void render() {
-            vao.bind();
-            vao.draw(drawMode, start, count);
-            vao.unbind();
+        if (vao == null) return;
+        vao.bind();
+        if (count <= 0) { vao.unbind(); return; }
+        vao.draw(drawMode, start, count);
+        vao.unbind();
         }
+
 
         public IVertexArrayObject getVAO() {
             return vao;


### PR DESCRIPTION
# Description of your *PR* and other info
Fixes a JVM crash (EXCEPTION_ACCESS_VIOLATION inside nvoglv64.dll) when rendering AE2 Crafting CPU Monitors. The NVIDIA driver tried to read vertex data from a null pointer during glDrawElements called from a display list replay.
The root cause: SubVBO.render() was called with either a null vao (stale/empty display list) or count <= 0 (Tessellator with no vertices), passing an invalid buffer reference to the driver.
Added two guards in SubVBO.render():
- if (vao == null) return; — skip draw if VAO was never created
- if (count <= 0) { vao.unbind(); return; } — skip draw if there are no vertices to render

Closes #1662
Closes #1478

### Before submitting a *pull request* make sure you have:
- [X] Read the [AI Contribution Policy](https://github.com/GTNewHorizons/Angelica/blob/master/AI_POLICY.md)
- [X] At least [skimmed](https://github.com/GTNewHorizons/Angelica/search?q=is%3Apr&type=Issues) the tracker for similar pull requests

</details>
