### PR TITLE
RenderChunkEvent for fluxloading to avoid mixin

### DIFF
--- a/src/main/java/com/gtnewhorizons/angelica/event/RenderChunkEvent.java
+++ b/src/main/java/com/gtnewhorizons/angelica/event/RenderChunkEvent.java
@@ -1,0 +1,15 @@
+package com.gtnewhorizons.angelica.event;
+
+import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.RecordEvent;
+
+public class RenderChunkEvent implements RecordEvent {
+    public static final EventBus<RenderChunkEvent> BUS = EventBus.create(RenderChunkEvent.class);
+
+    private static final RenderChunkEvent INSTANCE = new RenderChunkEvent();
+
+    public static void post() {
+        if (!BUS.hasListeners()) return;
+        BUS.post(INSTANCE);
+    }
+}

--- a/src/mixin/java/com/gtnewhorizons/angelica/mixins/early/celeritas/terrain/MixinRenderGlobal.java
+++ b/src/mixin/java/com/gtnewhorizons/angelica/mixins/early/celeritas/terrain/MixinRenderGlobal.java
@@ -2,6 +2,7 @@ package com.gtnewhorizons.angelica.mixins.early.celeritas.terrain;
 
 import com.gtnewhorizons.angelica.compat.mojang.Camera;
 import com.gtnewhorizons.angelica.compat.mojang.GameModeUtil;
+import com.gtnewhorizons.angelica.event.RenderChunkEvent;
 import com.gtnewhorizons.angelica.glsm.GLStateManager;
 import com.gtnewhorizons.angelica.mixins.interfaces.IRenderGlobalExt;
 import com.gtnewhorizons.angelica.rendering.AngelicaRenderQueue;
@@ -164,6 +165,7 @@ public class MixinRenderGlobal implements IRenderGlobalExt {
             } else {
                 mc.mcProfiler.endStartSection("draw_chunk_layer_translucent");
                 this.celeritas$renderer.drawChunkLayer(BlockRenderLayer.TRANSLUCENT, camX, camY, camZ);
+                RenderChunkEvent.post();
             }
         } finally {
             RenderDevice.exitManagedCode();


### PR DESCRIPTION
# feat: RenderChunkEvent
<!-- Please include a summary of the change -->
Adds a RenderChunkEvent to celeritas to avoid mixing into Angelica in fluxloading

Related mixin being replaced with an event [here](https://github.com/Midnight145/FluxLoading-1.7.10/blob/1.7.10/src/main/java/com/tttsaurus/fluxloading/mixin/late/MixinCeleritasWorldRenderer.java).

Let me know if there's a better spot to throw the event, I didn't _see_ one anywhere, but I'm not positive.
<!-- Any details that you think are important to review this PR? -->
<!-- Are there any Issues / PRs related to this one? -->

<!-- Add a screenshot or a video demonstration for new features -->

<details open><summary>Template</summary> <!-- OPEN is intentional -->

### Before submitting a *pull request* make sure you have:
- [x] Read the [AI Contribution Policy](https://github.com/GTNewHorizons/Angelica/blob/master/AI_POLICY.md)
- [x] At least [skimmed](https://github.com/GTNewHorizons/Angelica/search?q=is%3Apr&type=Issues) the tracker for similar pull requests

</details>
