### PR TITLE
Fix Mekanism crash when it cast chunkTileEntityMap to HashMap

### DIFF
--- a/src/main/java/com/gtnewhorizons/angelica/utils/ConcurrentTileEntityMap.java
+++ b/src/main/java/com/gtnewhorizons/angelica/utils/ConcurrentTileEntityMap.java
@@ -7,6 +7,7 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.ChunkPosition;
 
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -16,8 +17,9 @@ import java.util.function.Consumer;
 /**
  * Thread-safe wrapper around a tile entity map for chunkTileEntityMap.
  * May wrap either a plain Object2ObjectOpenHashMap (vanilla) or a ColumnTileEntityMap (cubic chunks).
+ * Extends HashMap for binary compatibility with mods that cast chunkTileEntityMap to HashMap.
  */
-public class ConcurrentTileEntityMap implements Map<ChunkPosition, TileEntity> {
+public class ConcurrentTileEntityMap extends HashMap<ChunkPosition, TileEntity> {
     private final Object2ObjectOpenHashMap<ChunkPosition, TileEntity> flatDelegate;
     private final Map<ChunkPosition, TileEntity> delegate;
     private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();


### PR DESCRIPTION
# Fix Mekanism crash
<!-- Please include a summary of the change -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there any Issues / PRs related to this one? -->

Client will crash when trying to load/generate a world with Mekanism and angelica with the following crash log:

```
[01:47:05] [Server thread/ERROR]: Exception caught during firing event net.minecraftforge.event.world.ChunkEvent$Load@137754cd:
java.lang.ClassCastException: com.gtnewhorizons.angelica.utils.ConcurrentTileEntityMap cannot be cast to java.util.HashMap
	at mekanism.common.Mekanism.onChunkLoad(Mekanism.java:1461) ~[Mekanism.class:?]
```

For this problem "ConcurrentTileEntityMap cannot be cast to HashMap", this PR made these changes in file `com/gtnewhorizons/angelica/utils/ConcurrentTileEntityMap.java`:

1. Add `import java.util.HashMap;`
2. changed `implements Map<ChunkPosition, TileEntity>` to `extends HashMap<ChunkPosition, TileEntity>`.

Which resolves the crash in my testing.

<!-- Add a screenshot or a video demonstration for new features -->

<details open><summary>Template</summary> <!-- OPEN is intentional -->

### Before submitting a *pull request* make sure you have:
- [x] Read the [AI Contribution Policy](https://github.com/GTNewHorizons/Angelica/blob/master/AI_POLICY.md)
- [x] At least [skimmed](https://github.com/GTNewHorizons/Angelica/search?q=is%3Apr&type=Issues) the tracker for similar pull requests

</details>
