### PR TITLE
Remove dead getCharWidth ModifyConstant

### DIFF
--- a/src/mixin/java/com/gtnewhorizons/angelica/mixins/early/angelica/fontrenderer/MixinFontRenderer.java
+++ b/src/mixin/java/com/gtnewhorizons/angelica/mixins/early/angelica/fontrenderer/MixinFontRenderer.java
@@ -20,9 +20,7 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Constant;
 import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.ModifyConstant;
 import org.spongepowered.asm.mixin.injection.ModifyVariable;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
@@ -193,11 +191,6 @@ public abstract class MixinFontRenderer implements FontRendererAccessor, IFontPa
 
     @Override
     public void angelica$bindTexture(ResourceLocation location) { this.bindTexture(location); }
-
-    @ModifyConstant(method = "getCharWidth", constant = @Constant(intValue = 7))
-    private int angelica$maxCharWidth(int original) {
-        return Integer.MAX_VALUE;
-    }
 
     @Inject(method = "getCharWidth", at = @At("HEAD"), cancellable = true)
     public void getCharWidth(char c, CallbackInfoReturnable<Integer> cir) {


### PR DESCRIPTION
# Description of your *PR* and other info
The @ModifyConstant that disabled the vanilla `if (k > 7)` glyph width clamp, added in #1011, has been unreachable since the custom font rework in #1017: getCharWidth is now fully replaced by an @Inject at HEAD returning getCharWidthFine, so the vanilla body never executes and the patched constant is never reached.

No behaviour change. FontProviderUnicode.getXAdvance computes widths without the clamp, matching what #1011 produced for every possible glyph_sizes.bin byte value.

Verified in game with a font whose glyphs use end columns above 7, where the clamp would be visible.

### Before submitting a *pull request* make sure you have:
- [X] Read the [AI Contribution Policy](https://github.com/GTNewHorizons/Angelica/blob/master/AI_POLICY.md)
- [ ] At least [skimmed](https://github.com/GTNewHorizons/Angelica/search?q=is%3Apr&type=Issues) the tracker for similar pull requests