### PR TITLE
Do not concat strings from `glCallList` when debug is off

### DIFF
--- a/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/GLDebug.java
+++ b/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/GLDebug.java
@@ -572,6 +572,15 @@ public final class GLDebug {
         }
     }
 
+    /**
+     * Overload that lets you gate the String concat behind the debugState
+     */
+    public static void pushGroup(String prefix, int value) {
+        if (debugState != null && Thread.currentThread() == GLStateManager.getMainThread()) {
+            debugState.pushGroup(prefix + value);
+        }
+    }
+
     public static void pushGroup(String group) {
         if (debugState != null && Thread.currentThread() == GLStateManager.getMainThread()) {
             debugState.pushGroup(group);

--- a/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/GLStateManager.java
+++ b/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/GLStateManager.java
@@ -3329,7 +3329,7 @@ public class GLStateManager {
     }
 
     public static void glCallList(int list) {
-        GLDebug.pushGroup("glCallList " + list);
+        GLDebug.pushGroup("glCallList ", list);
         try {
             DisplayListManager.glCallList(list);
         } finally {


### PR DESCRIPTION
# Description of your *PR* and other info
Only do string concat when debug is on for the `glCallList` method is used.

I was trying to understand why all my arcane bores were so heavy in memory allocations, and apparently it's all because of that string concat:
<img width="1237" height="679" alt="image" src="https://github.com/user-attachments/assets/053f3725-f294-48d6-92a5-41c5d97b733a" />

When removed, the problem disappears itself. 

<!-- Add a screenshot or a video demonstration for new features -->

<details open><summary>Template</summary> <!-- OPEN is intentional -->

### Before submitting a *pull request* make sure you have:
- [x] Read the [AI Contribution Policy](https://github.com/GTNewHorizons/Angelica/blob/master/AI_POLICY.md)
- [x] At least [skimmed](https://github.com/GTNewHorizons/Angelica/search?q=is%3Apr&type=Issues) the tracker for similar pull requests

</details>
