### PR TITLE
Fix compat for the original battlegear 2

### DIFF
--- a/src/main/java/com/gtnewhorizons/angelica/compat/ModStatus.java
+++ b/src/main/java/com/gtnewhorizons/angelica/compat/ModStatus.java
@@ -24,6 +24,7 @@ public class ModStatus {
     public static boolean isXaerosMinimapLoaded;
     public static boolean isHoloInventoryLoaded;
     public static boolean isBattlegearLoaded;
+    public static boolean isNHBattlegearLoaded;
     public static boolean isBackhandLoaded;
     public static boolean isThaumcraftLoaded;
     public static boolean isThaumicHorizonsLoaded;
@@ -46,7 +47,6 @@ public class ModStatus {
         isChunkAPILoaded = Loader.isModLoaded("chunkapi");
         isXaerosMinimapLoaded = Loader.isModLoaded("XaeroMinimap");
         isHoloInventoryLoaded = Loader.isModLoaded("holoinventory");
-        isBattlegearLoaded = Loader.isModLoaded("battlegear2");
         isThaumcraftLoaded = Loader.isModLoaded("Thaumcraft");
         isThaumicHorizonsLoaded = Loader.isModLoaded("ThaumicHorizons");
         isBaublesLoaded = Loader.isModLoaded("Baubles");
@@ -58,12 +58,16 @@ public class ModStatus {
         isHoloInventoryLoaded = Loader.isModLoaded("holoinventory");
         isBOPLoaded = Loader.isModLoaded("BiomesOPlenty");
 
-        // remove compat with original release of BG2
-        if (isBattlegearLoaded){
-            isBattlegearLoaded = new DefaultArtifactVersion("1.2.0")
-                .compareTo(
-                    LoadControllerHelper.getOwningMod(Battlegear.class).getProcessedVersion()
-                ) <= 0;
+        // Angelica's compat relies on GTNH extensions, so this should only be true for NH Battlegear2, 1.2.0+
+        if (Loader.isModLoaded("battlegear2")) {
+            // Don't ask me why battlegear2 reports as 1.7.10, I don't know
+            final var OG_BG2_VER = new DefaultArtifactVersion("1.7.10");
+            final var NH_BG2_VER = new DefaultArtifactVersion("1.2.0");
+
+            @SuppressWarnings("DataFlowIssue")
+            var battlegearVersion = LoadControllerHelper.getOwningMod(Battlegear.class).getProcessedVersion();
+            // We can be sure the NH version will never be 1.7.10, because that garbage got archived.
+            isBattlegearLoaded = battlegearVersion.compareTo(OG_BG2_VER) != 0 && battlegearVersion.compareTo(NH_BG2_VER) >= 0;
         }
 
         isNEIDMetadataExtended = false;

--- a/src/main/java/com/gtnewhorizons/angelica/compat/ModStatus.java
+++ b/src/main/java/com/gtnewhorizons/angelica/compat/ModStatus.java
@@ -24,7 +24,6 @@ public class ModStatus {
     public static boolean isXaerosMinimapLoaded;
     public static boolean isHoloInventoryLoaded;
     public static boolean isBattlegearLoaded;
-    public static boolean isNHBattlegearLoaded;
     public static boolean isBackhandLoaded;
     public static boolean isThaumcraftLoaded;
     public static boolean isThaumicHorizonsLoaded;

--- a/src/main/java/com/gtnewhorizons/angelica/dynamiclights/DynamicLights.java
+++ b/src/main/java/com/gtnewhorizons/angelica/dynamiclights/DynamicLights.java
@@ -620,8 +620,7 @@ public class DynamicLights {
                     if (offhand != null) {
                         luminance = Math.max(luminance, getLuminanceFromItemStack(offhand));
                     }
-                }
-                else if (ModStatus.isBackhandLoaded){
+                } else if (ModStatus.isBackhandLoaded){
                     final ItemStack offhand = BackhandReflectionCompat.getOffhandItem(player);
                     if (offhand != null) {
                         luminance = Math.max(luminance, getLuminanceFromItemStack(offhand));


### PR DESCRIPTION
# Description of your *PR* and other info
The original battlegear 2 reports it's verison as `1.7.10`, which is unfortunately higher than the required `1.2.0` for compat with Dynamic Lights. This adds a special case to detect that and disable the compat, so we don't crash with the original mod.

Fixes #1508 

<details open><summary>Template</summary> <!-- OPEN is intentional -->

### Before submitting a *pull request* make sure you have:
- [x] Read the [AI Contribution Policy](https://github.com/GTNewHorizons/Angelica/blob/master/AI_POLICY.md)
- [x] At least [skimmed](https://github.com/GTNewHorizons/Angelica/search?q=is%3Apr&type=Issues) the tracker for similar pull requests

</details>
