### PR TITLE
Synchronize CubicChunks tile entity mutations

### DIFF
--- a/src/main/java/com/gtnewhorizons/angelica/mixins/Mixins.java
+++ b/src/main/java/com/gtnewhorizons/angelica/mixins/Mixins.java
@@ -395,6 +395,12 @@ public enum Mixins implements IMixins {
         )
     ),
 
+    CELERITAS_CUBIC_CHUNKS(new MixinBuilder()
+        .setPhase(Phase.EARLY)
+        .addRequiredMod(TargetedMod.CUBIC_CHUNKS)
+        .addClientMixins("celeritas.terrain.MixinCubicChunksCube")
+    ),
+
     CELERITAS_COLORED_LIGHT(new MixinBuilder("Colored light infrastructure for celeritas light pipeline")
         .setPhase(Phase.EARLY)
         .setApplyIf(() -> {

--- a/src/main/java/com/gtnewhorizons/angelica/mixins/TargetedMod.java
+++ b/src/main/java/com/gtnewhorizons/angelica/mixins/TargetedMod.java
@@ -12,6 +12,7 @@ public enum TargetedMod implements ITargetMod {
     CAMPFIRE_BACKPORT(null, "campfirebackport"),
     CHISEL(null, "chisel"),
     COFHCORE( "cofh.asm.LoadingPlugin", "CoFHCore"),
+    CUBIC_CHUNKS("com.cardinalstar.cubicchunks.asm.coremod.CubicChunksCoreMod", "cubicchunks"),
     DYNAMIC_SURROUNDINGS_MIST("org.blockartistry.mod.DynSurround.mixinplugin.DynamicSurroundingsEarlyMixins", "dsurround"),
     DYNAMIC_SURROUNDINGS_ORIGINAL("org.blockartistry.mod.DynSurround.asm.TransformLoader", "dsurround"),
     DRAGON_API("Reika.DragonAPI.Auxiliary.DragonAPIASMHandler", "DragonAPI"),

--- a/src/mixin/java/com/gtnewhorizons/angelica/mixins/early/celeritas/terrain/MixinCubicChunksCube.java
+++ b/src/mixin/java/com/gtnewhorizons/angelica/mixins/early/celeritas/terrain/MixinCubicChunksCube.java
@@ -1,0 +1,30 @@
+package com.gtnewhorizons.angelica.mixins.early.celeritas.terrain;
+
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.world.chunk.Chunk;
+
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Pseudo;
+import org.spongepowered.asm.mixin.Shadow;
+
+import com.gtnewhorizons.angelica.mixins.interfaces.IChunkTileEntityMapHolder;
+import com.gtnewhorizons.angelica.utils.ConcurrentTileEntityMap;
+
+import com.llamalad7.mixinextras.injector.wrapmethod.WrapMethod;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+
+@Pseudo
+@Mixin(targets = "com.cardinalstar.cubicchunks.world.cube.Cube", remap = false)
+public abstract class MixinCubicChunksCube {
+
+    @Final
+    @Shadow(remap = false)
+    private Chunk column;
+
+    @WrapMethod(method = "setBlockTileEntityInChunk")
+    private void angelica$lockTileEntityMutation(int x, int y, int z, TileEntity tileEntity, Operation<Void> original) {
+        ConcurrentTileEntityMap tileEntities = ((IChunkTileEntityMapHolder) column).angelica$getConcurrentTEMap();
+        tileEntities.withWriteLock(() -> original.call(x, y, z, tileEntity));
+    }
+}


### PR DESCRIPTION
Fixed potential ConcurrentModificationException with CubicChunks. Angelica locks the ColumnTileEntityMap while copying tile entities for render snapshots, but CubicChunks directly modifies the underlying cubeTileEntityMap without taking the same lock. Cube tile entity mutations now use the column map's write lock.

@DarkShadow44 