### PR TITLE
Use bound texture instead of hardcoded vanilla textures for cached vanilla model rendering

### DIFF
--- a/src/main/java/com/gtnewhorizons/angelica/mixins/Mixins.java
+++ b/src/main/java/com/gtnewhorizons/angelica/mixins/Mixins.java
@@ -159,6 +159,7 @@ public enum Mixins implements IMixins {
         .setApplyIf(() -> AngelicaConfig.enableTESRChestCache)
         .addClientMixins(
             "angelica.tesr.MixinTileEntityChestRenderer",
+            "angelica.tesr.MixinTileEntityChestRenderer_BindTexture",
             "angelica.tesr.MixinTileEntityEnderChestRenderer"
         )
     ),

--- a/src/mixin/java/com/gtnewhorizons/angelica/mixins/early/angelica/tesr/MixinTileEntityChestRenderer.java
+++ b/src/mixin/java/com/gtnewhorizons/angelica/mixins/early/angelica/tesr/MixinTileEntityChestRenderer.java
@@ -2,6 +2,7 @@ package com.gtnewhorizons.angelica.mixins.early.angelica.tesr;
 
 import com.gtnewhorizons.angelica.config.AngelicaConfig;
 import com.gtnewhorizons.angelica.rendering.tesr.VanillaModelMeshes;
+import com.llamalad7.mixinextras.injector.wrapmethod.WrapMethod;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import com.llamalad7.mixinextras.sugar.Local;
@@ -10,21 +11,22 @@ import net.minecraft.client.model.ModelLargeChest;
 import net.minecraft.client.renderer.tileentity.TileEntityChestRenderer;
 import net.minecraft.tileentity.TileEntityChest;
 import net.minecraft.util.ResourceLocation;
-import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Dynamic;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 
 @Mixin(TileEntityChestRenderer.class)
 public abstract class MixinTileEntityChestRenderer {
+    @Unique
+    private ResourceLocation angelica$lastBoundTexture = null;
 
-    @Shadow @Final private static ResourceLocation field_147507_b; // trapped_double
-    @Shadow @Final private static ResourceLocation field_147508_c; // christmas_double
-    @Shadow @Final private static ResourceLocation field_147505_d; // normal_double
-    @Shadow @Final private static ResourceLocation field_147506_e; // trapped
-    @Shadow @Final private static ResourceLocation field_147503_f; // christmas
-    @Shadow @Final private static ResourceLocation field_147504_g; // normal
-    @Shadow private boolean field_147509_j; // Christmas season flag
+    @Dynamic(mixin = MixinTileEntityChestRenderer_BindTexture.class)
+    @WrapMethod(method = "bindTexture(Lnet/minecraft/util/ResourceLocation;)V", require = 1)
+    private void angelica$storeBoundTexture(ResourceLocation resourceLocation, Operation<Void> original) {
+        this.angelica$lastBoundTexture = resourceLocation;
+        original.call(resourceLocation);
+    }
 
     @WrapOperation(method = "renderTileEntityAt(Lnet/minecraft/tileentity/TileEntityChest;DDDF)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/model/ModelChest;renderAll()V"))
     private void angelica$cachedRenderAll(ModelChest model, Operation<Void> original, @Local(argsOnly = true) TileEntityChest chest) {
@@ -33,10 +35,8 @@ public abstract class MixinTileEntityChestRenderer {
             return;
         }
         final boolean isDouble = model instanceof ModelLargeChest;
-        final boolean trapped = chest.func_145980_j() == 1;
-        final ResourceLocation texture = isDouble
-            ? (trapped ? field_147507_b : field_147509_j ? field_147508_c : field_147505_d)
-            : (trapped ? field_147506_e : field_147509_j ? field_147503_f : field_147504_g);
-        VanillaModelMeshes.renderChest(model, texture, isDouble);
+        if (angelica$lastBoundTexture != null) {
+            VanillaModelMeshes.renderChest(model, angelica$lastBoundTexture, isDouble);
+        }
     }
 }

--- a/src/mixin/java/com/gtnewhorizons/angelica/mixins/early/angelica/tesr/MixinTileEntityChestRenderer_BindTexture.java
+++ b/src/mixin/java/com/gtnewhorizons/angelica/mixins/early/angelica/tesr/MixinTileEntityChestRenderer_BindTexture.java
@@ -1,0 +1,19 @@
+package com.gtnewhorizons.angelica.mixins.early.angelica.tesr;
+
+import net.minecraft.client.renderer.tileentity.TileEntityChestRenderer;
+import net.minecraft.client.renderer.tileentity.TileEntityEnderChestRenderer;
+import net.minecraft.client.renderer.tileentity.TileEntitySpecialRenderer;
+import net.minecraft.util.ResourceLocation;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+
+@Mixin(value = { TileEntityChestRenderer.class, TileEntityEnderChestRenderer.class }, priority = 100)
+public abstract class MixinTileEntityChestRenderer_BindTexture extends TileEntitySpecialRenderer {
+    // this just provides a default override of bindTexture that other mixins can mixin into
+    // in a way that makes it compatible, even if a mixin like this is applied multiple times
+    @Unique
+    @Override
+    protected void bindTexture(ResourceLocation resourceLocation) {
+        super.bindTexture(resourceLocation);
+    }
+}

--- a/src/mixin/java/com/gtnewhorizons/angelica/mixins/early/angelica/tesr/MixinTileEntityEnderChestRenderer.java
+++ b/src/mixin/java/com/gtnewhorizons/angelica/mixins/early/angelica/tesr/MixinTileEntityEnderChestRenderer.java
@@ -2,6 +2,7 @@ package com.gtnewhorizons.angelica.mixins.early.angelica.tesr;
 
 import com.gtnewhorizons.angelica.config.AngelicaConfig;
 import com.gtnewhorizons.angelica.rendering.tesr.VanillaModelMeshes;
+import com.llamalad7.mixinextras.injector.wrapmethod.WrapMethod;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import com.llamalad7.mixinextras.sugar.Local;
@@ -9,15 +10,22 @@ import net.minecraft.client.model.ModelChest;
 import net.minecraft.client.renderer.tileentity.TileEntityEnderChestRenderer;
 import net.minecraft.tileentity.TileEntityEnderChest;
 import net.minecraft.util.ResourceLocation;
-import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Dynamic;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 
 @Mixin(TileEntityEnderChestRenderer.class)
 public abstract class MixinTileEntityEnderChestRenderer {
+    @Unique
+    private ResourceLocation angelica$lastBoundTexture = null;
 
-    @Shadow @Final private static ResourceLocation field_147520_b; // ender
+    @Dynamic(mixin = MixinTileEntityChestRenderer_BindTexture.class)
+    @WrapMethod(method = "bindTexture(Lnet/minecraft/util/ResourceLocation;)V", require = 1)
+    private void angelica$storeBoundTexture(ResourceLocation resourceLocation, Operation<Void> original) {
+        this.angelica$lastBoundTexture = resourceLocation;
+        original.call(resourceLocation);
+    }
 
     @WrapOperation(method = "renderTileEntityAt(Lnet/minecraft/tileentity/TileEntityEnderChest;DDDF)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/model/ModelChest;renderAll()V"))
     private void angelica$cachedRenderAll(ModelChest model, Operation<Void> original, @Local(argsOnly = true) TileEntityEnderChest chest) {
@@ -25,6 +33,8 @@ public abstract class MixinTileEntityEnderChestRenderer {
             original.call(model);
             return;
         }
-        VanillaModelMeshes.renderChest(model, field_147520_b, false);
+        if (angelica$lastBoundTexture != null) {
+            VanillaModelMeshes.renderChest(model, angelica$lastBoundTexture, false);
+        }
     }
 }


### PR DESCRIPTION
# Description of your *PR* and other info
<!-- Please include a summary of the change -->
<!-- Any details that you think are important to review this PR? -->
This is mainly to fix chest TESR caching for modded chests that extend the vanilla TESR. The way it worked before, it would just use the vanilla textures for the modded blocks. Now it just uses the last texture bound in the TESR.
<!-- Are there any Issues / PRs related to this one? -->

<!-- Add a screenshot or a video demonstration for new features -->

<details open><summary>Template</summary> <!-- OPEN is intentional -->

### Before submitting a *pull request* make sure you have:
- [x] Read the [AI Contribution Policy](https://github.com/GTNewHorizons/Angelica/blob/master/AI_POLICY.md)
- [x] At least [skimmed](https://github.com/GTNewHorizons/Angelica/search?q=is%3Apr&type=Issues) the tracker for similar pull requests

</details>
