### PR TITLE
Warm-up the video option GUI for performance

### DIFF
--- a/src/main/java/com/gtnewhorizons/angelica/proxy/ClientProxy.java
+++ b/src/main/java/com/gtnewhorizons/angelica/proxy/ClientProxy.java
@@ -13,6 +13,7 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiMainMenu;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.client.gui.GuiVideoSettings;
+import net.minecraft.client.gui.ScaledResolution;
 import net.minecraft.client.network.NetHandlerPlayClient;
 import net.minecraft.server.integrated.IntegratedServer;
 import net.minecraft.util.Direction;
@@ -355,6 +356,7 @@ public final class ClientProxy extends CommonProxy {
     }
 
     private float gameStartTime = -1;
+    private boolean videoOptionsWarmedUp;
 
     @SubscribeEvent(priority = EventPriority.LOWEST)
     public void onGuiOpen(GuiOpenEvent event) {
@@ -366,6 +368,14 @@ public final class ClientProxy extends CommonProxy {
 
             // force reset zoom when a GUI is opened
             if (AngelicaConfig.enableZoom && event.gui != null) Zoom.resetZoom();
+        }
+    }
+
+    @SubscribeEvent
+    public void onMainMenuInit(GuiScreenEvent.InitGuiEvent.Post event) {
+        if (event.gui instanceof GuiMainMenu && !videoOptionsWarmedUp) {
+            warmupVideoOptions();
+            videoOptionsWarmedUp = true;
         }
     }
 
@@ -402,6 +412,26 @@ public final class ClientProxy extends CommonProxy {
         if (event.phase == TickEvent.Phase.END && mc.theWorld != null) {
             CloudRenderer.getCloudRenderer().checkSettings();
         }
+    }
+
+    private void warmupVideoOptions() {
+        final GuiScreen videoOptions;
+        if (AngelicaConfig.enableNotFineOptions) {
+            videoOptions = new GuiCustomMenu(
+                    null,
+                    NotFineGameOptionPages.general(),
+                    NotFineGameOptionPages.detail(),
+                    NotFineGameOptionPages.atmosphere(),
+                    NotFineGameOptionPages.particles(),
+                    NotFineGameOptionPages.other());
+        } else if (!AngelicaConfig.enableReesesSodiumOptions) {
+            videoOptions = new SodiumOptionsGUI(null);
+        } else {
+            videoOptions = new ReeseSodiumVideoOptionsScreen(null);
+        }
+
+        final ScaledResolution resolution = new ScaledResolution(mc, mc.displayWidth, mc.displayHeight);
+        videoOptions.setWorldAndResolution(mc, resolution.getScaledWidth(), resolution.getScaledHeight());
     }
 
     // This only disables FOV changes from vanilla, leaving mod FOV changes untouched


### PR DESCRIPTION
Preloads the GUIs to provide a smooth transition when selecting 'Video Options' instead of waiting 2-3 seconds when selecting it for the first time.

NOT FIXED VERSION

https://github.com/user-attachments/assets/3f5948da-d512-4dd7-87f5-bdc5350c01b5

FIXED VERSION

https://github.com/user-attachments/assets/ae9c8f25-6c87-42c2-82ee-87c28b02fa8e


<details open><summary>Template</summary> <!-- OPEN is intentional -->

### Before submitting a *pull request* make sure you have:
- [x] Read the [AI Contribution Policy](https://github.com/GTNewHorizons/Angelica/blob/master/AI_POLICY.md)
- [x] At least [skimmed](https://github.com/GTNewHorizons/Angelica/search?q=is%3Apr&type=Issues) the tracker for similar pull requests

</details>
