### PR TITLE
Fix some CTM Allocations 

### DIFF
--- a/src/main/java/com/prupe/mcpatcher/ctm/CTMUtils.java
+++ b/src/main/java/com/prupe/mcpatcher/ctm/CTMUtils.java
@@ -71,7 +71,7 @@ public class CTMUtils {
     }
 
     public static void clearCurrentCompact() {
-        CURRENT_COMPACT.remove();
+        CURRENT_COMPACT.set(null);
     }
 
     private static final StampedLock lock = new StampedLock();


### PR DESCRIPTION
# Description of your *PR* and other info
<!-- Please include a summary of the change -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there any Issues / PRs related to this one? -->
I was tracking down memory allocations in GT's block rendering and i saw that threadlocals repeatedly got recreated. Since the threadlocal data here is lazily fed, i made it so it nulls the data instead of removing the threadlocal from the pool.

Tested in daily 694 and no issue visible.
<!-- Add a screenshot or a video demonstration for new features -->

<details open><summary>Template</summary> <!-- OPEN is intentional -->

### Before submitting a *pull request* make sure you have:
- [x] Read the [AI Contribution Policy](https://github.com/GTNewHorizons/Angelica/blob/master/AI_POLICY.md)
- [x] At least [skimmed](https://github.com/GTNewHorizons/Angelica/search?q=is%3Apr&type=Issues) the tracker for similar pull requests

</details>
