### PR TITLE
Add Secondary Color Support to Angelica

### DIFF
--- a/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/DisplayListManager.java
+++ b/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/DisplayListManager.java
@@ -307,6 +307,11 @@ public class DisplayListManager {
         }
     }
 
+    public static void recordSecondaryColor(float r, float g, float b) {
+        drawBarrier();
+        currentRecorder.writeSecondaryColor(r, g, b);
+    }
+
     public static void recordColorMask(boolean r, boolean g, boolean b, boolean a) {
         drawBarrier();
         currentRecorder.writeColorMask(r, g, b, a);

--- a/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/Feature.java
+++ b/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/Feature.java
@@ -199,6 +199,7 @@ public class Feature {
         ));
         attribToFeatures.put(GL11.GL_FOG_BIT, ImmutableSet.of(
               GLStateManager.getFogMode()
+            , GLStateManager.getColorSumState()
             , GLStateManager.getFogState()
                                        // ^^ Fog density
                                        // ^^ Linear fog start

--- a/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/Feature.java
+++ b/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/Feature.java
@@ -99,6 +99,7 @@ public class Feature {
         ));
         attribToFeatures.put(GL11.GL_CURRENT_BIT, ImmutableSet.of(
               GLStateManager.getColor()
+            , GLStateManager.getSecondaryColor() // Current secondary color
             , ShaderManager.getNormalStack()    // Current normal vector
             , ShaderManager.getTexCoordStack()  // Current texture coordinates
             // Current color index
@@ -122,6 +123,7 @@ public class Feature {
             , GLStateManager.getBlendMode()
             , GLStateManager.getColorLogicOpState()
             , GLStateManager.getColorMaterial()
+            , GLStateManager.getColorSumState()
             , GLStateManager.getCullState()
             , GLStateManager.getDepthTest()
             , GLStateManager.getDitherState()

--- a/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/GLContextState.java
+++ b/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/GLContextState.java
@@ -185,7 +185,7 @@ class GLContextState {
     public final int[] clientAttribSavedVertexFlags = new int[GLStateManager.CLIENT_ATTRIB_STACK_DEPTH];
     public int clientAttribStackPointer = 0;
     public final boolean[] restoreUnitChanged = new boolean[GLStateManager.MAX_TEXTURE_UNITS];
-    public boolean restoreDepthChanged, restoreBlendChanged, restoreColorMaskChanged, restoreClearColorChanged, restoreDrawBufferChanged, restoreLogicOpChanged, restoreStencilChanged, restoreViewportChanged, restoreLineChanged, restorePointChanged, restorePolygonChanged, restoreActiveUnitChanged;
+    public boolean restoreDepthChanged, restoreBlendChanged, restoreColorMaskChanged, restoreClearColorChanged, restoreDrawBufferChanged, restoreLogicOpChanged, restoreStencilChanged, restoreViewportChanged, restoreLineChanged, restorePointChanged, restorePolygonChanged, restoreActiveUnitChanged, restoreSecondaryColorChanged;
     public final BlendState vanillaBlendBefore = new BlendState();
     public final BlendState vanillaBlendAfter = new BlendState();
     public boolean vanillaBlendEnabledBefore;

--- a/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/GLContextState.java
+++ b/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/GLContextState.java
@@ -31,6 +31,7 @@ import org.lwjgl.BufferUtils;
 import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.GL12;
 import org.lwjgl.opengl.GL13;
+import org.lwjgl.opengl.GL14;
 
 import java.nio.DoubleBuffer;
 import java.nio.FloatBuffer;
@@ -104,6 +105,9 @@ class GLContextState {
     public final FogStateStack fogState = new FogStateStack();
     public final BooleanStateStack fogMode = track(new BooleanStateStack(GL11.GL_FOG, false, true));
     public final Color4Stack color = new Color4Stack();
+    // GL_CURRENT_SECONDARY_COLOR - alpha is always 1 and unused, the color sum only adds RGB
+    public final Color4Stack secondaryColor = new Color4Stack(new Color4(0.0F, 0.0F, 0.0F, 1.0F));
+    public final BooleanStateStack colorSumState = track(new BooleanStateStack(GL14.GL_COLOR_SUM, false, true));
     public final Color4Stack clearColor = new Color4Stack(new Color4(0.0F, 0.0F, 0.0F, 0.0F));
     public final ColorMaskStack colorMask = new ColorMaskStack();
     public final IntegerStateStack drawBuffer = new IntegerStateStack(GLStateManager.DEFAULT_DRAW_BUFFER);

--- a/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/GLStateManager.java
+++ b/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/GLStateManager.java
@@ -504,6 +504,7 @@ public class GLStateManager {
             .addFeature(GL11.GL_COLOR_WRITEMASK)
             .addFeature(GL11.GL_CURRENT_COLOR)
             .addFeature(GL11.GL_CURRENT_NORMAL)
+            .addFeature(GL14.GL_CURRENT_SECONDARY_COLOR)
             .addFeature(GL11.GL_CURRENT_RASTER_COLOR)
             .addFeature(GL11.GL_CURRENT_RASTER_POSITION)
             .addFeature(GL11.GL_CURRENT_RASTER_TEXTURE_COORDS)
@@ -659,6 +660,7 @@ public class GLStateManager {
             case GL11.GL_BLEND -> enableBlend();
             case GL11.GL_COLOR_MATERIAL -> enableColorMaterial();
             case GL11.GL_COLOR_LOGIC_OP -> glCtx.colorLogicOpState.enable();
+            case GL14.GL_COLOR_SUM -> glCtx.colorSumState.enable();
             case GL11.GL_CULL_FACE -> enableCull();
             case GL11.GL_DEPTH_TEST -> enableDepthTest();
             case GL11.GL_DITHER -> glCtx.ditherState.enable();
@@ -740,6 +742,7 @@ public class GLStateManager {
             case GL11.GL_BLEND -> disableBlend();
             case GL11.GL_COLOR_MATERIAL -> disableColorMaterial();
             case GL11.GL_COLOR_LOGIC_OP -> glCtx.colorLogicOpState.disable();
+            case GL14.GL_COLOR_SUM -> glCtx.colorSumState.disable();
             case GL11.GL_CULL_FACE -> disableCull();
             case GL11.GL_DEPTH_TEST -> disableDepthTest();
             case GL11.GL_DITHER -> glCtx.ditherState.disable();
@@ -815,6 +818,7 @@ public class GLStateManager {
             case GL11.GL_BLEND -> glCtx.blendMode.isEnabled();
             case GL11.GL_COLOR_MATERIAL -> glCtx.colorMaterial.isEnabled();
             case GL11.GL_COLOR_LOGIC_OP -> glCtx.colorLogicOpState.isEnabled();
+            case GL14.GL_COLOR_SUM -> glCtx.colorSumState.isEnabled();
             case GL11.GL_CULL_FACE -> glCtx.cullState.isEnabled();
             case GL11.GL_DEPTH_TEST -> glCtx.depthTest.isEnabled();
             case GL11.GL_DITHER -> glCtx.ditherState.isEnabled();
@@ -890,6 +894,7 @@ public class GLStateManager {
             case GL11.GL_BLEND -> glCtx.blendMode.isEnabled();
             case GL11.GL_COLOR_MATERIAL -> glCtx.colorMaterial.isEnabled();
             case GL11.GL_COLOR_LOGIC_OP -> glCtx.colorLogicOpState.isEnabled();
+            case GL14.GL_COLOR_SUM -> glCtx.colorSumState.isEnabled();
             case GL11.GL_CULL_FACE -> glCtx.cullState.isEnabled();
             case GL11.GL_DEPTH_TEST -> glCtx.depthTest.isEnabled();
             case GL11.GL_DEPTH_WRITEMASK -> glCtx.depthState.isEnabled();
@@ -1133,6 +1138,7 @@ public class GLStateManager {
             case GL11.GL_TEXTURE_MATRIX -> glCtx.textures.getTextureUnitMatrix(getActiveTextureUnit()).get(0, params);
             case GL11.GL_COLOR_CLEAR_VALUE -> glCtx.clearColor.get(params);
             case GL11.GL_CURRENT_COLOR -> glCtx.color.get(params);
+            case GL14.GL_CURRENT_SECONDARY_COLOR -> glCtx.secondaryColor.get(params);
             case GL11.GL_DEPTH_RANGE -> {
                 final int pos = params.position();
                 params.put(pos, (float) glCtx.viewportState.depthRangeNear);
@@ -1231,7 +1237,7 @@ public class GLStateManager {
             }
             case GL11.GL_MODELVIEW_MATRIX, GL11.GL_PROJECTION_MATRIX, GL11.GL_TEXTURE_MATRIX -> widenFromFloat(pname, params, 16);
             case GL11.GL_COLOR_CLEAR_VALUE, GL11.GL_CURRENT_COLOR, GL11.GL_CURRENT_TEXTURE_COORDS, GL11.GL_FOG_COLOR,
-                GL11.GL_LIGHT_MODEL_AMBIENT, GL14.GL_BLEND_COLOR -> widenFromFloat(pname, params, 4);
+                GL11.GL_LIGHT_MODEL_AMBIENT, GL14.GL_BLEND_COLOR, GL14.GL_CURRENT_SECONDARY_COLOR -> widenFromFloat(pname, params, 4);
             case GL11.GL_CURRENT_NORMAL -> widenFromFloat(pname, params, 3);
             default -> {
                 if (!HAS_MULTIPLE_SET.contains(pname)) {
@@ -1752,6 +1758,40 @@ public class GLStateManager {
             return true;
         }
         return false;
+    }
+
+    public static void glSecondaryColor3f(float red, float green, float blue) {
+        final RecordMode mode = DisplayListManager.getRecordMode();
+        if (mode != RecordMode.NONE) {
+            DisplayListManager.recordSecondaryColor(red, green, blue);
+            if (mode == RecordMode.COMPILE) {
+                return;
+            }
+        }
+        changeSecondaryColor(red, green, blue);
+    }
+
+    public static void glSecondaryColor3d(double red, double green, double blue) {
+        glSecondaryColor3f((float) red, (float) green, (float) blue);
+    }
+
+    public static void glSecondaryColor3b(byte red, byte green, byte blue) {
+        glSecondaryColor3f(b2f(red), b2f(green), b2f(blue));
+    }
+
+    public static void glSecondaryColor3ub(byte red, byte green, byte blue) {
+        glSecondaryColor3f(ub2f(red), ub2f(green), ub2f(blue));
+    }
+
+    /** Helper for glSecondaryColor* - the color sum is emulated by the FFP shaders, nothing is sent to the driver. */
+    private static void changeSecondaryColor(float red, float green, float blue) {
+        final GLContextState glCtx = ctx();
+        if (!isCachingEnabled() || red != glCtx.secondaryColor.getRed() || green != glCtx.secondaryColor.getGreen() || blue != glCtx.secondaryColor.getBlue()) {
+            glCtx.secondaryColor.setRed(red);
+            glCtx.secondaryColor.setGreen(green);
+            glCtx.secondaryColor.setBlue(blue);
+            glCtx.fragmentGeneration++;
+        }
     }
 
     private static final Color4 DirtyColor = new Color4(-1.0F, -1.0F, -1.0F, -1.0F);
@@ -3832,6 +3872,8 @@ public class GLStateManager {
                 ShaderManager.bumpTexCoordGeneration();
                 glCtx.dirtyTexCoordAttrib = true;
             }
+            // The secondary color is a fragment stage uniform, not a vertex attribute
+            if (glCtx.fragmentGeneration != glCtx.savedFragmentGen[depth]) glCtx.fragmentGeneration++;
         }
 
         postVanillaBlendChangeIfMoved(blendSnapshotted);
@@ -7409,6 +7451,14 @@ public class GLStateManager {
 
     public static Color4Stack getColor() {
         return ctx().color;
+    }
+
+    public static Color4Stack getSecondaryColor() {
+        return ctx().secondaryColor;
+    }
+
+    public static BooleanStateStack getColorSumState() {
+        return ctx().colorSumState;
     }
 
     public static Color4Stack getClearColor() {

--- a/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/GLStateManager.java
+++ b/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/GLStateManager.java
@@ -3696,6 +3696,9 @@ public class GLStateManager {
             glCtx.restoreDrawBufferChanged = glCtx.drawBuffer.topChanged();
             glCtx.restoreLogicOpChanged = glCtx.logicOpMode.topChanged();
         }
+        if ((mask & GL11.GL_CURRENT_BIT) != 0) {
+            glCtx.restoreSecondaryColorChanged = glCtx.secondaryColor.topChanged();
+        }
         if ((mask & GL11.GL_STENCIL_BUFFER_BIT) != 0) {
             glCtx.restoreStencilChanged = glCtx.stencilState.topChanged();
         }
@@ -3873,7 +3876,7 @@ public class GLStateManager {
                 glCtx.dirtyTexCoordAttrib = true;
             }
             // The secondary color is a fragment stage uniform, not a vertex attribute
-            if (glCtx.fragmentGeneration != glCtx.savedFragmentGen[depth]) glCtx.fragmentGeneration++;
+            if (glCtx.restoreSecondaryColorChanged) glCtx.fragmentGeneration++;
         }
 
         postVanillaBlendChangeIfMoved(blendSnapshotted);

--- a/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/ffp/FFPUniformBlock.java
+++ b/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/ffp/FFPUniformBlock.java
@@ -103,6 +103,7 @@ public final class FFPUniformBlock {
     public static final int TEX_ENV_COLOR_2 = vec4("u_TexEnvColor2");
     public static final int TEX_ENV_COLOR_3 = vec4("u_TexEnvColor3");
     public static final int OVERLAY_COLOR = vec4("u_OverlayColor");
+    public static final int SECONDARY_COLOR = vec3("u_SecondaryColor");
     public static final int FOG_PARAMS = vec4("u_FogParams");
     public static final int FOG_COLOR = vec4("u_FogColor");
 

--- a/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/ffp/FragmentKey.java
+++ b/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/ffp/FragmentKey.java
@@ -131,15 +131,12 @@ public final class FragmentKey {
             global |= (1L << BIT_LINE_STIPPLE);
         }
 
-        // Color sum - adds the current secondary color on top of the texture stage output
-        if (GLStateManager.getColorSumState().isEnabled()) {
-            global |= (1L << BIT_COLOR_SUM);
-        }
-
-        // Separate specular
+        // Separate specular / color sum
         if (GLStateManager.getLightingState().isEnabled()
             && GLStateManager.getLightModel().colorControl == GL12.GL_SEPARATE_SPECULAR_COLOR) {
             global |= (1L << BIT_SEPARATE_SPECULAR);
+        } else if (GLStateManager.getColorSumState().isEnabled()) {
+            global |= (1L << BIT_COLOR_SUM);
         }
 
         // Per-unit state

--- a/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/ffp/FragmentKey.java
+++ b/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/ffp/FragmentKey.java
@@ -12,7 +12,7 @@ import org.lwjgl.opengl.GL13;
  * Packed-long fragment shader permutation key for FFP emulation.
  *
  * Layout:
- *   long[0]: global bits (12) + unit 0 (47 bits at offset 12)
+ *   long[0]: global bits (13) + unit 0 (47 bits at offset 13)
  *   long[1..3]: unit 1..3 (47 bits each, low-aligned)
  * Only max(1, nrEnabledUnits) longs are significant.
  *
@@ -63,7 +63,7 @@ public final class FragmentKey {
     public static final int FOG_EXP    = 2;
     public static final int FOG_EXP2   = 3;
 
-    private static final int GLOBAL_BITS = 12;
+    private static final int GLOBAL_BITS = 13;
     private static final int BIT_FOG_MODE          = 0;  // 2 bits
     private static final int BIT_ALPHA_TEST        = 2;  // 1 bit
     private static final int BIT_ALPHA_FUNC        = 3;  // 3 bits
@@ -71,6 +71,7 @@ public final class FragmentKey {
     private static final int BIT_NR_ENABLED_UNITS  = 7;  // 3 bits
     private static final int BIT_OVERLAY_ENABLED   = 10; // 1 bit
     private static final int BIT_LINE_STIPPLE      = 11; // 1 bit
+    private static final int BIT_COLOR_SUM         = 12; // 1 bit
 
     private static final int U_ENABLED         = 0;
     private static final int U_MODE            = 1;   // 3 bits
@@ -128,6 +129,11 @@ public final class FragmentKey {
 
         if (GLStateManager.lineStippleActive) {
             global |= (1L << BIT_LINE_STIPPLE);
+        }
+
+        // Color sum - adds the current secondary color on top of the texture stage output
+        if (GLStateManager.getColorSumState().isEnabled()) {
+            global |= (1L << BIT_COLOR_SUM);
         }
 
         // Separate specular
@@ -238,6 +244,7 @@ public final class FragmentKey {
     public boolean alphaTestEnabled() { return ((packed[0] >> BIT_ALPHA_TEST) & 1) != 0; }
     public int alphaTestFunc()        { return (int) ((packed[0] >> BIT_ALPHA_FUNC) & 0x7); }
     public boolean separateSpecular() { return ((packed[0] >> BIT_SEPARATE_SPECULAR) & 1) != 0; }
+    public boolean colorSum()         { return ((packed[0] >> BIT_COLOR_SUM) & 1) != 0; }
     public boolean lineStipple()      { return ((packed[0] >> BIT_LINE_STIPPLE) & 1) != 0; }
     public int nrEnabledUnits()       { return (int) ((packed[0] >> BIT_NR_ENABLED_UNITS) & 0x7); }
     public boolean overlayEnabled()   { return ((packed[0] >> BIT_OVERLAY_ENABLED) & 1) != 0; }
@@ -374,10 +381,10 @@ public final class FragmentKey {
             default -> "?";
         };
         final StringBuilder sb = new StringBuilder();
-        sb.append(String.format("FFPFragmentKey[fog=%s alpha=%b(%s) specSep=%b overlay=%b units=%d",
+        sb.append(String.format("FFPFragmentKey[fog=%s alpha=%b(%s) specSep=%b colorSum=%b overlay=%b units=%d",
             fogName, alphaTestEnabled(),
             alphaTestEnabled() ? String.format("0x%04X", decodeAlphaFunc(alphaTestFunc())) : "-",
-            separateSpecular(), overlayEnabled(), nrEnabledUnits()));
+            separateSpecular(), colorSum(), overlayEnabled(), nrEnabledUnits()));
         for (int i = 0; i < nrEnabledUnits(); i++) {
             if (!unitEnabled(i)) {
                 sb.append(String.format(" u%d=OFF", i));

--- a/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/ffp/FragmentShaderGenerator.java
+++ b/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/ffp/FragmentShaderGenerator.java
@@ -276,6 +276,10 @@ public final class FragmentShaderGenerator {
             sb.append("  // Add separate specular\n");
             sb.append("  color.rgb += v_SpecularColor;\n");
         }
+        if (key.colorSum()) {
+            sb.append("  // Color sum - GL_COLOR_SUM with the current secondary color\n");
+            sb.append("  color.rgb += u_SecondaryColor;\n");
+        }
     }
 
     private static void emitAlphaTest(StringBuilder sb, FragmentKey key) {

--- a/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/ffp/Uniforms.java
+++ b/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/ffp/Uniforms.java
@@ -331,6 +331,9 @@ public class Uniforms {
             GLStateManager.getOverlayR(), GLStateManager.getOverlayG(),
             GLStateManager.getOverlayB(), GLStateManager.getOverlayA());
 
+        final var secondary = GLStateManager.getSecondaryColor();
+        putVec3(FFPUniformBlock.SECONDARY_COLOR, secondary.getRed(), secondary.getGreen(), secondary.getBlue());
+
         // Mesa STATE_FOG_PARAMS_OPTIMIZED
         final FogState fog = GLStateManager.getFogState();
         final float start = fog.getStart();

--- a/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/recording/CommandBufferExecutor.java
+++ b/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/recording/CommandBufferExecutor.java
@@ -274,6 +274,13 @@ public final class CommandBufferExecutor {
                     ptr += 16;
                     GLStateManager.glColor4f(r, g, b, a);
                 }
+                case GLCommand.SECONDARY_COLOR -> {
+                    final float r = memGetFloat(ptr);
+                    final float g = memGetFloat(ptr + 4);
+                    final float b = memGetFloat(ptr + 8);
+                    ptr += 12;
+                    GLStateManager.glSecondaryColor3f(r, g, b);
+                }
                 case GLCommand.CLEAR_COLOR -> {
                     final float r = memGetFloat(ptr);
                     final float g = memGetFloat(ptr + 4);

--- a/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/recording/CommandRecorder.java
+++ b/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/recording/CommandRecorder.java
@@ -356,6 +356,14 @@ public final class CommandRecorder {
         writeFloat(a);
     }
 
+    public void writeSecondaryColor(float r, float g, float b) {
+        ensureCapacity(16);
+        writeInt(GLCommand.SECONDARY_COLOR);
+        writeFloat(r);
+        writeFloat(g);
+        writeFloat(b);
+    }
+
     public void writeClearColor(float r, float g, float b, float a) {
         ensureCapacity(20);
         writeInt(GLCommand.CLEAR_COLOR);

--- a/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/recording/GLCommand.java
+++ b/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/recording/GLCommand.java
@@ -61,6 +61,7 @@ public final class GLCommand {
     public static final int COLOR = 54;              // [cmd:4][r:4f][g:4f][b:4f][a:4f]
     public static final int CLEAR_COLOR = 55;        // [cmd:4][r:4f][g:4f][b:4f][a:4f]
     public static final int BLEND_COLOR = 56;        // [cmd:4][r:4f][g:4f][b:4f][a:4f]
+    public static final int SECONDARY_COLOR = 57;    // [cmd:4][r:4f][g:4f][b:4f]
 
     // === Mixed int+float commands ===
     public static final int ALPHA_FUNC = 60;         // [cmd:4][func:4][ref:4f]
@@ -155,6 +156,7 @@ public final class GLCommand {
             case COLOR -> "COLOR";
             case CLEAR_COLOR -> "CLEAR_COLOR";
             case BLEND_COLOR -> "BLEND_COLOR";
+            case SECONDARY_COLOR -> "SECONDARY_COLOR";
             case ALPHA_FUNC -> "ALPHA_FUNC";
             case FOGF -> "FOGF";
             case LIGHTF -> "LIGHTF";
@@ -211,7 +213,7 @@ public final class GLCommand {
             // Three int commands (16 bytes)
             case GLCommand.STENCIL_FUNC, GLCommand.STENCIL_OP, GLCommand.TEX_PARAMETERI,
                  GLCommand.LIGHTF, GLCommand.LIGHTI,
-                 GLCommand.MATERIALF, GLCommand.TEX_PARAMETERF -> 16;
+                 GLCommand.MATERIALF, GLCommand.TEX_PARAMETERF, GLCommand.SECONDARY_COLOR -> 16;
 
             // Four int commands (20 bytes)
             case GLCommand.VIEWPORT, GLCommand.BLEND_FUNC, GLCommand.COLOR_MASK,

--- a/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/redirect/GLSMRedirector.java
+++ b/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/redirect/GLSMRedirector.java
@@ -403,7 +403,12 @@ public class GLSMRedirector {
             .add("glBlendEquation")
             .add("glMultiDrawArrays")
             .add("glPointParameterf")
-            .add("glPointParameteri");
+            .add("glPointParameteri")
+            // Removed in core profile - emulated by the FFP shaders, calling through would abort the JVM
+            .add("glSecondaryColor3f")
+            .add("glSecondaryColor3d")
+            .add("glSecondaryColor3b")
+            .add("glSecondaryColor3ub");
         final var gl15 = RedirectMap.newMap()
             .add("glGenBuffers")
             .add("glBindBuffer")

--- a/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/redirect/GLSMRedirector.java
+++ b/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/redirect/GLSMRedirector.java
@@ -142,6 +142,7 @@ public class GLSMRedirector {
     private static final String GLU = "org/lwjgl/util/glu/GLU";
     private static final String OpenGlHelper = "net/minecraft/client/renderer/OpenGlHelper";
     private static final String EXTBlendFunc = "org/lwjgl/opengl/EXTBlendFuncSeparate";
+    private static final String EXTSecondaryColor = "org/lwjgl/opengl/EXTSecondaryColor";
     private static final String ARBMultiTexture = "org/lwjgl/opengl/ARBMultitexture";
     private static final String ARBShaderObjects = "org/lwjgl/opengl/ARBShaderObjects";
     private static final String ARBInstancedArrays = "org/lwjgl/opengl/ARBInstancedArrays";
@@ -594,6 +595,11 @@ public class GLSMRedirector {
             .add("isFramebufferEnabled")
         );
         methodRedirects.put(EXTBlendFunc, RedirectMap.newMap().add("glBlendFuncSeparateEXT", "tryBlendFuncSeparate"));
+        methodRedirects.put(EXTSecondaryColor, RedirectMap.newMap()
+            .add("glSecondaryColor3bEXT", "glSecondaryColor3b")
+            .add("glSecondaryColor3fEXT", "glSecondaryColor3f")
+            .add("glSecondaryColor3dEXT", "glSecondaryColor3d")
+            .add("glSecondaryColor3ubEXT", "glSecondaryColor3ub"));
 
         // ARB
         methodRedirects.put(ARBMultiTexture, RedirectMap.newMap()

--- a/glsm/src/test/java/com/gtnewhorizons/angelica/glsm/GLSM_CoreRemovedCaps_GLTest.java
+++ b/glsm/src/test/java/com/gtnewhorizons/angelica/glsm/GLSM_CoreRemovedCaps_GLTest.java
@@ -50,6 +50,14 @@ public class GLSM_CoreRemovedCaps_GLTest {
         return Arguments.of(name, value);
     }
 
+    private static void assertSecondaryColor(float red, float green, float blue) {
+        final FloatBuffer params = BufferUtils.createFloatBuffer(4);
+        GLStateManager.glGetFloat(GL14.GL_CURRENT_SECONDARY_COLOR, params);
+        assertEquals(red, params.get(0), "red must round-trip through the cache");
+        assertEquals(green, params.get(1), "green must round-trip through the cache");
+        assertEquals(blue, params.get(2), "blue must round-trip through the cache");
+    }
+
     private static void assertNoGlError(String what) {
         final int error = GL11.glGetError();
         assertEquals(GL11.GL_NO_ERROR, error, () -> what + " raised 0x" + Integer.toHexString(error));
@@ -89,16 +97,12 @@ public class GLSM_CoreRemovedCaps_GLTest {
 
     @Test
     void secondaryColorIsCacheOnly() {
-        final FloatBuffer params = BufferUtils.createFloatBuffer(4);
         try {
             // Calling through to the driver here aborts the JVM in a core profile - the color sum is emulated by the FFP shaders
             GLStateManager.glSecondaryColor3f(0.25F, 0.5F, 0.75F);
             assertNoGlError("glSecondaryColor3f");
 
-            GLStateManager.glGetFloat(GL14.GL_CURRENT_SECONDARY_COLOR, params);
-            assertEquals(0.25F, params.get(0), "red must round-trip through the cache");
-            assertEquals(0.5F, params.get(1), "green must round-trip through the cache");
-            assertEquals(0.75F, params.get(2), "blue must round-trip through the cache");
+            assertSecondaryColor(0.25F, 0.5F, 0.75F);
         } finally {
             GLStateManager.glSecondaryColor3f(0.0F, 0.0F, 0.0F);
             while (GL11.glGetError() != GL11.GL_NO_ERROR) {}
@@ -107,7 +111,6 @@ public class GLSM_CoreRemovedCaps_GLTest {
 
     @Test
     void secondaryColorIsRestoredByPopAttrib() {
-        final FloatBuffer params = BufferUtils.createFloatBuffer(4);
         try {
             GLStateManager.glSecondaryColor3f(0.125F, 0.25F, 0.375F);
             GLStateManager.glPushAttrib(GL11.GL_CURRENT_BIT);
@@ -115,11 +118,43 @@ public class GLSM_CoreRemovedCaps_GLTest {
             GLStateManager.glPopAttrib();
             assertNoGlError("glPushAttrib/glSecondaryColor3f/glPopAttrib");
 
-            GLStateManager.glGetFloat(GL14.GL_CURRENT_SECONDARY_COLOR, params);
-            assertEquals(0.125F, params.get(0));
-            assertEquals(0.25F, params.get(1));
-            assertEquals(0.375F, params.get(2));
+            assertSecondaryColor(0.125F, 0.25F, 0.375F);
         } finally {
+            GLStateManager.glSecondaryColor3f(0.0F, 0.0F, 0.0F);
+            while (GL11.glGetError() != GL11.GL_NO_ERROR) {}
+        }
+    }
+
+    @Test
+    void colorSumIsRestoredByFogBitPopAttrib() {
+        try {
+            GLStateManager.glPushAttrib(GL11.GL_FOG_BIT);
+            GLStateManager.glEnable(GL14.GL_COLOR_SUM);
+            GLStateManager.glPopAttrib();
+            assertNoGlError("glPushAttrib(GL_FOG_BIT)/glEnable(GL_COLOR_SUM)/glPopAttrib");
+            assertFalse(GLStateManager.glIsEnabled(GL14.GL_COLOR_SUM));
+        } finally {
+            GLStateManager.glDisable(GL14.GL_COLOR_SUM);
+            while (GL11.glGetError() != GL11.GL_NO_ERROR) {}
+        }
+    }
+
+    @Test
+    void secondaryColorReplaysFromDisplayList() {
+        final int list = GLStateManager.glGenLists(1);
+        try {
+            GLStateManager.glNewList(list, GL11.GL_COMPILE);
+            GLStateManager.glSecondaryColor3f(0.5F, 0.625F, 0.75F);
+            GLStateManager.glEndList();
+            assertNoGlError("glSecondaryColor3f display list compile");
+
+            GLStateManager.glSecondaryColor3f(0.0F, 0.0F, 0.0F);
+            GLStateManager.glCallList(list);
+            assertNoGlError("glSecondaryColor3f display list replay");
+
+            assertSecondaryColor(0.5F, 0.625F, 0.75F);
+        } finally {
+            GLStateManager.glDeleteLists(list, 1);
             GLStateManager.glSecondaryColor3f(0.0F, 0.0F, 0.0F);
             while (GL11.glGetError() != GL11.GL_NO_ERROR) {}
         }

--- a/glsm/src/test/java/com/gtnewhorizons/angelica/glsm/GLSM_CoreRemovedCaps_GLTest.java
+++ b/glsm/src/test/java/com/gtnewhorizons/angelica/glsm/GLSM_CoreRemovedCaps_GLTest.java
@@ -4,8 +4,11 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.lwjgl.BufferUtils;
 import org.lwjgl.opengl.GL11;
+import org.lwjgl.opengl.GL14;
 
+import java.nio.FloatBuffer;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -22,6 +25,7 @@ public class GLSM_CoreRemovedCaps_GLTest {
             cap("GL_POLYGON_STIPPLE", GL11.GL_POLYGON_STIPPLE),
             cap("GL_INDEX_LOGIC_OP", GL11.GL_INDEX_LOGIC_OP),
             cap("GL_AUTO_NORMAL", GL11.GL_AUTO_NORMAL),
+            cap("GL_COLOR_SUM", GL14.GL_COLOR_SUM),
             cap("GL_MAP1_COLOR_4", GL11.GL_MAP1_COLOR_4),
             cap("GL_MAP1_INDEX", GL11.GL_MAP1_INDEX),
             cap("GL_MAP1_NORMAL", GL11.GL_MAP1_NORMAL),
@@ -79,6 +83,44 @@ public class GLSM_CoreRemovedCaps_GLTest {
             assertFalse(GLStateManager.glIsEnabled(cap));
         } finally {
             GLStateManager.glDisable(cap);
+            while (GL11.glGetError() != GL11.GL_NO_ERROR) {}
+        }
+    }
+
+    @Test
+    void secondaryColorIsCacheOnly() {
+        final FloatBuffer params = BufferUtils.createFloatBuffer(4);
+        try {
+            // Calling through to the driver here aborts the JVM in a core profile - the color sum is emulated by the FFP shaders
+            GLStateManager.glSecondaryColor3f(0.25F, 0.5F, 0.75F);
+            assertNoGlError("glSecondaryColor3f");
+
+            GLStateManager.glGetFloat(GL14.GL_CURRENT_SECONDARY_COLOR, params);
+            assertEquals(0.25F, params.get(0), "red must round-trip through the cache");
+            assertEquals(0.5F, params.get(1), "green must round-trip through the cache");
+            assertEquals(0.75F, params.get(2), "blue must round-trip through the cache");
+        } finally {
+            GLStateManager.glSecondaryColor3f(0.0F, 0.0F, 0.0F);
+            while (GL11.glGetError() != GL11.GL_NO_ERROR) {}
+        }
+    }
+
+    @Test
+    void secondaryColorIsRestoredByPopAttrib() {
+        final FloatBuffer params = BufferUtils.createFloatBuffer(4);
+        try {
+            GLStateManager.glSecondaryColor3f(0.125F, 0.25F, 0.375F);
+            GLStateManager.glPushAttrib(GL11.GL_CURRENT_BIT);
+            GLStateManager.glSecondaryColor3f(1.0F, 1.0F, 1.0F);
+            GLStateManager.glPopAttrib();
+            assertNoGlError("glPushAttrib/glSecondaryColor3f/glPopAttrib");
+
+            GLStateManager.glGetFloat(GL14.GL_CURRENT_SECONDARY_COLOR, params);
+            assertEquals(0.125F, params.get(0));
+            assertEquals(0.25F, params.get(1));
+            assertEquals(0.375F, params.get(2));
+        } finally {
+            GLStateManager.glSecondaryColor3f(0.0F, 0.0F, 0.0F);
             while (GL11.glGetError() != GL11.GL_NO_ERROR) {}
         }
     }


### PR DESCRIPTION
Fixes #2006

I think this will fix the Campfire Backport crash for any issues regarding GL Secondary Color.

### Before submitting a *pull request* make sure you have:
- [X] Read the [AI Contribution Policy](https://github.com/GTNewHorizons/Angelica/blob/master/AI_POLICY.md)
- [X] At least [skimmed](https://github.com/GTNewHorizons/Angelica/search?q=is%3Apr&type=Issues) the tracker for similar pull requests