### PR TITLE
CTM Transitions - neighbor detection and influence

### DIFF
--- a/src/main/java/com/prupe/mcpatcher/ctm/RenderBlockState.java
+++ b/src/main/java/com/prupe/mcpatcher/ctm/RenderBlockState.java
@@ -36,6 +36,7 @@ abstract public class RenderBlockState {
     public static final int CONNECT_BY_BLOCK = 0;
     public static final int CONNECT_BY_TILE = 1;
     public static final int CONNECT_BY_MATERIAL = 2;
+    public static final int CONNECT_BY_LIST = 3;
 
     protected static int[] add(int[] a, int[] b) {
         if (a.length != b.length) {

--- a/src/main/java/com/prupe/mcpatcher/ctm/TileOverride.java
+++ b/src/main/java/com/prupe/mcpatcher/ctm/TileOverride.java
@@ -159,8 +159,7 @@ public abstract class TileOverride implements Comparable<TileOverride> {
         if (matchBlocks.isEmpty() && matchTiles.isEmpty()) {
             matchTiles.add(baseFilename);
         }
-        connectBlocks = getBlockList(
-            properties.getString("connectBlocks", ""), properties.getString("connectMetadata", ""));
+        connectBlocks = getBlockList(properties.getString("connectBlocks", ""), properties.getString("connectMetadata", ""));
 
         faceMatcher = BlockFaceMatcher.create(properties.getString("faces", ""));
 

--- a/src/main/java/com/prupe/mcpatcher/ctm/TileOverride.java
+++ b/src/main/java/com/prupe/mcpatcher/ctm/TileOverride.java
@@ -1,6 +1,7 @@
 package com.prupe.mcpatcher.ctm;
 
 import static com.prupe.mcpatcher.ctm.RenderBlockState.CONNECT_BY_BLOCK;
+import static com.prupe.mcpatcher.ctm.RenderBlockState.CONNECT_BY_LIST;
 import static com.prupe.mcpatcher.ctm.RenderBlockState.CONNECT_BY_MATERIAL;
 import static com.prupe.mcpatcher.ctm.RenderBlockState.CONNECT_BY_TILE;
 import static com.prupe.mcpatcher.ctm.RenderBlockState.NORMALS;
@@ -40,6 +41,7 @@ public abstract class TileOverride implements Comparable<TileOverride> {
     private final int weight;
     private final List<BlockStateMatcher> matchBlocks;
     private final Set<String> matchTiles;
+    private final List<BlockStateMatcher> connectBlocks;
     private final BlockFaceMatcher faceMatcher;
     private final int connectType;
     private final boolean innerSeams;
@@ -157,6 +159,8 @@ public abstract class TileOverride implements Comparable<TileOverride> {
         if (matchBlocks.isEmpty() && matchTiles.isEmpty()) {
             matchTiles.add(baseFilename);
         }
+        connectBlocks = getBlockList(
+            properties.getString("connectBlocks", ""), properties.getString("connectMetadata", ""));
 
         faceMatcher = BlockFaceMatcher.create(properties.getString("faces", ""));
 
@@ -167,6 +171,14 @@ public abstract class TileOverride implements Comparable<TileOverride> {
             case "block" -> connectType = CONNECT_BY_BLOCK;
             case "tile" -> connectType = CONNECT_BY_TILE;
             case "material" -> connectType = CONNECT_BY_MATERIAL;
+            case "list" -> {
+                if (connectBlocks.isEmpty()) {
+                    properties.error("connect=list requires a non-empty connectBlocks= list");
+                    connectType = CONNECT_BY_BLOCK;
+                } else {
+                    connectType = CONNECT_BY_LIST;
+                }
+            }
             default -> {
                 properties.error("invalid connect type %s", connectType1);
                 connectType = CONNECT_BY_BLOCK;
@@ -433,6 +445,16 @@ public abstract class TileOverride implements Comparable<TileOverride> {
             case CONNECT_BY_TILE -> renderBlockState.shouldConnectByTile(neighbor, icon, x, y, z);
             case CONNECT_BY_BLOCK -> renderBlockState.shouldConnectByBlock(neighbor, x, y, z);
             case CONNECT_BY_MATERIAL -> block.blockMaterial == neighbor.blockMaterial;
+            case CONNECT_BY_LIST -> {
+                boolean matched = false;
+                for (BlockStateMatcher matcher : connectBlocks) {
+                    if (matcher.match(blockAccess, x, y, z)) {
+                        matched = true;
+                        break;
+                    }
+                }
+                yield matched;
+            }
             default -> false;
         };
     }


### PR DESCRIPTION
# Enables CTM transitions properties
This is a fix/step in the direction of optifine's CTM transitions method.
It introduces a new CTM property to allow neighbor aware overlays.
This does operate on the basis of "I change my texture" not "neighbor changes"
I've seen no issues on Angelica related to this, but I noticed it from my own
resource pack work.

* Allows detection of blockface next to a fluid, but fluid textures don't run through the ctm pipeline :(

<details><summary>CTM debug shot</summary>
<img width="854" height="480" alt="stone with lava" src="https://github.com/user-attachments/assets/2f0bec0e-2626-4cb7-84aa-adf756f4d538" />
</details>
<details><summary>Works with labPBR</summary>
<img width="854" height="480" alt="pbr with distortion2" src="https://github.com/user-attachments/assets/6387ed06-2e53-47c5-baf8-80221f8b3496" />
</details>
I created a [spark profile](https://spark.lucko.me/1lyDwyadkW) showcasing new chunk generation.  It looks like the iterative loop for neighbor checks doesn't impact processing time.

<details open><summary>Template</summary> <!-- OPEN is intentional -->

### Before submitting a *pull request* make sure you have:
- [X] Read the [AI Contribution Policy](https://github.com/GTNewHorizons/Angelica/blob/master/AI_POLICY.md)
- [X] At least [skimmed](https://github.com/GTNewHorizons/Angelica/search?q=is%3Apr&type=Issues) the tracker for similar pull requests

No similar pull requests.
AI was used to understand and generate changes.  I discussed with, and understand what the changes are doing.

Included is a spark profile from generating new chunks, utilizing ~160 automatically generated ctm properties.  No noticeable impact.
</details>
