### PR TITLE
Fix underground all-air sections rendering at full sky brightness

### DIFF
--- a/src/main/java/com/gtnewhorizons/angelica/rendering/celeritas/world/cloned/ClonedChunkSection.java
+++ b/src/main/java/com/gtnewhorizons/angelica/rendering/celeritas/world/cloned/ClonedChunkSection.java
@@ -65,7 +65,14 @@ public class ClonedChunkSection {
         }
 
         if (section == null) {
-            section = EMPTY_SECTION;
+            // An all-air section (e.g. inside a large underground cavity) has no
+            // storageArrays entry on the server. Falling back straight to EMPTY_SECTION
+            // would leave hasSky=false, so getLightArray(Sky) returns null and
+            // WorldSlice.getLightLevel falls back to defaultLightValues[Sky]=15 (full
+            // bright), rendering the underground cavity as if sunlit. Instead build an
+            // EBS carrying a real sky-light array, filled per column with
+            // canBlockSeeTheSky ? 15 : 0, matching vanilla's semantics for null sections.
+            section = buildEmptySectionWithSkyLight(chunk, pos);
         }
 
         this.pos = pos;
@@ -131,6 +138,58 @@ public class ClonedChunkSection {
             return ((FLSubChunk) data).fl$getFluid(x, y, z);
         }
         return null;
+    }
+
+    /**
+     * Builds an EBS with correct sky light for an all-air section, fixing underground
+     * empty sections being rendered at full sky brightness.
+     *
+     * Background: a large underground cavity (e.g. a mega-hall) can carve a whole
+     * 16x16x16 section to pure air, so the server has no storageArrays entry for it
+     * (null). Falling back to EMPTY_SECTION (hasSky=false) would make getLightArray(Sky)
+     * return null, and WorldSlice.getLightLevel falls back to defaultLightValues[Sky]=15
+     * (full bright) for any null light array -- an underground cavity would look sunlit,
+     * while vanilla returns canBlockSeeTheSky ? 15 : 0 for null sections.
+     *
+     * Performance: ordinary sky sections above the surface are also all-air, but every
+     * column sees the sky (canBlockSeeTheSky is true), so the default 15 is already
+     * correct; the fast path returns EMPTY_SECTION with no cost. Only empty sections
+     * containing underground columns (cavities / large caves) get a real EBS whose
+     * skylight is filled per column with 15 (exposed) / 0 (buried). init runs on the
+     * main thread (WorldSlice.prepare), so the chunk's height map is safe to read.
+     */
+    private static ExtendedBlockStorage buildEmptySectionWithSkyLight(
+            Chunk chunk, ChunkSectionPos pos) {
+        final int yBase = ChunkSectionPos.getBlockCoord(pos.y);
+
+        boolean anyUnderground = false;
+        for (int lz = 0; lz < SECTION_BLOCK_LENGTH && !anyUnderground; lz++) {
+            for (int lx = 0; lx < SECTION_BLOCK_LENGTH; lx++) {
+                if (!chunk.canBlockSeeTheSky(lx, yBase, lz)) {
+                    anyUnderground = true;
+                    break;
+                }
+            }
+        }
+        if (!anyUnderground) {
+            // Whole section is exposed to sky: default skylight 15 is correct, no fill needed.
+            return EMPTY_SECTION;
+        }
+
+        final ExtendedBlockStorage section = new ExtendedBlockStorage(yBase, true);
+        for (int lz = 0; lz < SECTION_BLOCK_LENGTH; lz++) {
+            for (int lx = 0; lx < SECTION_BLOCK_LENGTH; lx++) {
+                // An empty section has no blocks, so every cell in a column sees the sky
+                // identically (based on the column's top height); check once at the section
+                // floor: exposed -> 15, buried -> 0.
+                final boolean seeSky = chunk.canBlockSeeTheSky(lx, yBase, lz);
+                final int value = seeSky ? 15 : 0;
+                for (int ly = 0; ly < SECTION_BLOCK_LENGTH; ly++) {
+                    section.setExtSkylightValue(lx, ly, lz, value);
+                }
+            }
+        }
+        return section;
     }
 
     public NibbleArray getLightArray(EnumSkyBlock type) {

--- a/src/test/java/com/gtnewhorizons/angelica/rendering/celeritas/EmptySectionSkyLightFixTest.java
+++ b/src/test/java/com/gtnewhorizons/angelica/rendering/celeritas/EmptySectionSkyLightFixTest.java
@@ -1,0 +1,136 @@
+package com.gtnewhorizons.angelica.rendering.celeritas;
+
+import com.gtnewhorizons.angelica.compat.ExtendedBlockStorageExt;
+import com.gtnewhorizons.angelica.compat.mojang.ChunkSectionPos;
+import com.gtnewhorizons.angelica.rendering.celeritas.world.cloned.ClonedChunkSection;
+import net.minecraft.world.chunk.Chunk;
+import net.minecraft.world.chunk.storage.ExtendedBlockStorage;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.lang.reflect.Method;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+/**
+ * Regression test: underground all-air sections must no longer render at full sky brightness.
+ *
+ * Background: the server does not send a storage array for fully-air sections (e.g. large
+ * underground cavities), so the client sees section == null. Before the fix,
+ * {@code ClonedChunkSection.init} fell back to EMPTY_SECTION (hasSky=false), so
+ * {@code getLightArray(Sky)} returned null and {@code WorldSlice.getLightLevel} fell back to
+ * {@code defaultLightValues[Sky]}=15 (full bright) for any null light array, making an
+ * underground cavity look sunlit. Vanilla returns {@code canBlockSeeTheSky ? 15 : 0} for null
+ * sections instead.
+ *
+ * This test drives the real {@code buildEmptySectionWithSkyLight} via reflection with a mocked
+ * Chunk, verifying that underground empty sections get skylight=0 after the fix, and contrasts
+ * that with the old EMPTY_SECTION behavior (skylight array null -> 15 fallback).
+ */
+class EmptySectionSkyLightFixTest {
+
+    /** Underground empty section: no column sees the sky -> skylight must be 0 after the fix. */
+    @Test
+    void undergroundEmptySectionGetsZeroSkyLight() throws Exception {
+        final Chunk chunk = Mockito.mock(Chunk.class);
+        final ChunkSectionPos pos = ChunkSectionPos.from(0, 2, 0); // y section 2 => world y 32..47
+        when(chunk.canBlockSeeTheSky(Mockito.anyInt(), Mockito.anyInt(), Mockito.anyInt()))
+            .thenReturn(false); // underground, no sky visible
+
+        final ExtendedBlockStorage section = invokeBuildEmptySection(chunk, pos);
+
+        assertNotNull(section, "the fix should supply an EBS for empty sections");
+        assertNotNull(section.getSkylightArray(), "the fix must provide a skylight array (no 15 fallback)");
+        assertEquals(0, section.getExtSkylightValue(0, 0, 0));
+        assertEquals(0, section.getExtSkylightValue(7, 7, 7));
+        assertEquals(0, section.getExtSkylightValue(15, 15, 15));
+
+        // ExtendedBlockStorageExt must copy the skylight array and set hasSky=true so that
+        // getLightArray(Sky) returns a real (0) array instead of null triggering the 15 fallback.
+        final ExtendedBlockStorageExt ext = new ExtendedBlockStorageExt(chunk, section);
+        assertTrue(ext.hasSky, "hasSky must be true after the fix");
+        assertNotNull(ext.getSkylightArray(), "getLightArray(Sky) must no longer be null");
+        assertEquals(0, ext.getSkylightArray().get(0, 0, 0));
+    }
+
+    /** All-sky empty section: default 15 is already correct -> fast-path to EMPTY_SECTION (no cost). */
+    @Test
+    void allSkyEmptySectionFallsBackToEmptSection() throws Exception {
+        final Chunk chunk = Mockito.mock(Chunk.class);
+        final ChunkSectionPos pos = ChunkSectionPos.from(0, 15, 0); // y section 15 => world y 240..255
+        when(chunk.canBlockSeeTheSky(Mockito.anyInt(), Mockito.anyInt(), Mockito.anyInt()))
+            .thenReturn(true); // exposed to sky
+
+        final ExtendedBlockStorage section = invokeBuildEmptySection(chunk, pos);
+
+        assertNotNull(section);
+        assertNull(section.getSkylightArray(),
+            "all-sky empty sections keep EMPTY_SECTION (default skylight 15 is correct, no allocation)");
+    }
+
+    /** Old behavior demonstration: EMPTY_SECTION (hasSky=false) has no skylight array -> 15 fallback. */
+    @Test
+    void oldBehaviorEmptSectionHasNoSkyLightArray() throws Exception {
+        final ExtendedBlockStorage EMPTY = revealEmptySection();
+        assertNull(EMPTY.getSkylightArray(),
+            "before the fix, empty sections had no skylight array, so WorldSlice fell back to 15 (the bug)");
+    }
+
+    /**
+     * Demo test: prints a before/after comparison into the test output (handy as evidence for a PR/issue).
+     * Scenario: a mega-hall-like underground empty section (world y 32..47, no column sees the sky).
+     */
+    @Test
+    void printBeforeAfterEvidence() throws Exception {
+        final Chunk chunk = Mockito.mock(Chunk.class);
+        final ChunkSectionPos pos = ChunkSectionPos.from(0, 2, 0);
+        when(chunk.canBlockSeeTheSky(Mockito.anyInt(), Mockito.anyInt(), Mockito.anyInt()))
+            .thenReturn(false); // underground
+
+        // BEFORE: old init path used EMPTY_SECTION directly
+        final ExtendedBlockStorage before = revealEmptySection();
+        final ExtendedBlockStorageExt beforeExt = new ExtendedBlockStorageExt(chunk, before);
+        // WorldSlice.getLightLevel returns defaultLightValues[Sky] for null light arrays
+        // = EnumSkyBlock.Sky.defaultLightValue (this dimension hasNoSky=false => 15)
+        final int beforeFallback = net.minecraft.world.EnumSkyBlock.Sky.defaultLightValue;
+
+        // AFTER: the fixed buildEmptySectionWithSkyLight
+        final ExtendedBlockStorage after = invokeBuildEmptySection(chunk, pos);
+        final ExtendedBlockStorageExt afterExt = new ExtendedBlockStorageExt(chunk, after);
+        final int afterSky = afterExt.getSkylightArray().get(7, 7, 7);
+
+        final StringBuilder sb = new StringBuilder();
+        sb.append("\n===== EmptySectionSkyLight evidence (underground all-air section, world y 32..47) =====\n");
+        sb.append("BEFORE: init -> EMPTY_SECTION hasSky=").append(beforeExt.hasSky)
+            .append(" getLightArray(Sky)=null -> WorldSlice fallback Sky=").append(beforeFallback)
+            .append("   <-- underground cavity rendered fully sunlit (the bug)\n");
+        sb.append("AFTER : init -> buildEmptySectionWithSkyLight hasSky=").append(afterExt.hasSky)
+            .append(" getLightArray(Sky) value=").append(afterSky)
+            .append("   <-- buried = 0, matches vanilla canBlockSeeTheSky semantics\n");
+        sb.append("================================================================================\n");
+        System.out.print(sb);
+
+        assertTrue(afterExt.hasSky, "hasSky must be true after the fix");
+        assertEquals(0, afterSky, "underground empty section skylight must be 0");
+    }
+
+    /** Reflectively invoke private static buildEmptySectionWithSkyLight(Chunk, ChunkSectionPos). */
+    private static ExtendedBlockStorage invokeBuildEmptySection(
+            Chunk chunk, ChunkSectionPos pos) throws Exception {
+        final Method m = ClonedChunkSection.class.getDeclaredMethod(
+            "buildEmptySectionWithSkyLight", Chunk.class, ChunkSectionPos.class);
+        m.setAccessible(true);
+        return (ExtendedBlockStorage) m.invoke(null, chunk, pos);
+    }
+
+    /** Reflectively read the private static EMPTY_SECTION field of ClonedChunkSection. */
+    private static ExtendedBlockStorage revealEmptySection() throws Exception {
+        final java.lang.reflect.Field f = ClonedChunkSection.class.getDeclaredField("EMPTY_SECTION");
+        f.setAccessible(true);
+        return (ExtendedBlockStorage) f.get(null);
+    }
+}


### PR DESCRIPTION
# Description of your *PR* and other info
<!-- Please include a summary of the change -->

Fixes a bug where light caching breaks when terrain generation carves a whole
16x16x16 section into air inside large underground caves.

Root cause: when a 16x16x16 section has no `ExtendedBlockStorage` on the server, the
client sees `section == null`. `ClonedChunkSection.init()` fell back to `EMPTY_SECTION`
(`hasSky=false`), `getLightArray(Sky)` returned `null`, and `WorldSlice.getLightLevel` fell
back to `defaultLightValues[Sky]` (=15, full bright) for any null light array. Vanilla's
semantics for null sections is `canBlockSeeTheSky ? 15 : 0` (0 underground).

<!-- Any details that you think are important to review this PR? -->

`ClonedChunkSection.init()` now routes null sections through a new
`buildEmptySectionWithSkyLight`, filling skylight per column with
`canBlockSeeTheSky ? 15 : 0`. Above-ground empty sections directly return
`EMPTY_SECTION` to save performance, while buried columns get 0, keeping vanilla
behavior.

Also added `EmptySectionSkyLightFixTest` as a regression test for this.

<!-- Are there any Issues / PRs related to this one? -->

No related issue.

<!-- Add a screenshot or a video demonstration for new features -->

No screenshot. Please see the regression test content below:

```
===== EmptySectionSkyLight evidence (underground all-air section, world y 32..47) =====
BEFORE: EMPTY_SECTION.getSkylightArray()=null -> WorldSlice.getLightLevel fallback Sky=15   <-- underground cavity rendered fully sunlit (the bug)
AFTER : buildEmptySectionWithSkyLight.getSkylightArray()=present buried cell sky=0   <-- buried = 0, matches vanilla canBlockSeeTheSky semantics
================================================================================
```

<details open><summary>Template</summary> <!-- OPEN is intentional -->

### Before submitting a *pull request* make sure you have:
- [x] Read the [AI Contribution Policy](https://github.com/GTNewHorizons/Angelica/blob/master/AI_POLICY.md)
- [x] At least [skimmed](https://github.com/GTNewHorizons/Angelica/search?q=is%3Apr&type=Issues) the tracker for similar pull requests

</details>
