### PR TITLE
Enable CTM mining/breaking overlays

### DIFF
--- a/src/mixin/java/com/gtnewhorizons/angelica/mixins/early/rendering/MixinRenderBlocks.java
+++ b/src/mixin/java/com/gtnewhorizons/angelica/mixins/early/rendering/MixinRenderBlocks.java
@@ -209,7 +209,11 @@ public abstract class MixinRenderBlocks implements ExtCeleritasRenderBlocks {
             return;
         }
 
-        if (processor.processFace((RenderBlocks)(Object)this, renderBlockState, icon, direction.ordinal())) {
+        RenderBlocks rb = (RenderBlocks) (Object) this;
+        if (rb.hasOverrideBlockTexture()) {
+            return;
+        }
+        if (processor.processFace(rb, renderBlockState, icon, direction.ordinal())) {
             ci.cancel();
         }
     }


### PR DESCRIPTION
# Fixes disappearing connected textures on block mining
Vanilla (Angelica) behavior - textures built with `method=ctm_compact` do not show
the typical "breaking block" texture, and instead have a weird "tint" to them.

This seems to happen specifically with the CTMQuadProcessor

<!-- Add a screenshot or a video demonstration for new features -->
<details><summary>Angelica 2.1.50 - GTNH 2.9 beta</summary>
<details><summary>Glass texture</summary>
<img width="1280" height="960" alt="ctm_compact" src="https://github.com/user-attachments/assets/5555f9cd-4f77-489a-b2fe-3c23bbe0124d" />
<img width="1280" height="960" alt="ctm_compact mining" src="https://github.com/user-attachments/assets/fa0c2aa2-3fb3-4fd0-81fa-7b75b5869cd4" />
</details>
<details><summary>Stone textured</summary>
<img width="1280" height="960" alt="ctm_compact stone" src="https://github.com/user-attachments/assets/11dbb26c-ae3c-4a60-99ea-7898b687dad2" />
<img width="1280" height="960" alt="ctm_compact stone mining" src="https://github.com/user-attachments/assets/31534b09-0e30-4f61-90a2-37078d09e067" />
</details>
</details>

<details><summary>PR fix</summary>
<img width="1870" height="1052" alt="2026-09-01_00 57 37" src="https://github.com/user-attachments/assets/014dc4f2-abc6-4ed1-8495-74f520f3e331" />
<img width="1870" height="1052" alt="2026-09-01_00 58 09" src="https://github.com/user-attachments/assets/20649453-2101-4c85-a701-37b6ee41b435" />
</details>

<details open><summary>Template</summary> <!-- OPEN is intentional -->

### Before submitting a *pull request* make sure you have:
- [X] Read the [AI Contribution Policy](https://github.com/GTNewHorizons/Angelica/blob/master/AI_POLICY.md)
- [X] At least [skimmed](https://github.com/GTNewHorizons/Angelica/search?q=is%3Apr&type=Issues) the tracker for similar pull requests

Skimmed the Issues tracker, doesn't look like an open or closed bug.
Human validated
</details>
