### PR TITLE
Fix animate-only-visible-textures setting

### DIFF
--- a/src/mixin/java/com/gtnewhorizons/angelica/mixins/early/angelica/animation/MixinTextureMap.java
+++ b/src/mixin/java/com/gtnewhorizons/angelica/mixins/early/angelica/animation/MixinTextureMap.java
@@ -3,7 +3,6 @@ package com.gtnewhorizons.angelica.mixins.early.angelica.animation;
 import com.gtnewhorizons.angelica.glsm.GLStateManager;
 import com.gtnewhorizons.angelica.mixins.interfaces.IPatchedTextureAtlasSprite;
 import com.gtnewhorizons.angelica.proxy.ClientProxy;
-import com.gtnewhorizons.angelica.utils.AnimationMode;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.texture.AbstractTexture;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
@@ -30,9 +29,8 @@ public abstract class MixinTextureMap extends AbstractTexture {
      */
     @Overwrite
     public void updateAnimations() {
-        final boolean renderAll = ClientProxy.animationsMode.is(AnimationMode.ALL);
-        final boolean renderVisible = ClientProxy.animationsMode.is(AnimationMode.VISIBLE_ONLY);
-
+        final boolean renderVisible = ClientProxy.options().performance.animateOnlyVisibleTextures;
+        
         Minecraft.getMinecraft().mcProfiler.startSection("updateAnimations");
         GLStateManager.glBindTexture(GL11.GL_TEXTURE_2D, this.getGlTextureId());
 
@@ -42,7 +40,7 @@ public abstract class MixinTextureMap extends AbstractTexture {
             final IPatchedTextureAtlasSprite patched = (IPatchedTextureAtlasSprite) sprite;
 
             // needsAnimationUpdate() is one-shot: returns true if marked, then auto-resets
-            if (renderAll || (renderVisible && patched.needsAnimationUpdate())) {
+            if (!renderVisible || patched.needsAnimationUpdate()) {
                 sprite.updateAnimation();
             } else {
                 // Keep frame counters in sync for sprites not being updated


### PR DESCRIPTION
# Fix Animate Only Visible Textures setting not being used
The animate only visible textures setting isn’t read by anything and this makes updateAnimations in MixinTextureMap.java use the config.
I didn’t test this but it should work fine, because the option exists.
Issue #829 describes the problem

<details open><summary>Template</summary> <!-- OPEN is intentional -->

### Before submitting a *pull request* make sure you have:
- [x] Read the [AI Contribution Policy](https://github.com/GTNewHorizons/Angelica/blob/master/AI_POLICY.md)
- [x] At least [skimmed](https://github.com/GTNewHorizons/Angelica/search?q=is%3Apr&type=Issues) the tracker for similar pull requests

</details>
