### PR TITLE
Fix custom font rendering on BetterLoadingScreen splash

### DIFF
--- a/src/main/java/com/gtnewhorizons/angelica/client/font/FontStrategist.java
+++ b/src/main/java/com/gtnewhorizons/angelica/client/font/FontStrategist.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.resources.DefaultResourcePack;
+import net.minecraft.client.resources.SimpleReloadableResourceManager;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -21,7 +22,6 @@ import java.io.IOException;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Iterator;
-import java.util.List;
 import java.util.Objects;
 
 public class FontStrategist {
@@ -76,9 +76,11 @@ public class FontStrategist {
             packMap.put(FontProviderCustom.getFallback().getAtlasResourceName(i), new File(FontProviderCustom.getFallback().getAtlasFullPath(i)));
         }
 
+        Minecraft mc = Minecraft.getMinecraft();
         DefaultResourcePack fontResourcePack = new DefaultResourcePack(packMap);
-        List defaultResourcePacks = ((ResourceAccessor) Minecraft.getMinecraft()).angelica$getDefaultResourcePacks();
-        defaultResourcePacks.add(fontResourcePack);
+
+        ((ResourceAccessor) mc).angelica$getDefaultResourcePacks().add(fontResourcePack);
+        ((SimpleReloadableResourceManager) mc.getResourceManager()).reloadResourcePack(fontResourcePack);
     }
 
     // Load .ttf/.otf shipped with the pack so customFontName* can point at a font that isn't installed


### PR DESCRIPTION
# Description

Problem: https://discord.com/channels/181078474394566657/522098956491030558/1545419963714502746
When Custom Font is enabled, characters are rendered as white bricks
<img width="3840" height="2160" alt="image" src="https://github.com/user-attachments/assets/77e86e67-0a12-4e19-8b7a-8c833ad398f2" />

#1342 is correct that the complete resource refresh is unnecessary, but it's incorrect that the added pack doesn't have to be refreshed at all. In https://github.com/GTNewHorizons/BetterLoadingScreen/pull/43, I also removed unnecessary refreshes, which now leads to a possible state where no one refreshed the texturepack we possibly would need

`reloadResourcePack` is a much softer method, so it shouldn't reintroduce any texturepack related problems

The reporter confirmed that the fix works


<details open><summary>Template</summary> <!-- OPEN is intentional -->

### Before submitting a *pull request* make sure you have:
- [x] Read the [AI Contribution Policy](https://github.com/GTNewHorizons/Angelica/blob/master/AI_POLICY.md)
- [x] At least [skimmed](https://github.com/GTNewHorizons/Angelica/search?q=is%3Apr&type=Issues) the tracker for similar pull requests

</details>
