### PR TITLE
Activate FFP when enabling with program 0

### DIFF
--- a/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/ffp/ShaderManager.java
+++ b/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/ffp/ShaderManager.java
@@ -80,6 +80,10 @@ public final class ShaderManager {
         warmUp();
         enabled = true;
 
+        if (GLStateManager.getActiveProgram() == 0) {
+            activate();
+        }
+
         GLStateManager.LOGGER.info("FFP shader emulation enabled");
     }
 


### PR DESCRIPTION
# Description
When FFP emulation is enabled while the current program is already 0, no subsequent glUseProgram(0) call may occur to activate the shader manager. This leaves FFP enabled but inactive until program 0 is bound again later

Activated FFP immediately in enable() when the current program is already 0, so the first FFP draw isn't skipped

Noticed it while tinkering with BetterLoadingScreen: i disabled thread renderer to simulate mobile behavior, so i got new frames only when someone (mainly FML in the beginning) sends a new progress bar step. There was a substantial delay before the first frame and the first time FML sends a step, so i had plenty time to see that the background image i rendered first is not visible, but more complicated font rendering surprisingly survived - because along the way someone called `glUseProgram(0)`

Tested.

<details open><summary>Template</summary> <!-- OPEN is intentional -->

### Before submitting a *pull request* make sure you have:
- [x] Read the [AI Contribution Policy](https://github.com/GTNewHorizons/Angelica/blob/master/AI_POLICY.md)
- [x] At least [skimmed](https://github.com/GTNewHorizons/Angelica/search?q=is%3Apr&type=Issues) the tracker for similar pull requests

</details>
