### PR TITLE
Added abutting block detection and processing

### DIFF
--- a/src/main/java/com/prupe/mcpatcher/ctm/TileOverride.java
+++ b/src/main/java/com/prupe/mcpatcher/ctm/TileOverride.java
@@ -46,6 +46,7 @@ public abstract class TileOverride implements Comparable<TileOverride> {
     private final List<BlockStateMatcher> matchBlocks;
     private final Set<String> matchTiles;
     private final List<BlockStateMatcher> connectBlocks;
+    private final List<BlockStateMatcher> abuttingBlocks;
     private final BlockFaceMatcher faceMatcher;
     private final int connectType;
     private final boolean innerSeams;
@@ -164,7 +165,7 @@ public abstract class TileOverride implements Comparable<TileOverride> {
             matchTiles.add(baseFilename);
         }
         connectBlocks = getBlockList(properties.getString("connectBlocks", ""), properties.getString("connectMetadata", ""));
-
+        abuttingBlocks = getBlockList(properties.getString("abuttingBlocks", ""), properties.getString("abuttingMetaData", ""));
         faceMatcher = BlockFaceMatcher.create(properties.getString("faces", ""));
 
         String connectType1 = properties.getString("connect", "")
@@ -499,6 +500,9 @@ public abstract class TileOverride implements Comparable<TileOverride> {
         if (faceMatcher != null && !faceMatcher.match(renderBlockState)) {
             return null;
         }
+        if (!abuttingBlocks.isEmpty() && !matchesAbuttingBlock(blockAccess, x,y,z, renderBlockState.getBlockFace())) {
+            return null;
+        }
         if (height != null && !height.get(y)) {
             return null;
         }
@@ -506,6 +510,22 @@ public abstract class TileOverride implements Comparable<TileOverride> {
             return null;
         }
         return getTileWorld_Impl(renderBlockState, origIcon);
+    }
+
+    private boolean matchesAbuttingBlock(IBlockAccess blockAccess, int x, int y, int z, int blockFace) {
+        if (blockFace < 0) {
+            return false;
+        }
+        int[] normal = NORMALS[blockFace];
+        x += normal[0];
+        y += normal[1];
+        z += normal[2];
+        for (BlockStateMatcher matcher : abuttingBlocks) {
+            if (matcher.match(blockAccess, x, y , z)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     public final IIcon getTileHeld(RenderBlockState renderBlockState, IIcon origIcon) {


### PR DESCRIPTION
# Abutting Blocks detection
While playing with CTM, I noticed that blocks facing non-blocks (fluids, non-opaque blocks) are forced to retain the texture of their host.  I had a "wouldn't it be cool if..." moment, and this is a next step for that.
-Adds a new key:value to properties files that enable detection of "what's in front of my block-face?"

<details><summary>Debug textures used below</summary>
<img width="1920" height="1017" alt="abuttingFence" src="https://github.com/user-attachments/assets/8d20906b-1cf5-4fd1-9cae-6445ed523d22" />
<img width="1920" height="1017" alt="abuttingLava" src="https://github.com/user-attachments/assets/c62c91de-e1b6-4b09-a096-0393954393e6" />
<img width="1920" height="1017" alt="abuttingWater" src="https://github.com/user-attachments/assets/7f987944-ea3c-49d6-808d-9493c12ac8f1" />

</details>

<details open><summary>Template</summary> <!-- OPEN is intentional -->

### Before submitting a *pull request* make sure you have:
- [X] Read the [AI Contribution Policy](https://github.com/GTNewHorizons/Angelica/blob/master/AI_POLICY.md)
- [X] At least [skimmed](https://github.com/GTNewHorizons/Angelica/search?q=is%3Apr&type=Issues) the tracker for similar pull requests

No similar tracker bugs/feature requests noticed.
</details>
