### PR TITLE
optimize resource reload

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ log4j = "2.0-beta9"
 asmCompile = "5.0.3"
 # End Frozen
 
-lwjgl3 = "3.4.2-20260602.093430-9"
+lwjgl3 = "3.4.2"
 lwjgl3ify = "3.0.31"
 
 celeritas = "2.5.10-GTNH"

--- a/src/main/java/com/prupe/mcpatcher/mal/resource/ResourceLocationWithSource.java
+++ b/src/main/java/com/prupe/mcpatcher/mal/resource/ResourceLocationWithSource.java
@@ -15,14 +15,15 @@ public class ResourceLocationWithSource extends ResourceLocation {
     private final boolean isDirectory;
 
     public ResourceLocationWithSource(IResourcePack source, ResourceLocation resource) {
+        String resourcePath = resource.getResourcePath();
+        boolean isDirectory = resourcePath.endsWith("/");
+
         super(
             resource.getResourceDomain(),
-            resource.getResourcePath()
-                .replaceFirst("/$", ""));
+            isDirectory ? resourcePath.substring(0, resourcePath.length() - 1) : resourcePath);
         this.source = source;
-        order = ResourceList.getResourcePackOrder(source);
-        isDirectory = resource.getResourcePath()
-            .endsWith("/");
+        this.order = ResourceList.getResourcePackOrder(source);
+        this.isDirectory = isDirectory;
     }
 
     public IResourcePack getSource() {

--- a/src/main/java/com/prupe/mcpatcher/mal/resource/TexturePackAPI.java
+++ b/src/main/java/com/prupe/mcpatcher/mal/resource/TexturePackAPI.java
@@ -196,10 +196,13 @@ public class TexturePackAPI {
         }
         path = path.replace(File.separatorChar, '/');
         if (path.startsWith(ASSETS)) {
-            path = path.substring(ASSETS.length());
-            int slash = path.indexOf('/');
-            if (slash > 0 && slash + 1 < path.length()) {
-                return new ResourceLocation(path.substring(0, slash), path.substring(slash + 1));
+            int namespaceStart = ASSETS.length();
+            int slash = path.indexOf('/', namespaceStart);
+
+            if (slash > namespaceStart && slash + 1 < path.length()) {
+                return new ResourceLocation(
+                    path.substring(namespaceStart, slash),
+                    path.substring(slash + 1));
             }
         }
         return null;


### PR DESCRIPTION
# Description

| Metric | Before | After | Improvement |
| --- | ---: | ---: | ---: |
| Resource list build | 902 ms | 562 ms | **-340 ms (-37.7%)** |
| Sampled allocations | 1359 MiB | 648 MiB | **-711 MiB (-52.3%)** |

about lwjgl3 update: the old version is not on the maven anymore, so dev env fails to download it

<details open><summary>Template</summary> <!-- OPEN is intentional -->

### Before submitting a *pull request* make sure you have:
- [x] Read the [AI Contribution Policy](https://github.com/GTNewHorizons/Angelica/blob/master/AI_POLICY.md)
- [x] At least [skimmed](https://github.com/GTNewHorizons/Angelica/search?q=is%3Apr&type=Issues) the tracker for similar pull requests

</details>
