### PR TITLE
Fixes TESR texts (travel anchors) depth test bug

### DIFF
--- a/src/main/java/com/gtnewhorizons/angelica/client/font/BatchingFontRenderer.java
+++ b/src/main/java/com/gtnewhorizons/angelica/client/font/BatchingFontRenderer.java
@@ -251,6 +251,7 @@ public class BatchingFontRenderer {
         int packedLight;
         float normalX, normalY, normalZ;
         int blockEntityId;
+        boolean depthTest;
     }
 
     // 16-bit EBO index range
@@ -516,6 +517,7 @@ public class BatchingFontRenderer {
         segment.normalY = normal.y;
         segment.normalZ = normal.z;
         segment.blockEntityId = CapturedRenderingState.INSTANCE.getCurrentRenderedBlockEntity();
+        segment.depthTest = GLStateManager.getDepthTest().isEnabled();
         batchSegments.add(segment);
         batchSealedEnd = end;
     }
@@ -603,6 +605,7 @@ public class BatchingFontRenderer {
         final boolean isAlphaTestEnabledBefore = GLStateManager.isEffectiveAlphaTestEnabled();
         GLStateManager.getEffectiveBlendState(deferredBlendStateBefore);
         final int boundTextureBefore = GLStateManager.glGetInteger(GL11.GL_TEXTURE_BINDING_2D);
+        final boolean depthTestBefore = GLStateManager.getDepthTest().isEnabled();
         final boolean depthMaskBefore = GLStateManager.isEffectiveDepthMaskEnabled();
         final int prevBlockEntityId = CapturedRenderingState.INSTANCE.getCurrentRenderedBlockEntity();
         boolean textureChanged = false;
@@ -619,12 +622,18 @@ public class BatchingFontRenderer {
         GLStateManager.glMatrixMode(GL11.GL_MODELVIEW);
         GLStateManager.glPushMatrix();
         try {
+            boolean curDepthTest = depthTestBefore;
             for (final TextSegment segment : deferredSegments) {
                 final BatchingFontRenderer owner = segment.owner;
                 if (segment.cmdStart == segment.cmdEnd) continue;
 
                 GLStateManager.setModelViewMatrix(segment.modelView);
                 CapturedRenderingState.INSTANCE.setCurrentBlockEntity(segment.blockEntityId);
+
+                if (segment.depthTest != curDepthTest) {
+                    if (segment.depthTest) GLStateManager.enableDepthTest(); else GLStateManager.disableDepthTest();
+                    curDepthTest = segment.depthTest;
+                }
 
                 final FontDrawCmd[] cmdsData = owner.batchCommands.elements();
                 Arrays.sort(cmdsData, segment.cmdStart, segment.cmdEnd, FontDrawCmd.DRAW_ORDER_COMPARATOR);
@@ -637,7 +646,7 @@ public class BatchingFontRenderer {
             CapturedRenderingState.INSTANCE.setCurrentBlockEntity(prevBlockEntityId);
             GbufferPrograms.endTranslucencyDeclaration(prevTranslucency);
 
-            GLStateManager.glDepthMask(depthMaskBefore);
+            restoreDepth(depthTestBefore, depthMaskBefore);
             if (isTextureEnabledBefore) {
                 GLStateManager.enableTexture();
             } else {
@@ -685,12 +694,17 @@ public class BatchingFontRenderer {
         try {
             try (MemoryStack stack = stackPush()) {
                 final FloatBuffer mvpBuf = stack.mallocFloat(16);
+                boolean curDepthTest = depthTestBefore;
                 for (final TextSegment segment : deferredSegments) {
                     mvpBuf.clear();
                     segment.mvp.get(mvpBuf);
                     GLStateManager.glUniformMatrix4(segment.owner.mvpMatrixLocation, false, mvpBuf);
                     uploadLightmap(segment.owner.lightmapLocation, segment.lightmapActive, segment.lightmapU,
                         segment.lightmapV, segment.lightmapTexture);
+                    if (segment.depthTest != curDepthTest) {
+                        if (segment.depthTest) GLStateManager.enableDepthTest(); else GLStateManager.disableDepthTest();
+                        curDepthTest = segment.depthTest;
+                    }
                     drawCommands(segment.owner.batchCommands.elements(), segment.cmdStart, segment.cmdEnd, segment.owner);
                 }
             }


### PR DESCRIPTION
Fixes a regression since #2017 that affects TESR texts. Now depth test state is captured at seal time.

# Description of your *PR* and other info
<!-- Please include a summary of the change -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there any Issues / PRs related to this one? -->
Related issue: 
fixes #2042 
<!-- Add a screenshot or a video demonstration for new features -->

Before:
<img width="833" height="446" alt="image" src="https://github.com/user-attachments/assets/1d5f606e-e99d-4f51-8001-6b85d32e7867" />
After:
<img width="985" height="527" alt="image" src="https://github.com/user-attachments/assets/cd255798-b4a9-4f87-80e2-35915b1b7be3" />

<details open><summary>Template</summary> <!-- OPEN is intentional -->

### Before submitting a *pull request* make sure you have:
- [ x ] Read the [AI Contribution Policy](https://github.com/GTNewHorizons/Angelica/blob/master/AI_POLICY.md)
- [ x ] At least [skimmed](https://github.com/GTNewHorizons/Angelica/search?q=is%3Apr&type=Issues) the tracker for similar pull requests

</details>
