### PR TITLE
Fix for texture being mistakenly turned off by Iris

### DIFF
--- a/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/hooks/events/TextureUnitStateEvent.java
+++ b/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/hooks/events/TextureUnitStateEvent.java
@@ -4,5 +4,6 @@ import net.minecraftforge.eventbus.api.event.MutableEvent;
 
 public final class TextureUnitStateEvent extends MutableEvent {
     public int unit;
+    public int cap;
     public boolean enabled;
 }

--- a/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/stacks/TextureUnitBooleanStateStack.java
+++ b/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/stacks/TextureUnitBooleanStateStack.java
@@ -44,6 +44,7 @@ public class TextureUnitBooleanStateStack extends BooleanStateStack {
 
             if (GLSMHooks.TEXTURE_UNIT_STATE.hasListeners()) {
                 GLSMHooks.textureUnitStateEvent.unit = unitIndex;
+                GLSMHooks.textureUnitStateEvent.cap = glCap;
                 GLSMHooks.textureUnitStateEvent.enabled = enabled;
                 GLSMHooks.TEXTURE_UNIT_STATE.post(GLSMHooks.textureUnitStateEvent);
             }

--- a/src/main/java/com/gtnewhorizons/angelica/iris/IrisGLSMBridge.java
+++ b/src/main/java/com/gtnewhorizons/angelica/iris/IrisGLSMBridge.java
@@ -29,6 +29,7 @@ import net.coderbot.iris.samplers.IrisSamplers;
 import net.coderbot.iris.texture.pbr.PBRTextureManager;
 import net.coderbot.iris.uniforms.SystemTimeUniforms;
 import it.unimi.dsi.fastutil.ints.Int2IntOpenHashMap;
+import org.lwjgl.opengl.GL11;
 
 public class IrisGLSMBridge {
 
@@ -257,6 +258,7 @@ public class IrisGLSMBridge {
 
         GLSMHooks.TEXTURE_UNIT_STATE.addListener(event -> {
             if (!Iris.enabled) return;
+            if (event.cap != GL11.GL_TEXTURE_2D) return;
             boolean updatePipeline = false;
             if (event.unit == IrisSamplers.ALBEDO_TEXTURE_UNIT) {
                 StateTracker.INSTANCE.albedoSampler = event.enabled;


### PR DESCRIPTION
…(fixes #2032)

When the ender tank draws its swirly portal effect, it briefly uses an old OpenGL texturing trick, and Angelica's notification to the shader system about that change doesn't say which setting was flipped — so Iris mistakes "portal trick switched off" for "textures switched off entirely." Iris then routes everything drawn afterwards through its untextured shader program, turning tile entities, your hand, and held items flat white and since the real texture setting never actually changed, the correcting notification never fires and it stays broken. The fix adds the missing "which setting" field to the notification and makes Iris ignore everything except the real texture toggle.

# Description of your *PR* and other info
<!-- Please include a summary of the change -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there any Issues / PRs related to this one? -->

<!-- Add a screenshot or a video demonstration for new features -->
Before:
<img width="1309" height="701" alt="image" src="https://github.com/user-attachments/assets/7ce1b0f5-3512-4c8d-b14a-840b0e0fac45" />

AFter:
<img width="1311" height="700" alt="image" src="https://github.com/user-attachments/assets/1421b5ab-d9be-49b7-a243-a73cb6a06700" />

<details open><summary>Template</summary> <!-- OPEN is intentional -->

### Before submitting a *pull request* make sure you have:
- [ x] Read the [AI Contribution Policy](https://github.com/GTNewHorizons/Angelica/blob/master/AI_POLICY.md)
- [x ] At least [skimmed](https://github.com/GTNewHorizons/Angelica/search?q=is%3Apr&type=Issues) the tracker for similar pull requests

</details>
