### PR TITLE
Fix tile entity pass markers skipped on newer class files

### DIFF
--- a/src/main/java/com/gtnewhorizons/angelica/loading/fml/transformers/CeleritasBlockTransformer.java
+++ b/src/main/java/com/gtnewhorizons/angelica/loading/fml/transformers/CeleritasBlockTransformer.java
@@ -7,6 +7,7 @@ import com.gtnewhorizons.angelica.loading.shared.transformers.TileEntityMarkerTr
 import net.minecraft.launchwrapper.IClassTransformer;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.tree.ClassNode;
 
 /** IClassTransformer wrapper for {@link CeleritasBlockTransform} */
@@ -18,7 +19,7 @@ public class CeleritasBlockTransformer implements IClassTransformer {
 
     public CeleritasBlockTransformer() {
         this.inner = new CeleritasBlockTransform(AngelicaClientTweaker.isObfEnv());
-        this.tileEntities = new TileEntityMarkerTransform(AngelicaClientTweaker.isObfEnv());
+        this.tileEntities = new TileEntityMarkerTransform(AngelicaClientTweaker.isObfEnv(), Opcodes.ASM5);
         this.exclusions = inner.getTransformerExclusions();
     }
 

--- a/src/main/java/com/gtnewhorizons/angelica/loading/rfb/transformers/RFBCeleritasBlockTransformer.java
+++ b/src/main/java/com/gtnewhorizons/angelica/loading/rfb/transformers/RFBCeleritasBlockTransformer.java
@@ -6,6 +6,7 @@ import com.gtnewhorizons.angelica.loading.shared.transformers.TileEntityMarkerTr
 import com.gtnewhorizons.retrofuturabootstrap.api.ClassHeaderMetadata;
 import com.gtnewhorizons.retrofuturabootstrap.api.ClassNodeHandle;
 import com.gtnewhorizons.retrofuturabootstrap.api.ExtensibleClassLoader;
+import com.gtnewhorizons.retrofuturabootstrap.api.RetroFuturaBootstrap;
 import com.gtnewhorizons.retrofuturabootstrap.api.RfbClassTransformer;
 import org.intellij.lang.annotations.Pattern;
 import org.jetbrains.annotations.NotNull;
@@ -21,7 +22,7 @@ public class RFBCeleritasBlockTransformer implements RfbClassTransformer {
 
     public RFBCeleritasBlockTransformer(boolean isObf) {
         inner = new CeleritasBlockTransform(isObf);
-        tileEntities = new TileEntityMarkerTransform(isObf);
+        tileEntities = new TileEntityMarkerTransform(isObf, RetroFuturaBootstrap.API.newestAsmVersion());
     }
 
     @Pattern("[a-z0-9-]+")

--- a/src/main/java/com/gtnewhorizons/angelica/loading/shared/transformers/TileEntityMarkerTransform.java
+++ b/src/main/java/com/gtnewhorizons/angelica/loading/shared/transformers/TileEntityMarkerTransform.java
@@ -30,6 +30,13 @@ public final class TileEntityMarkerTransform {
     private static final String TILE_ENTITY = "net/minecraft/tileentity/TileEntity";
     private static final int SCAN_FLAGS = ClassReader.SKIP_CODE | ClassReader.SKIP_DEBUG | ClassReader.SKIP_FRAMES;
 
+    /**
+     * Opcodes.ASM9, spelled out because this is compiled against ASM 5. An ASM5 visitor refuses to visit attributes
+     * added by later class file versions, such as the NestMember one javac emits for classes with nested classes,
+     * which would leave those classes unmarked.
+     */
+    private static final int ASM_API = 0x00090000;
+
     private record Marker(int bit, String method, String desc, String iface) {}
 
     private final Marker[] markers;
@@ -67,7 +74,7 @@ public final class TileEntityMarkerTransform {
     public byte[] addMarkers(byte[] classBytes, int markers) {
         final ClassReader cr = new ClassReader(classBytes);
         final ClassWriter cw = new ClassWriter(cr, 0);
-        cr.accept(new ClassVisitor(Opcodes.ASM5, cw) {
+        cr.accept(new ClassVisitor(ASM_API, cw) {
 
             @Override
             public void visit(int version, int access, String name, String sig, String superName, String[] interfaces) {
@@ -112,7 +119,7 @@ public final class TileEntityMarkerTransform {
         private int alreadyPresent;
 
         MarkerScanner() {
-            super(Opcodes.ASM5);
+            super(ASM_API);
         }
 
         @Override

--- a/src/main/java/com/gtnewhorizons/angelica/loading/shared/transformers/TileEntityMarkerTransform.java
+++ b/src/main/java/com/gtnewhorizons/angelica/loading/shared/transformers/TileEntityMarkerTransform.java
@@ -30,20 +30,20 @@ public final class TileEntityMarkerTransform {
     private static final String TILE_ENTITY = "net/minecraft/tileentity/TileEntity";
     private static final int SCAN_FLAGS = ClassReader.SKIP_CODE | ClassReader.SKIP_DEBUG | ClassReader.SKIP_FRAMES;
 
-    /**
-     * Opcodes.ASM9, spelled out because this is compiled against ASM 5. An ASM5 visitor refuses to visit attributes
-     * added by later class file versions, such as the NestMember one javac emits for classes with nested classes,
-     * which would leave those classes unmarked.
-     */
-    private static final int ASM_API = 0x00090000;
-
     private record Marker(int bit, String method, String desc, String iface) {}
+
+    /**
+     * A visitor refuses to visit attributes newer than its api level, such as the NestMember one javac emits for
+     * classes with nested classes, so the caller passes the highest level its class loader supports.
+     */
+    private final int asmApi;
 
     private final Marker[] markers;
     private final ClassConstantPoolParser prefilter;
     private final Set<String> tileEntities = Collections.newSetFromMap(new ConcurrentHashMap<>());
 
-    public TileEntityMarkerTransform(boolean isObf) {
+    public TileEntityMarkerTransform(boolean isObf, int asmApi) {
+        this.asmApi = asmApi;
         this.markers = new Marker[] {
             new Marker(MARK_DESCRIPTION_PACKET, isObf ? "func_145844_m" : "getDescriptionPacket", "()Lnet/minecraft/network/Packet;", SENDS_DESCRIPTION_PACKET),
             new Marker(MARK_SHOULD_RENDER_IN_PASS, "shouldRenderInPass", "(I)Z", OVERRIDES_SHOULD_RENDER_IN_PASS),
@@ -74,7 +74,7 @@ public final class TileEntityMarkerTransform {
     public byte[] addMarkers(byte[] classBytes, int markers) {
         final ClassReader cr = new ClassReader(classBytes);
         final ClassWriter cw = new ClassWriter(cr, 0);
-        cr.accept(new ClassVisitor(ASM_API, cw) {
+        cr.accept(new ClassVisitor(asmApi, cw) {
 
             @Override
             public void visit(int version, int access, String name, String sig, String superName, String[] interfaces) {
@@ -119,7 +119,7 @@ public final class TileEntityMarkerTransform {
         private int alreadyPresent;
 
         MarkerScanner() {
-            super(ASM_API);
+            super(asmApi);
         }
 
         @Override


### PR DESCRIPTION
# Description

Tile entities whose class carries a NestMember attribute never got the OverridesShouldRenderInPass marker, because the marker visitor is created at ASM5 and throws on that attribute. LaunchWrapper swallows the exception as a warning, so the class silently keeps being rendered in pass 0 only.

Reproduced with OpenBlocks: the Enhanced Building Guide draws its orbiting cubes in pass 0 and its ghost blocks in pass 1, so the ghosts never appeared. Five OpenBlocks tile entities were affected, all of them classes with nested classes.

Not the same as #1653, which had the same symptom but a different cause and was fixed in 2.1.40.

- [x] Read the [AI Contribution Policy](https://github.com/GTNewHorizons/Angelica/blob/master/AI_POLICY.md)
- [x] At least [skimmed](https://github.com/GTNewHorizons/Angelica/search?q=is%3Apr&type=Issues) the tracker for similar pull requests
