### PR TITLE
Remove superflous glVertexAttribPointer call

### DIFF
--- a/src/main/java/net/coderbot/iris/compat/dh/IrisGenericRenderProgram.java
+++ b/src/main/java/net/coderbot/iris/compat/dh/IrisGenericRenderProgram.java
@@ -137,7 +137,6 @@ public class IrisGenericRenderProgram implements IDhApiGenericObjectShaderProgra
 
         this.va = GLStateManager.glGenVertexArrays();
         GLStateManager.glBindVertexArray(va);
-        GLStateManager.glVertexAttribPointer(0, 3, GL11.GL_FLOAT, false, 0, 0);
         GLStateManager.glEnableVertexAttribArray(0);
 
         this.instancedShaderOffsetChunkUniform = this.tryGetUniformLocation2("uOffsetChunk");


### PR DESCRIPTION
# Description of your *PR* and other info
This PR removes a superflous call from DH integration, this call crashes on lwjgl2.

### Before submitting a *pull request* make sure you have:
- [x] Read the [AI Contribution Policy](https://github.com/GTNewHorizons/Angelica/blob/master/AI_POLICY.md)
- [x] At least [skimmed](https://github.com/GTNewHorizons/Angelica/search?q=is%3Apr&type=Issues) the tracker for similar pull requests

</details>
